### PR TITLE
chore(ops): ブランチ運用ルールを CLAUDE.md に明文化

### DIFF
--- a/.claude/skills/content/exam-keyword-cycle/SKILL.md
+++ b/.claude/skills/content/exam-keyword-cycle/SKILL.md
@@ -293,7 +293,7 @@ node .claude/skills/content/exam-keyword-cycle/scripts/sync-umbrella.mjs --all
 
 ### Phase 6: PR 作成
 
-`/pr-create --base main` を呼出。PR body は HEREDOC で以下のテンプレに従う:
+`/pr-create --base develop` を呼出（CLAUDE.md「ブランチ運用ルール」に準拠）。PR body は HEREDOC で以下のテンプレに従う:
 
 ```markdown
 ## 起点過去問

--- a/.claude/skills/dev/pr-create/SKILL.md
+++ b/.claude/skills/dev/pr-create/SKILL.md
@@ -20,9 +20,9 @@ user-invocable: true
 /pr-create [--base <branch>] [--draft]
 ```
 
-- **`--base`**: PR の base ブランチ（省略時は `main`）
+- **`--base`**: PR の base ブランチ（省略時は `develop` — CLAUDE.md「ブランチ運用ルール」に準拠）
 - **`--draft`**: Draft PR として作成
-- 引数省略時: 現在の branch から `main` への PR を作成
+- 引数省略時: 現在の branch から `develop` への PR を作成。`main` 直指定は本番障害 hotfix のみ
 
 ## 実行手順
 
@@ -85,26 +85,36 @@ EOF
 ### Step 5: URL 返却 + 次アクション提示
 
 - gh CLI が返した PR URL を報告
-- CI が走る場合はその旨を案内（`ci.yml` が PR on main で実行）
+- CI が走る場合はその旨を案内（`ci.yml` が PR on main/develop で実行）
 - draft で作成した場合は「準備できたら `gh pr ready <number>` で ready に変更」と案内
 
 ## 例
 
-### 例 1: develop から main への PR
+### 例 1: feature ブランチから develop への PR（デフォルト）
 
 ```bash
 /pr-create
 ```
 
-→ base = main、現在の develop との差分でタイトル・body 生成、`gh pr create` 実行。
+→ base = develop、現在のブランチとの差分でタイトル・body 生成、`gh pr create` 実行。
 
-### 例 2: feature/ui-tokens ブランチから develop へ
+### 例 2: develop から main への PR（リリース時のみ、通常は `/deploy` を使う）
 
 ```bash
-/pr-create --base develop
+/pr-create --base main
 ```
 
-→ base = develop、feature/ui-tokens との差分で PR 作成。
+→ base = main、develop との差分で PR 作成。リリース用。
+
+### 例 3: 本番障害 hotfix
+
+feature ブランチを main から直接切って:
+
+```bash
+/pr-create --base main
+```
+
+→ hotfix 用の緊急 PR。merge 後は main → develop 逆 merge を忘れない。
 
 ### 例 3: Draft PR
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Pre-merge check (type + test + build)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
     branches: [develop]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,19 @@ MDX を書くときに **毎回守るべき最低限** のルール。詳細な�
 - **手動**: `npm run build && npx wrangler pages deploy build --project-name=doboku-note`
 - **Secrets**: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
 
