### PR TITLE
chore(infra): one-shot workflow to delete kakkom Pages project

### DIFF
--- a/.github/scripts/cf-cleanup-kakkom.mjs
+++ b/.github/scripts/cf-cleanup-kakkom.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// 使い捨てスクリプト: kakkom Pages プロジェクトと全 deployments を削除する。
+// 実行後はこのスクリプトと対応する workflow ファイルを削除すること。
+//
+// 環境変数（GitHub Actions の secret から注入される想定）:
+//   CLOUDFLARE_API_TOKEN  (Pages:Edit 権限必須)
+//   CLOUDFLARE_ACCOUNT_ID
+
+const TOKEN = process.env.CLOUDFLARE_API_TOKEN;
+const ACCOUNT = process.env.CLOUDFLARE_ACCOUNT_ID;
+const PROJECT = 'kakkom';
+
+if (!TOKEN || !ACCOUNT) {
+  console.error('CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required');
+  process.exit(1);
+}
+
+const base = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT}/pages/projects/${PROJECT}`;
+const headers = { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' };
+
+async function listDeployments() {
+  const res = await fetch(`${base}/deployments?per_page=25`, { headers });
+  if (!res.ok) throw new Error(`list failed: ${res.status} ${await res.text()}`);
+  return (await res.json()).result || [];
+}
+
+async function deleteDeployment(id) {
+  const res = await fetch(`${base}/deployments/${id}?force=true`, { method: 'DELETE', headers });
+  return { ok: res.ok, status: res.status, body: await res.text() };
+}
+
+async function deleteProject() {
+  const res = await fetch(base, { method: 'DELETE', headers });
+  return { ok: res.ok, status: res.status, body: await res.text() };
+}
+
+let total = 0;
+let failed = 0;
+const failedIds = new Set();
+
+while (true) {
+  const list = await listDeployments();
+  if (list.length === 0) {
+    console.log('No more deployments.');
+    break;
+  }
+  const toProcess = list.filter(d => !failedIds.has(d.id));
+  if (toProcess.length === 0) {
+    console.log('Remaining deployments all failed previously. Stopping loop.');
+    break;
+  }
+  console.log(`Batch: ${toProcess.length} deployments (list size: ${list.length})`);
+  let batchOk = 0;
+  for (const d of toProcess) {
+    const r = await deleteDeployment(d.id);
+    if (r.ok) {
+      total++;
+      batchOk++;
+      process.stdout.write('.');
+    } else {
+      failed++;
+      failedIds.add(d.id);
+      console.log(`\n  FAIL ${d.id}: ${r.status} ${r.body.slice(0, 200)}`);
+    }
+  }
+  console.log('');
+  if (batchOk === 0) {
+    console.log('No progress in this batch. Stopping loop.');
+    break;
+  }
+}
+
+console.log(`\nDeployments: deleted=${total} failed=${failed}`);
+if (failed > 0) {
+  console.log('Failed deployment IDs:');
+  for (const id of failedIds) console.log(`  ${id}`);
+  console.log('');
+}
+
+console.log('Attempting to delete kakkom project...');
+const proj = await deleteProject();
+if (proj.ok) {
+  console.log('OK: kakkom project deleted.');
+} else {
+  console.log(`FAIL: project delete failed: ${proj.status} ${proj.body}`);
+  console.log('Hint: まだ残っている production deployment があればダッシュボードから手動削除して再実行。');
+  process.exit(1);
+}

--- a/.github/workflows/cf-cleanup.yml
+++ b/.github/workflows/cf-cleanup.yml
@@ -1,0 +1,37 @@
+name: Cloudflare cleanup (one-shot)
+
+# 使い捨て workflow: kakkom Pages プロジェクトと全 deployments を削除する。
+# 実行後は `.github/workflows/cf-cleanup.yml` と `.github/scripts/cf-cleanup-kakkom.mjs` を
+# PR で削除し、不要になった secret も GitHub Settings から削除すること。
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "delete-kakkom" to confirm deletion'
+        required: true
+        type: string
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard
+        if: inputs.confirm != 'delete-kakkom'
+        run: |
+          echo "Confirm input mismatch. Expected 'delete-kakkom'. Aborting."
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Delete kakkom (deployments + project)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: node .github/scripts/cf-cleanup-kakkom.mjs


### PR DESCRIPTION
## Summary

- kakkom Pages プロジェクト（202 deployments）を削除するための使い捨て workflow を追加
- 企業ネットワーク（Palo Alto MITM）から Cloudflare API を直接叩けないため、GitHub Actions 経由で実行する

## 実行後の掃除

本 workflow の実行成功後、以下のファイルを削除する PR を別途出す:
- \`.github/workflows/cf-cleanup.yml\`
- \`.github/scripts/cf-cleanup-kakkom.mjs\`

## Dispatch 方法

\`\`\`bash
gh workflow run cf-cleanup.yml --ref main -f confirm=delete-kakkom
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)