### PR TITLE
feat: SVG デザイン一貫性の基盤整備（tokens + SKILL + audit P6/P7/P8）

### DIFF
--- a/.claude/design-system/svg-tokens.json
+++ b/.claude/design-system/svg-tokens.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "svg-tokens",
+  "description": "SVG 図版のデザイントークン単一真実源。create-svg / audit-svg / audit-svg-colors が共通参照する。src/styles/globals.css の --color-* と整合すべき（SVG は <img> で配信されるため CSS 変数は使えず、hex リテラルで埋め込む）。",
+  "version": "1.0.0",
+  "updated": "2026-04-21",
+  "colors": {
+    "brand":    { "fill": "#e8f0fe", "stroke": "#2e6da4", "text": "#1a3a5c", "description": "情報・基本・中立" },
+    "positive": { "fill": "#d0e8d0", "stroke": "#3a7d44", "text": "#1a3a5c", "description": "完了・成功・肯定" },
+    "warn":     { "fill": "#fff3cd", "stroke": "#d4a017", "text": "#1a3a5c", "description": "注意・強調" },
+    "danger":   { "fill": "#f8d7da", "stroke": "#b22234", "text": "#1a3a5c", "description": "警告・重要・否定" },
+    "surface":  { "fill": "#f5f5f5", "stroke": "#d7d7d7", "text": "#222",    "description": "弱背景・区切り線" },
+    "ink":      { "strong": "#222", "body": "#555", "muted": "#8a8a8a" }
+  },
+  "colorsAllowList": [
+    "#e8f0fe", "#2e6da4", "#1a3a5c",
+    "#d0e8d0", "#3a7d44",
+    "#fff3cd", "#d4a017",
+    "#f8d7da", "#b22234",
+    "#f5f5f5", "#d7d7d7",
+    "#222", "#555", "#8a8a8a",
+    "#ffffff", "#fff",
+    "none"
+  ],
+  "font": {
+    "family": "Inter, 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', sans-serif",
+    "sizes": {
+      "title": 14,
+      "label": 12,
+      "text":  13,
+      "small": 11
+    },
+    "minSize": 11
+  },
+  "geometry": {
+    "viewBox": {
+      "maxWidth":       400,
+      "preferredWidth": 400,
+      "absoluteMax":    500
+    },
+    "radius": {
+      "box":    6,
+      "inline": 3
+    },
+    "stroke": {
+      "default": 1.5,
+      "divider": 1
+    },
+    "spacing": {
+      "minElementGap": 15
+    }
+  },
+  "required": {
+    "rootAttributes": [
+      "viewBox",
+      "role=\"img\"",
+      "aria-label",
+      "style=\"max-width:{viewBox width}px;width:100%\""
+    ],
+    "fontFamily": "必ず font.family を <svg> or <style> block で指定（ブラウザデフォルトのセリフに陥るのを防ぐ）"
+  },
+  "prohibited": {
+    "darkBackgroundWithWhiteText": "fill が輝度 0.3 未満の濃色 + 内部に白/薄色テキストを置く構成は prohibited.md 違反。淡色 bg + 濃色文字（ink-strong / ink-body）を使用する。",
+    "inlinePresentationStyle": "<rect fill=\"...\" stroke=\"...\"> のようなインライン装飾より、<defs><style> ブロック + class 属性を推奨。保守性が高まる。",
+    "unknownColors": "本 tokens の colorsAllowList 外の hex を使用しない。サイト特色の維持とブランド一貫性のため。"
+  },
+  "references": {
+    "cssVars":          "src/styles/globals.css の --color-* と整合",
+    "designPrinciples": ".claude/design-system/principles.md",
+    "prohibitedRules":  ".claude/design-system/prohibited.md",
+    "createSkill":      ".claude/skills/content/create-svg/SKILL.md",
+    "auditSkill":       ".claude/skills/content/audit-svg/SKILL.md"
+  }
+}

--- a/.claude/skills/content/audit-svg/SKILL.md
+++ b/.claude/skills/content/audit-svg/SKILL.md
@@ -22,6 +22,9 @@ description: >
 | **P3-missing-maxwidth** | HIGH | ルート `<svg>` に `style="max-width:Xpx;width:100%"` が無い | PC で viewBox 幅を超えて拡大表示されるリスク |
 | **P4-tiny-font** | LOW | `font-size < 11px` | モバイル 375px での可読性下限割れ |
 | **P5-wide-viewbox** | MEDIUM | `viewBox` 幅が 400px 超過 | create-svg の原則違反（モバイル縮小率低下） |
