### PR TITLE
release: lastRewrittenAt ISO 8601 化 + UI 最終レビュー日表示

### DIFF
--- a/.claude/agents/keyword-rewriter.md
+++ b/.claude/agents/keyword-rewriter.md
@@ -64,7 +64,7 @@ model: sonnet
   - 短い一文で済む事実を Callout 化すると強調が希薄化するため、2〜4 文の実質的な内容にまとめる
 - frontmatter に以下を追加:
   - `reviewStatus: needs-review`
-  - `lastRewrittenAt: YYYY-MM-DD`
+  - `lastRewrittenAt: ISO 8601 秒単位`（例: `'2026-04-21T12:34:56.789Z'`、並行作業検出と品質劣化の可視化に使用。UI では日付部分のみ「最終レビュー: YYYY年M月D日」で表示）
   - `revisionCycle: 1`（既存値があれば +1）
 
 ### やってはいけないこと

--- a/.claude/skills/content/civil-textbook-cycle/scripts/lib/civil-prompts.mjs
+++ b/.claude/skills/content/civil-textbook-cycle/scripts/lib/civil-prompts.mjs
@@ -140,7 +140,7 @@ ${extraInstructions}
   3. 既存本文を尊重しつつ、推奨拡張パターン（最大2個）を適用
   4. frontmatter に以下を追加（既存値があれば上書き）:
      - reviewStatus: needs-review
-     - lastRewrittenAt: ${new Date().toISOString().split('T')[0]}
+     - lastRewrittenAt: ${new Date().toISOString()}  // ISO 8601 秒単位（並行作業検出用）
      - revisionCycle: 1（既存値があれば +1）
   5. 改行コードは元ファイルを保持（\`.claude/scripts/lib/mdx-io.mjs\` の readMdxFile/writeMdxFile を使う）
   6. Edit ツールまたは Write + mdx-io で書き戻し（after_chars を記録）

--- a/.claude/skills/content/quality-cycle/SKILL.md
+++ b/.claude/skills/content/quality-cycle/SKILL.md
@@ -115,6 +115,7 @@ unscored → scored → rewriting → needs-review → verified → approved
 - **拡張パターンの多様化**: `keyword-rewriter` は各ページに違うパターンを選ぶよう設計されているが、念のため目視確認推奨
 - **コスト**: Tier 2 評価は LLM 呼び出しを伴う。200 件で約 5〜15 分。コスト発生
 - **べき等**: 一度評価したページはキャッシュされる。再実行で重複しない
+- **並行作業検出**（rewrite モード）: frontmatter `lastRewrittenAt` が直近 4 時間以内に更新された slug は自動 skip される（`MIN_REWRITE_INTERVAL_MINUTES`）。個別リライトや exam-keyword-cycle と並行実行しても差分衝突を防ぐ。`lastRewrittenAt` は ISO 8601 秒単位（例: `'2026-04-21T12:34:56Z'`）で記録される
 
 ## 連携スキル・エージェント
 

--- a/.claude/skills/content/quality-cycle/scripts/lib/cem-qa-prompt.mjs
+++ b/.claude/skills/content/quality-cycle/scripts/lib/cem-qa-prompt.mjs
@@ -101,7 +101,7 @@ ${gInstructions}
   5. G パターン: 既存の該当する表を箇条書きに変換（既存構造の in-place 変更）
   6. frontmatter に以下を追加（既存値があれば上書き）:
      - reviewStatus: needs-review
-     - lastRewrittenAt: ${new Date().toISOString().split('T')[0]}
+     - lastRewrittenAt: ${new Date().toISOString()}  // ISO 8601 秒単位（並行作業検出用）
      - revisionCycle: 1（既存値があれば +1）
   7. 改行コードは元ファイルを保持（.claude/scripts/lib/mdx-io.mjs を必ず使う）
   8. Edit ツールで書き戻し

--- a/.claude/skills/content/quality-cycle/scripts/quality-cycle.mjs
+++ b/.claude/skills/content/quality-cycle/scripts/quality-cycle.mjs
@@ -111,6 +111,33 @@ Options:
 `);
 }
 
