### PR TITLE
fix(katex): @layer 外に KaTeX オーバーライドを移動（PR #55 の hotfix、refs #52）

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -138,20 +138,6 @@
     margin-bottom: 0;
   }
 
-  /* KaTeX 数式のフォントを本文（Inter + Noto Sans JP）に揃える
-     - .katex { font-size: 1.21em } の既定拡大を解除し、本文基準に戻す
-     - .mord.text と .cjk_fallback は本文フォントチェーンを継承（日本語を Noto Sans JP で描画）
-     - 数学記号（x, y, ∫, ∑ 等）は KaTeX_Math の italic serif を保持（数学慣習を維持）
-     背景: Issue #52 の CJK 縮小問題への追加対応。\dfrac でサイズは揃ったが、本文との
-     font-family・font-size の差異が残っていたため均質化する */
-  .katex {
-    font-size: inherit;
-  }
-  .katex .mord.text,
-  .katex .cjk_fallback {
-    font-family: inherit;
-  }
-
   /* リンク: 常時アンダーライン（note風、半透明 + offset 4px、hoverで濃く） */
   .prose-blog a {
     text-decoration: underline;
@@ -581,4 +567,23 @@
 .dark .toc-content .ol-depth-2 li.active::before {
   background: #0f83fd;
   border-color: #0f83fd;
+}
+
+/* =====================================================================
+   KaTeX 数式フォントを本文に揃える
+   注: @layer components 内だと katex.min.css（無 layer）の既定に負けて
+   効かない。CSS カスケード上 @layer 内のルールは layer 外のルールより
+   優先度が低い仕様。ここでは layer 外に配置して katex.min.css と同等の
+   カスケード層に置き、後勝ちで上書きする。
+
+   - .katex { font-size: 1.21em } の既定拡大を解除、本文基準に
+   - .mord.text と .cjk_fallback は本文フォントチェーン（Inter + Noto Sans JP）を継承
+   - 数学記号（x, y, ∫, ∑ 等）は KaTeX_Math の italic serif を保持（数学慣習）
+   背景: Issue #52 */
+.katex {
+  font-size: inherit;
+}
+.katex .mord.text,
+.katex .cjk_fallback {
+  font-family: inherit;
 }


### PR DESCRIPTION
## 問題
PR #55 で追加した KaTeX フォント統一ルールが効かなかった。ローカル dev で確認したところフォントが変わっていなかった。

## 原因
ルールを `@layer components` 内に配置したため。CSS の @layer 仕様では、**layer 内のルールは layer 外のルールより優先度が低い**。`katex.min.css` は `import` で読み込まれ無 layer で適用されるため、`@layer components` 内の私のルールは上書きされていた。

## 修正
globals.css の末尾（layer 外）に移動。katex.min.css と同じカスケード層で、後勝ちで上書きされる。

## 教訓
サードパーティ CSS を上書きする際は @layer 外に配置するか、十分な specificity を確保する。今回は前者を採用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)