+| **P6-color-drift** | MEDIUM | `svg-tokens.json` の colorsAllowList 外の hex 使用 | サイト特色・ブランド一貫性の崩壊 |
+| **P7-missing-font-family** | MEDIUM | `font-family` が SVG 内のどこにも未指定 | ブラウザデフォルト serif に落ちて本文と不整合 |
+| **P8-dark-bg** | **HIGH** | 濃色 fill（輝度 < 0.3）+ 内部に白/薄色テキスト（輝度 > 0.8 or "white"） | `prohibited.md` 違反（淡色 bg + 濃色文字を使う） |
 
 ## 制限事項
 

--- a/.claude/skills/content/audit-svg/scripts/detect.mjs
+++ b/.claude/skills/content/audit-svg/scripts/detect.mjs
@@ -7,6 +7,9 @@
  *   P3: ルート <svg> に必須属性（role="img" / aria-label / style max-width）が欠落
  *   P4: フォントサイズが 11px 未満（モバイル視認性下限）
  *   P5: viewBox 幅が 400px 超過（create-svg 原則違反）
+ *   P6: svg-tokens.json の colorsAllowList 外の hex 使用（色ドリフト）
+ *   P7: font-family が未指定（ブラウザデフォルト serif に落ちる）
+ *   P8: 濃色 fill + 内部に白/薄色テキスト（prohibited.md 違反）
  *
  * 制限事項:
  *   - 正規表現ベースのため、ネストされた <tspan> や transform 付き <text> は
