### PR TITLE
fix(katex): CSS import 順修正（PR #57 の hotfix、refs #52）

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { Inter, Noto_Sans_JP } from "next/font/google";
-import "../styles/globals.css";
+// katex.min.css を先に import して、後続の globals.css で上書きできるようにする
+// （CSS カスケードは後勝ちのため、import 順で決まる）
 import "katex/dist/katex.min.css";
+import "../styles/globals.css";
 import { Suspense } from "react";
 import BackToTopButton from "@/components/ui/BackToTopButton";
 import GoogleAnalytics from "@/components/GoogleAnalytics";


### PR DESCRIPTION
## 問題
PR #57（@layer 外へ移動）でも KaTeX フォントが本文に揃わず。

## 原因
`src/app/layout.tsx` の import 順:
```
import "../styles/globals.css";        // 先
import "katex/dist/katex.min.css";     // 後 ← 後勝ちで勝利
```

## 修正
```
import "katex/dist/katex.min.css";     // 先
import "../styles/globals.css";        // 後 ← globals.css が上書き可能
```

## 検証
コンパイル済 CSS で globals.css の `.katex { font-size: inherit }` が katex.min.css の `.katex { font: 1.21em ... }` より**後に**出力されることを確認済。

refs #52