+## ブランチ運用ルール
+
+複数エージェント・複数セッションが並行して作業することを前提に、以下を**常に**守る。
+
+- **全 PR のデフォルト base は `develop`**。feature ブランチ（`claude/*` や `feat/*`）から `develop` へ PR を出し、レビュー後 `develop` に merge する
+- **`main` は常にデプロイ済みの安定版**。`develop` → `main` への merge は `/deploy` スキル経由でユーザーがタイミングを判断（= deploy の発火）
+- **例外: 本番障害の hotfix のみ `--base main` 直 PR を認める**。merge 後は必ず `main` → `develop` へ逆 merge して差分を解消する
+- **小修正のたびに main へ push しない**。`develop` に複数機能・修正を蓄積し、機能まとまり or 週次の単位でまとめて main merge
+- **`develop` は週 1 回 `main` から rebase/merge して追従**（`git checkout develop && git merge origin/main`）。長命化によるコンフリクト膨張を防ぐ
+- スキル側の扱い: `/pr-create` の `--base` 省略時は `develop`、`/deploy` は `develop` → `main` 経路を担当、`/exam-keyword-cycle` 等のコンテンツサイクル PR も `--base develop` で作る
+
+このルールは並行エージェント作業時の衝突を減らし、main の安定性を担保し、deploy タイミングをユーザー判断下に置くための運用則。SKILL.md 内で base 指定を書く場合もこのルールに従う。
+
 ## 頻用コマンド
 
 ```bash


### PR DESCRIPTION
## 背景

複数エージェント・複数セッションが並行して作業する状況で、PR の base ブランチ指定が SKILL.md 間で統一されていない問題が判明した。

- `.claude/skills/content/exam-keyword-cycle/SKILL.md` Phase 6: `--base main` と明記
- `.claude/skills/dev/pr-create/SKILL.md` デフォルト: `main`
- memory `feedback_deploy_discipline.md`: 「小修正で main へ deploy しない、develop で検証してから」

直近の R04 Ⅰ-1-2 サイクル（PR #86）で SKILL.md と memory の矛盾が表面化したのをきっかけに、真実源を CLAUDE.md に一本化する。

## 変更内容

### 1. CLAUDE.md に「ブランチ運用ルール」節を追加（真実源）

- 全 PR のデフォルト base は `develop`
- `main` マージ（= Cloudflare Pages 本番デプロイ発火）は `/deploy` 経由でユーザーがタイミング判断
- 例外: 本番障害 hotfix のみ `--base main` 直。merge 後 `main` → `develop` 逆 merge を必須
- 小修正のたびに main へ push しない。`develop` に機能まとまり or 週次で蓄積
- `develop` は週 1 回 `main` から rebase/merge して追従（コンフリクト膨張回避）

### 2. `/pr-create` スキルのデフォルト変更

- `--base` 省略時: `main` → `develop`
- 例題を「feature → develop（デフォルト）」「develop → main（リリース）」「hotfix」の 3 パターンに刷新
- `main` 直 PR は本番障害 hotfix のみと明記

### 3. `/exam-keyword-cycle` スキル Phase 6 の base 修正

- `/pr-create --base main` → `/pr-create --base develop`
- CLAUDE.md 参照を明記

### 4. CI トリガー拡張

- `.github/workflows/ci.yml`: `pull_request: [main]` → `pull_request: [main, develop]`
- develop 向け PR でも pre-merge で type-check / test / validate-mdx / build が走る
- 従来は develop PR が CI なし（push 後検証のみ）で merge 前検出ができなかった

### 5. memory の整理

- `feedback_deploy_discipline.md` を CLAUDE.md 参照の軽量化版に書き換え（Why としての KaTeX 事例は保持）
- MEMORY.md インデックスの 1 行も更新

## 影響範囲

- **新規 PR**: 自動的に `--base develop` が既定になる（下流スキル呼出時）
- **既存運用**: 既に develop 基盤の運用になっている（`/deploy` スキル、memory）ので破壊的変更なし
- **CI**: develop PR の pre-merge チェックが増え、検出タイミングが早まる（コスト微増）

## 検証

- [x] `.claude/` 配下の `--base main` / `base main` 参照を grep で洗い出し済み（該当 2 ファイルのみ修正）
- [x] 本 PR 自体を `--base develop` で作成（ドッグフード）
- [ ] develop 向け PR で CI が走ることを確認（本 PR がその最初のケース）
- [ ] レビュアー確認後 develop に merge、次回 `/deploy` で main へ

## 関連

- 契機: PR #86（R04 Ⅰ-1-2 サイクル）でのルール矛盾
- 真実源: CLAUDE.md「ブランチ運用ルール」節（本 PR で追加）
- 関連スキル: `/pr-create`, `/deploy`, `/exam-keyword-cycle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)