@@ -17,6 +20,22 @@
  */
 
 import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+// svg-tokens.json の colorsAllowList をロード（P6 用）
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TOKENS_PATH = resolve(__dirname, "../../../../design-system/svg-tokens.json");
+let SVG_TOKENS = null;
+try {
+  SVG_TOKENS = JSON.parse(readFileSync(TOKENS_PATH, "utf-8"));
+} catch {
+  SVG_TOKENS = { colorsAllowList: [] };
+}
+const ALLOWED_COLORS = new Set(
+  (SVG_TOKENS.colorsAllowList || []).map((c) => c.toLowerCase())
+);
 
 /** 日本語（CJK）文字かどうか判定 */
 function isCjk(code) {
@@ -262,9 +281,122 @@ export function detectSvgIssues(svg) {
   return findings;
 }
 
+/** hex 文字列を正規化（短縮 #fff → #ffffff、小文字統一） */
+function normalizeHex(hex) {
+  if (!hex) return null;
+  let h = hex.toLowerCase().trim();
+  if (!h.startsWith("#")) return h; // 名前色 or "none" 等
+  if (h.length === 4) {
+    // #abc → #aabbcc
+    h = "#" + h[1] + h[1] + h[2] + h[2] + h[3] + h[3];
+  }
+  return h;
+}
+
+/** hex の輝度（0-1）を計算。P8 の濃色判定に使う */
+function luminance(hex) {
+  if (!hex || !hex.startsWith("#") || hex.length !== 7) return null;
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  // 近似（sRGB の相対輝度）
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * colorsAllowList に含まれるか判定。
+ * svg-tokens.json の allowlist は短縮形（#fff）と正式形（#ffffff）の両方を含むため、
+ * 両方を試す。
+ */
+function isAllowedColor(raw) {
+  if (!raw) return true; // 未指定は検出対象外
+  const lower = raw.toLowerCase().trim();
+  if (ALLOWED_COLORS.has(lower)) return true;
+  const norm = normalizeHex(raw);
+  if (norm && ALLOWED_COLORS.has(norm)) return true;
+  // 短縮形 #fff を #ffffff に展開した上で再照合
+  return false;
+}
+
+/**
+ * 追加検出ルール: P6 (color drift), P7 (missing font), P8 (dark bg + light text)
+ * 正規表現ベースで SVG 全文を走査。
+ */
+function detectColorAndFontIssues(content) {
+  const findings = [];
+
+  // P7: font-family 未指定
+  // <svg> ルート or <style> 内 or どこかに font-family 指定があるかを広く検出
+  const hasFontFamily = /font-family\s*[:=]/.test(content);
+  if (!hasFontFamily) {
+    findings.push({
+      pattern: "P7-missing-font-family",
+      severity: "MEDIUM",
+      detail: "font-family が未指定（ブラウザデフォルト serif に落ちて本文と不整合）",
+    });
+  }
+
+  // P6: 使用中の hex 色を全抽出し、allowlist 外を報告
+  // fill / stroke 属性、style 属性、<style> 内の fill:/stroke:/color: 値
+  const colorRe = /(?:fill|stroke|color)\s*[:=]\s*"?(#[0-9a-fA-F]{3,6}|[a-zA-Z]+)"?/g;
+  const seenOutliers = new Set();
+  let m;
+  while ((m = colorRe.exec(content)) !== null) {
+    const raw = m[1];
+    // url(...) 参照や CSS 変数は除外
+    if (!raw || raw === "none" || raw.startsWith("url(") || raw.startsWith("var(")) continue;
+    if (!isAllowedColor(raw)) {
+      const key = raw.toLowerCase();
+      if (seenOutliers.has(key)) continue;
+      seenOutliers.add(key);
+      findings.push({
+        pattern: "P6-color-drift",
+        severity: "MEDIUM",
+        detail: `allowlist 外の色: ${raw}（svg-tokens.json の colorsAllowList 参照）`,
+      });
+    }
+  }
+
+  // P8: 濃色 fill + 白/薄色テキストの組合せ（prohibited.md 違反）
+  // <rect ... fill="#444">（輝度 < 0.3）+ 同 SVG 内に <text ... fill="white|#fff|#xxxx" 輝度 > 0.8>
+  const darkRects = [];
+  const rectRe = /<rect[^>]*fill\s*=\s*"([^"]+)"[^>]*>/g;
+  while ((m = rectRe.exec(content)) !== null) {
+    const raw = normalizeHex(m[1]);
+    const lum = luminance(raw);
+    if (lum !== null && lum < 0.3) darkRects.push({ fill: raw, lum });
+  }
+  if (darkRects.length > 0) {
+    // 白/薄色テキストの存在
+    const lightTextRe = /<text[^>]*fill\s*=\s*"([^"]+)"/g;
+    const lightTextColors = [];
+    while ((m = lightTextRe.exec(content)) !== null) {
+      const raw = normalizeHex(m[1]);
+      if (raw === "white" || raw === "#ffffff") {
+        lightTextColors.push(raw);
+        continue;
+      }
+      const lum = luminance(raw);
+      if (lum !== null && lum > 0.8) lightTextColors.push(raw);
+    }
+    if (lightTextColors.length > 0) {
+      findings.push({
+        pattern: "P8-dark-bg",
+        severity: "HIGH",
+        detail: `濃色 bg (例: ${darkRects[0].fill}) + 白/薄色テキスト (例: ${lightTextColors[0]}) の組合せを検出。prohibited.md 違反、淡色 bg + 濃色文字に修正せよ`,
+      });
+    }
+  }
+
+  return findings;
+}
+
 /** ファイルパスから監査結果を取得する便利関数 */
 export function auditSvgFile(path) {
   const content = readFileSync(path, "utf-8");
   const svg = parseSvg(content);
-  return detectSvgIssues(svg);
+  const findings = detectSvgIssues(svg);
+  // P6/P7/P8 は content 全文を直接走査（parseSvg の対象外）
+  findings.push(...detectColorAndFontIssues(content));
+  return findings;
 }

--- a/.claude/skills/content/create-svg/SKILL.md
+++ b/.claude/skills/content/create-svg/SKILL.md
@@ -120,13 +120,55 @@ SVG は**全体の流れ・構造を一目で把握させる**ためのもの。
 
 ### タイポグラフィ
 
+**font-family は必ず明示指定する**（未指定だとブラウザのデフォルト serif に落ちて本文と不整合になる）。本文は Inter + Noto Sans JP のため、SVG も同じチェーンを揃える:
+
 ```xml
 <style>
-  text { font-family: "Hiragino Sans", "Yu Gothic", sans-serif; fill: #1f2937; }
+  text { font-family: Inter, "Noto Sans JP", "Hiragino Kaku Gothic ProN", sans-serif; fill: #222; }
 </style>
 ```
 
 - font-weight: **bold**（見出し・ボックスタイトル）、**normal**（本文・補足）
