### PR TITLE
release: KaTeX CSS import 順修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { Inter, Noto_Sans_JP } from "next/font/google";
-import "../styles/globals.css";
+// katex.min.css を先に import して、後続の globals.css で上書きできるようにする
+// （CSS カスケードは後勝ちのため、import 順で決まる）
 import "katex/dist/katex.min.css";
+import "../styles/globals.css";
 import { Suspense } from "react";
 import BackToTopButton from "@/components/ui/BackToTopButton";
 import GoogleAnalytics from "@/components/GoogleAnalytics";


### PR DESCRIPTION
PR #59（import 順修正）を main へ。globals.css が katex.min.css を正しく上書き。refs #52