### PR TITLE
feat(ci): R2 画像自動同期ワークフロー追加（refs #64）

### DIFF
--- a/.github/scripts/r2-sync.mjs
+++ b/.github/scripts/r2-sync.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * R2 同期スクリプト（GitHub Actions 用）
+ *
+ * 既存の CLOUDFLARE_API_TOKEN + wrangler CLI で R2 にアップロードする。
+ * ローカル `.local/r2/posts/**\/img/*` を R2 の `posts/...` に同期。
+ *
+ * Usage:
+ *   node .github/scripts/r2-sync.mjs [--mode=all|diff] [--dry-run]
+ *
+ * Modes:
+ *   - all:  `.local/r2/posts/` 配下の全画像を upload（初回・手動）
+ *   - diff: git の前 commit との差分を upload（push トリガー用）
+ *
+ * Env:
+ *   CLOUDFLARE_API_TOKEN  wrangler 認証用（R2 Edit 権限が必要）
+ *   CLOUDFLARE_ACCOUNT_ID
+ *   DRY_RUN               "true" でアップロード skip
+ *   BASE_SHA              diff モード時の比較先 SHA（デフォルト: HEAD^）
+ *   HEAD_SHA              diff モード時の現在 SHA（デフォルト: HEAD）
+ */
+
+import { execSync } from "child_process";
+import { globSync } from "glob";
+import { statSync } from "fs";
+import path from "path";
+
+const BUCKET = "doboku-note";
+const CONCURRENCY = 10;
+
+const args = process.argv.slice(2);
+const mode = args.find((a) => a.startsWith("--mode="))?.split("=")[1] || "all";
+const dryRunArg = args.includes("--dry-run");
+const dryRunEnv = process.env.DRY_RUN === "true";
+const DRY_RUN = dryRunArg || dryRunEnv;
+
+const IMAGE_EXT = /\.(svg|png|jpe?g|gif|webp)$/i;
+
+function log(msg) {
+  console.log(`[r2-sync] ${msg}`);
+}
+
+/** 対象ファイル一覧を取得 */
+function listFiles() {
+  if (mode === "diff") {
+    const base = process.env.BASE_SHA || "HEAD^";
+    const head = process.env.HEAD_SHA || "HEAD";
+    log(`diff mode: ${base}..${head}`);
+    try {
+      const output = execSync(
+        `git diff --name-only --diff-filter=ACMR ${base}..${head} -- '.local/r2/posts/**/img/**'`,
+        { encoding: "utf-8" }
+      );
+      return output
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .filter((f) => IMAGE_EXT.test(f));
+    } catch (e) {
+      log(`git diff failed (${e.message}), falling back to all mode`);
+    }
+  }
+  log("all mode: scanning .local/r2/posts/**/img/**");
+  return globSync(".local/r2/posts/**/img/**/*", { nodir: true }).filter((f) =>
+    IMAGE_EXT.test(f)
+  );
+}
+
+/** ローカルパスを R2 のキーに変換: .local/r2/posts/.../file → posts/.../file */
+function toR2Key(localPath) {
+  const normalized = localPath.replace(/\\/g, "/");
+  return normalized.replace(/^\.local\/r2\//, "");
+}
+
+/** 1 ファイルを wrangler でアップロード */
+async function uploadOne(file) {
+  const key = toR2Key(file);
+  if (DRY_RUN) {
+    console.log(`DRY-RUN  ${key}`);
+    return { ok: true, key, dryRun: true };
+  }
+  try {
+    // wrangler r2 object put <bucket>/<key> --file=<path> --remote
+    const cmd = `wrangler r2 object put "${BUCKET}/${key}" --file="${file}" --remote`;
+    execSync(cmd, { stdio: ["ignore", "pipe", "pipe"] });
+    return { ok: true, key };
+  } catch (e) {
+    return { ok: false, key, error: e.message };
+  }
+}
+
+/** 並列アップロード（セマフォ方式） */
+async function uploadAll(files) {
+  const results = [];
+  const queue = [...files];
+  const workers = Array.from({ length: CONCURRENCY }, async () => {
+    while (queue.length) {
+      const file = queue.shift();
+      if (!file) break;
+      const result = await uploadOne(file);
+      results.push(result);
+      const pct = ((results.length / files.length) * 100).toFixed(1);
+      if (result.ok) {
+        console.log(`[${results.length}/${files.length} ${pct}%] ${result.dryRun ? "DRY" : "OK "} ${result.key}`);
+      } else {
+        console.error(`[${results.length}/${files.length}] FAIL ${result.key}: ${result.error.slice(0, 100)}`);
+      }
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+async function main() {
+  if (!process.env.CLOUDFLARE_API_TOKEN) {
+    console.error("Error: CLOUDFLARE_API_TOKEN not set");
+    process.exit(1);
+  }
+
+  log(`mode=${mode} dry-run=${DRY_RUN} concurrency=${CONCURRENCY}`);
+
+  const files = listFiles();
+  log(`found ${files.length} image file(s) to sync`);
+
+  if (files.length === 0) {
+    log("nothing to sync, exiting");
+    return;
+  }
+
+  if (files.length > 0 && files.length <= 20) {
+    log("files:");
+    files.forEach((f) => console.log(`  ${toR2Key(f)}`));
+  }
+
+  const startMs = Date.now();
+  const results = await uploadAll(files);
+  const elapsed = ((Date.now() - startMs) / 1000).toFixed(1);
+
+  const ok = results.filter((r) => r.ok).length;
+  const fail = results.filter((r) => !r.ok).length;
+
+  log(`done: ${ok} ok / ${fail} fail / ${elapsed}s`);
+
+  if (fail > 0) {
+    console.error(`\nFailed files:`);
+    for (const r of results.filter((r) => !r.ok)) {
+      console.error(`  ${r.key}: ${r.error?.slice(0, 200)}`);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`Fatal: ${e.message}`);
+  process.exit(1);
+});

--- a/.github/workflows/r2-sync.yml
+++ b/.github/workflows/r2-sync.yml
@@ -1,0 +1,90 @@
+name: R2 Sync Images
+
+# .local/r2/posts/**/img/** が変更されたとき、R2 に自動同期する。
+# 既存 CLOUDFLARE_API_TOKEN + wrangler CLI で実行（R2 Edit 権限が必要）。
+
+on:
+  # main へ push 時、画像パス変更のみトリガー（diff 同期で高速）
+  push:
+    branches:
+      - main
+    paths:
+      - '.local/r2/posts/**/img/**'
+
+  # 手動実行（初回・緊急・一括同期用）
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Sync mode (all: 全画像、diff: 直前 commit との差分のみ)'
+        required: true
+        default: 'diff'
+        type: choice
+        options:
+          - all
+          - diff
+      dry_run:
+        description: 'Dry run（アップロードせず対象一覧のみ出力）'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  # 同一ブランチの並行実行を抑制（R2 競合回避）
+  group: r2-sync-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout (fetch-depth 2 for diff mode)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install wrangler
+        run: npm install -g wrangler@4
+
+      - name: Verify Cloudflare token
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo "=== wrangler whoami ==="
+          wrangler whoami
+          echo ""
+          echo "=== R2 bucket accessibility check ==="
+          wrangler r2 bucket list || {
+            echo "::error::wrangler r2 bucket list failed. CLOUDFLARE_API_TOKEN needs 'Workers R2 Storage: Edit' permission."
+            echo "::error::Fallback: add CLOUDFLARE_R2_ACCESS_KEY_ID and CLOUDFLARE_R2_SECRET_ACCESS_KEY secrets and switch to S3 API script."
+            exit 1
+          }
+
+      - name: Sync images to R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          MODE="${{ github.event.inputs.mode || 'diff' }}"
+          DRY_ARG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY_ARG="--dry-run"
+          fi
+          node .github/scripts/r2-sync.mjs --mode=$MODE $DRY_ARG
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## R2 Sync Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- Mode: ${{ github.event.inputs.mode || 'diff' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Dry run: ${{ github.event.inputs.dry_run || 'false' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Trigger: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Base SHA: ${{ github.event.before || 'N/A' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Head SHA: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 目的
.local/r2/posts/**/img/* → R2 の同期を手動運用から GitHub Actions 自動化へ移行。Issue #64 の画像 404 を構造的に解消。

## 新規
- .github/workflows/r2-sync.yml: push to main (paths filter) + workflow_dispatch
- .github/scripts/r2-sync.mjs: wrangler CLI 経由で並列アップロード（CONCURRENCY=10）

## 認証
既存の CLOUDFLARE_API_TOKEN を使用（追加 secrets 不要）。事前検証で R2 Edit 権限の有無を確認、なければ明示エラー。

## 初回実行プラン
1. 本 PR → develop マージ
2. develop → main release PR に本 commit を含める（他 PR #61/62/63/65/66 と束ねて 1 回 deploy）
3. main への merge 後、push トリガーで初回自動実行（diff モードだが初 push は全件扱い）
4. 必要なら workflow_dispatch で --mode=all --dry_run=true を先に打って検証

## Fallback
CLOUDFLARE_API_TOKEN に R2 Edit 権限がない場合、エラーメッセージで B1（CLOUDFLARE_R2_ACCESS_KEY_ID/SECRET を secrets に追加）への切替を案内。

refs #64