+- font-size: 本文 13px、ラベル 12px、見出し 14px、補足 11px（最小）
+
+### 推奨テンプレート（defs + class 方式）
+
+インラインで色を書くと保守が難しい。**`<defs><style>` に class を定義し、`<rect class="...">` で参照する**:
+
+```xml
+<svg width="400" height="260" viewBox="0 0 400 260"
+     xmlns="http://www.w3.org/2000/svg"
+     style="max-width:400px;width:100%"
+     role="img"
+     aria-label="[図の目的を 40-80 字で]">
+  <defs>
+    <style>
+      text { font-family: Inter, "Noto Sans JP", "Hiragino Kaku Gothic ProN", sans-serif; }
+      .t-title { font-size: 14px; font-weight: bold; fill: #222; }  /* ink-strong */
+      .t-label { font-size: 12px; fill: #555; }                     /* ink-body */
+      .t-text  { font-size: 13px; fill: #222; }                     /* ink-strong */
+      .box-brand    { fill: #e8f0fe; stroke: #2e6da4; stroke-width: 1.5; }
+      .box-positive { fill: #d0e8d0; stroke: #3a7d44; stroke-width: 1.5; }
+      .box-warn     { fill: #fff3cd; stroke: #d4a017; stroke-width: 1.5; }
+      .box-danger   { fill: #f8d7da; stroke: #b22234; stroke-width: 1.5; }
+      .box-surface  { fill: #f5f5f5; stroke: #d7d7d7; stroke-width: 1.5; }
+    </style>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#2e6da4"/>
+    </marker>
+  </defs>
+
+  <!-- 本体 -->
+  <rect class="box-brand" x="20" y="20" width="180" height="60" rx="6"/>
+  <text class="t-title" x="110" y="55" text-anchor="middle">見出し</text>
+</svg>
+```
+
+### 禁止事項
+
+- **濃色背景 + 白/薄色文字の組合せ**（例: `<rect fill="#444"/><text fill="white">`）は `prohibited.md` 違反。淡色 bg（`box-brand` 等）+ 濃色文字（`t-title` / `t-text`）を使う
+- **svg-tokens.json の colorsAllowList 外の hex 使用禁止**（サイト特色の維持）
+- **font-family 未指定禁止**（ブラウザデフォルト serif で描画され本文と不整合）
 
 ### 形状
 