+// ── 共通: 並行作業検出（lastRewrittenAt が直近に更新された slug を skip） ──
+
+// bulk 処理の最小インターバル（分）。この範囲内に lastRewrittenAt が更新された
+// slug は別プロセス（個別リライト、並行サイクル等）が触っている可能性があるため skip。
+const MIN_REWRITE_INTERVAL_MINUTES = 240; // 4 時間
+
+function getLastRewrittenAt(slug) {
+  const filePath = join(BASE_DIR, slug, 'article.mdx');
+  if (!existsSync(filePath)) return null;
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const { data } = matter(raw);
+    return data.lastRewrittenAt || null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecentlyRewritten(slug, minIntervalMinutes = MIN_REWRITE_INTERVAL_MINUTES) {
+  const ts = getLastRewrittenAt(slug);
+  if (!ts) return false;
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return false;
+  const ageMs = Date.now() - d.getTime();
+  return ageMs < minIntervalMinutes * 60 * 1000;
+}
+
 // ── 共通: keyword ページ列挙 ────────────────────────────────────
 
 function listKeywordPages() {
@@ -327,12 +354,21 @@ function runRewrite(args) {
       .map(([slug]) => slug),
   );
 
+  // 並行作業検出で skip された slug を記録（ログ用）
+  const skippedRecent = [];
+
   let candidates = Object.entries(scores.pages)
     .filter(([slug, p]) => {
       if (alreadyHandled.has(slug)) return false;
       if (args.flagshipOnly && !flagshipSet.has(slug)) return false;
       if (p.weighted >= threshold) return false;
       if (args.minWeighted !== undefined && p.weighted < args.minWeighted) return false;
+      // 直近 MIN_REWRITE_INTERVAL_MINUTES 以内に更新された slug は別プロセスが
+      // 触っている可能性があるため skip（並行作業の差分衝突を防ぐ）
+      if (isRecentlyRewritten(slug)) {
+        skippedRecent.push(slug);
+        return false;
+      }
       return true;
     })
     .sort(([, a], [, b]) => a.weighted - b.weighted);
@@ -350,6 +386,9 @@ function runRewrite(args) {
   console.log(`[rewrite] 対象: ${candidates.length} 件 (バッチサイズ ${batch})`);
   if (alreadyHandled.size > 0) {
     console.log(`[rewrite] 既処理スキップ: ${alreadyHandled.size} 件`);
+  }
+  if (skippedRecent.length > 0) {
+    console.log(`[rewrite] 並行作業検出スキップ: ${skippedRecent.length} 件 (直近 ${MIN_REWRITE_INTERVAL_MINUTES} 分以内に lastRewrittenAt 更新)`);
   }
 
   if (args.dryRun) {

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -295,7 +295,8 @@ export default async function DocPage({
             {/* 執筆者・最終更新日（全記事共通・E-A-T 強化） */}
             <AuthorCard
               publishedAt={(doc.meta as any).publishedAt || (doc.meta as any).created}
-              updatedAt={(doc.meta as any).lastRewrittenAt || (doc.meta as any).updatedAt}
+              updatedAt={(doc.meta as any).updatedAt}
+              lastRewrittenAt={(doc.meta as any).lastRewrittenAt}
             />
           </main>
 

--- a/src/components/ui/AuthorCard/AuthorCard.tsx
+++ b/src/components/ui/AuthorCard/AuthorCard.tsx
@@ -4,6 +4,7 @@ import { AUTHOR } from "@/config/author";
 interface AuthorCardProps {
   publishedAt?: string;
   updatedAt?: string;
+  lastRewrittenAt?: string;
 }
 
 function formatDate(iso?: string): string | null {
@@ -17,9 +18,14 @@ function formatDate(iso?: string): string | null {
   }
 }
 
-export default function AuthorCard({ publishedAt, updatedAt }: AuthorCardProps) {
+export default function AuthorCard({
+  publishedAt,
+  updatedAt,
+  lastRewrittenAt,
+}: AuthorCardProps) {
   const published = formatDate(publishedAt);
   const updated = formatDate(updatedAt);
+  const lastReviewed = formatDate(lastRewrittenAt);
 
   return (
     <aside
@@ -51,10 +57,15 @@ export default function AuthorCard({ publishedAt, updatedAt }: AuthorCardProps) 
           <p className="mt-2 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
             {AUTHOR.bio}
           </p>
-          {(published || updated) && (
+          {(published || updated || lastReviewed) && (
             <div className="mt-3 text-xs text-gray-500 dark:text-gray-400 flex flex-wrap gap-x-4 gap-y-1">
               {published && <span>公開日: {published}</span>}
               {updated && updated !== published && <span>最終更新: {updated}</span>}
+              {lastReviewed &&
+                lastReviewed !== published &&
+                lastReviewed !== updated && (
+                  <span>最終レビュー: {lastReviewed}</span>
+                )}
             </div>
           )}
           <Link


### PR DESCRIPTION
## develop → main リリース

PR #48 を本番デプロイ。

### 変更概要
- `lastRewrittenAt` を ISO 8601 秒単位にアップグレード（並行作業検出の基盤）
- UI に「最終レビュー: YYYY年M月D日」を追加表示
- quality-cycle rewrite モードに並行作業 skip ロジック追加（4 時間インターバル）

詳細は #48 参照。

### デプロイ後確認
- [ ] https://doboku-note.com/docs/pe-comprehensive-management-cash-flow-statement で「最終レビュー」表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)