--- a/.local/r2/posts/pe-comprehensive-management/value-engineering/img/ve-basic-steps.svg
+++ b/.local/r2/posts/pe-comprehensive-management/value-engineering/img/ve-basic-steps.svg
@@ -1,30 +1,46 @@
-  <svg width="420" height="110" viewBox="0 0 420 110" xmlns="http://www.w3.org/2000/svg" font-family="sans-serif" font-size="11" style="max-width:420px;width:100%">
-    <defs>
-      <marker id="a2" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L0,8 L8,4 z" fill="#444"/></marker>
-    </defs>
-    <!-- Box1: 機能定義 -->
-    <rect x="8" y="8" width="108" height="92" rx="6" fill="#444" stroke="#222"/>
-    <text x="62" y="30" text-anchor="middle" fill="white" font-size="12" font-weight="bold">機能定義</text>
-    <line x1="20" y1="36" x2="104" y2="36" stroke="#aaa" stroke-width="0.8"/>
-    <text x="62" y="50" text-anchor="middle" fill="#ddd" font-size="10">・VE対象の情報収集</text>
-    <text x="62" y="64" text-anchor="middle" fill="#ddd" font-size="10">・機能の定義</text>
-    <text x="62" y="78" text-anchor="middle" fill="#ddd" font-size="10">・機能の整理</text>
-    <!-- 矢印 -->
-    <line x1="116" y1="54" x2="152" y2="54" stroke="#444" stroke-width="2" marker-end="url(#a2)"/>
-    <!-- Box2: 機能評価 -->
-    <rect x="152" y="8" width="108" height="92" rx="6" fill="#555" stroke="#333"/>
-    <text x="206" y="30" text-anchor="middle" fill="white" font-size="12" font-weight="bold">機能評価</text>
-    <line x1="164" y1="36" x2="248" y2="36" stroke="#aaa" stroke-width="0.8"/>
-    <text x="206" y="50" text-anchor="middle" fill="#ddd" font-size="10">・機能別コスト分析</text>
-    <text x="206" y="64" text-anchor="middle" fill="#ddd" font-size="10">・機能の評価</text>
-    <text x="206" y="78" text-anchor="middle" fill="#ddd" font-size="10">・対象分野の選定</text>
-    <!-- 矢印 -->
-    <line x1="260" y1="54" x2="296" y2="54" stroke="#444" stroke-width="2" marker-end="url(#a2)"/>
-    <!-- Box3: 代替案作成 -->
-    <rect x="296" y="8" width="116" height="92" rx="6" fill="#666" stroke="#444"/>
-    <text x="354" y="30" text-anchor="middle" fill="white" font-size="12" font-weight="bold">代替案作成</text>
-    <line x1="308" y1="36" x2="400" y2="36" stroke="#aaa" stroke-width="0.8"/>
-    <text x="354" y="50" text-anchor="middle" fill="#ddd" font-size="10">・アイデア評価</text>
-    <text x="354" y="64" text-anchor="middle" fill="#ddd" font-size="10">・概略評価・具体化</text>
-    <text x="354" y="78" text-anchor="middle" fill="#ddd" font-size="10">・詳細評価</text>
-  </svg>
+<svg width="400" height="200" viewBox="0 0 400 200"
+     xmlns="http://www.w3.org/2000/svg"
+     style="max-width:400px;width:100%"
+     role="img"
+     aria-label="VE の基本 3 ステップ：機能定義 → 機能評価 → 代替案作成">
+  <defs>
+    <style>
+      text { font-family: Inter, "Noto Sans JP", "Hiragino Kaku Gothic ProN", sans-serif; }
+      .t-step-n  { font-size: 11px; fill: #555; }
+      .t-title   { font-size: 13px; font-weight: bold; fill: #1a3a5c; }
+      .t-desc    { font-size: 11px; fill: #555; }
+      .box-brand    { fill: #e8f0fe; stroke: #2e6da4; stroke-width: 1.5; }
+      .box-positive { fill: #d0e8d0; stroke: #3a7d44; stroke-width: 1.5; }
+    </style>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#2e6da4"/>
+    </marker>
+  </defs>
+
+  <!-- Step 1 -->
+  <rect class="box-brand" x="12" y="40" width="110" height="90" rx="6"/>
+  <text class="t-step-n" x="67" y="62" text-anchor="middle">STEP 1</text>
+  <text class="t-title"  x="67" y="82" text-anchor="middle">機能定義</text>
+  <text class="t-desc"   x="67" y="104" text-anchor="middle">対象の機能を</text>
+  <text class="t-desc"   x="67" y="120" text-anchor="middle">「…を…する」で洗出</text>
+
+  <line x1="124" y1="85" x2="142" y2="85" stroke="#2e6da4" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 2 -->
+  <rect class="box-brand" x="148" y="40" width="110" height="90" rx="6"/>
+  <text class="t-step-n" x="203" y="62" text-anchor="middle">STEP 2</text>
+  <text class="t-title"  x="203" y="82" text-anchor="middle">機能評価</text>
+  <text class="t-desc"   x="203" y="104" text-anchor="middle">重要度・コストを測定</text>
+  <text class="t-desc"   x="203" y="120" text-anchor="middle">価値の低い機能を特定</text>
+
+  <line x1="260" y1="85" x2="278" y2="85" stroke="#2e6da4" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 3 -->
+  <rect class="box-positive" x="284" y="40" width="110" height="90" rx="6"/>
+  <text class="t-step-n" x="339" y="62" text-anchor="middle">STEP 3</text>
+  <text class="t-title"  x="339" y="82" text-anchor="middle">代替案作成</text>
+  <text class="t-desc"   x="339" y="104" text-anchor="middle">機能を維持しつつ</text>
+  <text class="t-desc"   x="339" y="120" text-anchor="middle">コスト削減案を立案</text>
+
+  <text class="t-desc" x="200" y="165" text-anchor="middle">順序が重要：機能評価が代替案作成より先に来る</text>
+</svg>

--- a/.local/r2/posts/pe-comprehensive-management/value-engineering/img/ve-function-tree.svg
+++ b/.local/r2/posts/pe-comprehensive-management/value-engineering/img/ve-function-tree.svg
@@ -1,49 +1,62 @@
-  <svg width="420" height="260" viewBox="0 0 420 260" xmlns="http://www.w3.org/2000/svg" font-family="sans-serif" font-size="12" style="max-width:420px;width:100%">
-    <defs>
-      <marker id="a1" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0,0 L0,7 L7,3.5 z" fill="#444"/></marker>
-    </defs>
-    <!-- 目的ボックス -->
-    <rect x="12" y="105" width="72" height="44" rx="4" fill="#444" stroke="#222"/>
-    <text x="48" y="124" text-anchor="middle" fill="white" font-size="12" font-weight="bold">目的</text>
-    <text x="48" y="140" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-    <!-- 矢印 目的→中段3つ -->
-    <line x1="84" y1="127" x2="130" y2="80" stroke="#444" stroke-width="1.5" marker-end="url(#a1)"/>
-    <line x1="84" y1="127" x2="130" y2="127" stroke="#444" stroke-width="1.5" marker-end="url(#a1)"/>
-    <line x1="84" y1="127" x2="130" y2="175" stroke="#444" stroke-width="1.5" marker-end="url(#a1)"/>
-    <!-- 中段ボックス -->
-    <rect x="130" y="60" width="78" height="40" rx="4" fill="#666" stroke="#444"/>
-    <text x="169" y="76" text-anchor="middle" fill="white" font-size="11">手段</text>
-    <text x="169" y="90" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-    <rect x="130" y="108" width="78" height="40" rx="4" fill="#666" stroke="#444"/>
-    <text x="169" y="124" text-anchor="middle" fill="white" font-size="11">手段</text>
-    <text x="169" y="138" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-    <rect x="130" y="156" width="78" height="40" rx="4" fill="#666" stroke="#444"/>
-    <text x="169" y="172" text-anchor="middle" fill="white" font-size="11">手段</text>
-    <text x="169" y="186" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-    <!-- 矢印 中段→右段 -->
-    <line x1="208" y1="80" x2="248" y2="55" stroke="#444" stroke-width="1.5" marker-end="url(#a1)"/>
-    <line x1="208" y1="80" x2="248" y2="95" stroke="#444" stroke-width="1.5" marker-end="url(#a1)"/>
-    <line x1="208" y1="128" x2="248" y2="128" stroke="#444" stroke-width="1.5" marker-end="url(#a1)"/>
-    <line x1="208" y1="128" x2="248" y2="155" stroke="#444" stroke-width="1.5" marker-end="url(#a1)"/>
-    <line x1="208" y1="176" x2="248" y2="185" stroke="#444" stroke-width="1.5" marker-end="url(#a1)"/>
-    <line x1="208" y1="176" x2="248" y2="215" stroke="#444" stroke-width="1.5" marker-end="url(#a1)"/>
-    <!-- 右段ボックス6つ -->
-    <rect x="248" y="36" width="78" height="36" rx="4" fill="#888" stroke="#555"/>
-    <text x="287" y="50" text-anchor="middle" fill="white" font-size="11">手段</text>
-    <text x="287" y="64" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-    <rect x="248" y="78" width="78" height="36" rx="4" fill="#888" stroke="#555"/>
-    <text x="287" y="92" text-anchor="middle" fill="white" font-size="11">手段</text>
-    <text x="287" y="106" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-    <rect x="248" y="110" width="78" height="36" rx="4" fill="#888" stroke="#555"/>
-    <text x="287" y="124" text-anchor="middle" fill="white" font-size="11">手段</text>
-    <text x="287" y="138" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-    <rect x="248" y="138" width="78" height="36" rx="4" fill="#888" stroke="#555"/>
-    <text x="287" y="152" text-anchor="middle" fill="white" font-size="11">手段</text>
-    <text x="287" y="166" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-    <rect x="248" y="168" width="78" height="36" rx="4" fill="#888" stroke="#555"/>
-    <text x="287" y="182" text-anchor="middle" fill="white" font-size="11">手段</text>
-    <text x="287" y="196" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-    <rect x="248" y="198" width="78" height="36" rx="4" fill="#888" stroke="#555"/>
-    <text x="287" y="212" text-anchor="middle" fill="white" font-size="11">手段</text>
-    <text x="287" y="226" text-anchor="middle" fill="white" font-size="10">（目的）</text>
-  </svg>
+<svg width="400" height="260" viewBox="0 0 400 260"
+     xmlns="http://www.w3.org/2000/svg"
+     style="max-width:400px;width:100%"
+     role="img"
+     aria-label="機能系統図（FAST ダイアグラム）：目的機能から手段機能への階層分解（Why/How の階層）">
+  <defs>
+    <style>
+      text { font-family: Inter, "Noto Sans JP", "Hiragino Kaku Gothic ProN", sans-serif; }
+      .t-root { font-size: 13px; font-weight: bold; fill: #1a3a5c; }
+      .t-mid  { font-size: 12px; fill: #1a3a5c; }
+      .t-leaf { font-size: 11px; fill: #1a3a5c; }
+      .t-axis { font-size: 11px; fill: #555; }
+      .box-root { fill: #e8f0fe; stroke: #2e6da4; stroke-width: 1.5; }
+      .box-mid  { fill: #d0e8d0; stroke: #3a7d44; stroke-width: 1.5; }
+      .box-leaf { fill: #fff3cd; stroke: #d4a017; stroke-width: 1.5; }
+    </style>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#2e6da4"/>
+    </marker>
+  </defs>
+
+  <!-- Axis labels: Why ← | → How -->
+  <text class="t-axis" x="60"  y="18" text-anchor="middle">目的（Why）</text>
+  <text class="t-axis" x="340" y="18" text-anchor="middle">手段（How）</text>
+  <line x1="20" y1="28" x2="380" y2="28" stroke="#d7d7d7" stroke-width="1"/>
+
+  <!-- Root -->
+  <rect class="box-root" x="12" y="110" width="80" height="40" rx="6"/>
+  <text class="t-root" x="52" y="135" text-anchor="middle">目的機能</text>
+
+  <!-- arrows to mid -->
+  <line x1="92" y1="130" x2="128" y2="80"  stroke="#2e6da4" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="92" y1="130" x2="128" y2="130" stroke="#2e6da4" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="92" y1="130" x2="128" y2="180" stroke="#2e6da4" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Mid 1-3 -->
+  <rect class="box-mid" x="134" y="60"  width="90" height="40" rx="6"/>
+  <text class="t-mid" x="179" y="85" text-anchor="middle">手段機能 A</text>
+  <rect class="box-mid" x="134" y="110" width="90" height="40" rx="6"/>
+  <text class="t-mid" x="179" y="135" text-anchor="middle">手段機能 B</text>
+  <rect class="box-mid" x="134" y="160" width="90" height="40" rx="6"/>
+  <text class="t-mid" x="179" y="185" text-anchor="middle">手段機能 C</text>
+
+  <!-- arrows to leaves -->
+  <line x1="224" y1="80"  x2="258" y2="55"  stroke="#3a7d44" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="224" y1="80"  x2="258" y2="95"  stroke="#3a7d44" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="224" y1="130" x2="258" y2="130" stroke="#3a7d44" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="224" y1="180" x2="258" y2="165" stroke="#3a7d44" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="224" y1="180" x2="258" y2="205" stroke="#3a7d44" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Leaves -->
+  <rect class="box-leaf" x="264" y="38"  width="84" height="34" rx="6"/>
+  <text class="t-leaf" x="306" y="60" text-anchor="middle">下位機能 A-1</text>
+  <rect class="box-leaf" x="264" y="78"  width="84" height="34" rx="6"/>
+  <text class="t-leaf" x="306" y="100" text-anchor="middle">下位機能 A-2</text>
+  <rect class="box-leaf" x="264" y="118" width="84" height="34" rx="6"/>
+  <text class="t-leaf" x="306" y="140" text-anchor="middle">下位機能 B-1</text>
+  <rect class="box-leaf" x="264" y="158" width="84" height="34" rx="6"/>
+  <text class="t-leaf" x="306" y="180" text-anchor="middle">下位機能 C-1</text>
+  <rect class="box-leaf" x="264" y="198" width="84" height="34" rx="6"/>
+  <text class="t-leaf" x="306" y="220" text-anchor="middle">下位機能 C-2</text>
+</svg>


### PR DESCRIPTION
## 変更
SVG 規律の 5 層モデル実装の Phase 1:
1. `svg-tokens.json` 新設（単一真実源）
2. create-svg SKILL に XML テンプレート + 禁止ルール追加
3. audit-svg に P6-color-drift / P7-missing-font-family / P8-dark-bg 追加
4. VE 系 SVG 2 枚をリライト（濃色 bg グレースケール → brand トークン）

## 検証
VE SVG 2 枚とも新 audit で HIGH/MEDIUM/LOW = 0/0/0 ✓

## 継続運用
別途 Issue「[SVG] デザイン一貫性の継続改善」を作成予定。

## デプロイ規律
develop のみマージ、main deploy は PR #61 / #62 と束ねて 1 回で。

refs #52