### PR TITLE
chore(skills): exam-keyword-cycle に「新規キーワードページ作成禁止」ルールを明記

### DIFF
--- a/.claude/skills/content/exam-keyword-cycle/SKILL.md
+++ b/.claude/skills/content/exam-keyword-cycle/SKILL.md
@@ -72,6 +72,16 @@ node .claude/skills/content/exam-keyword-cycle/scripts/select-next-question.mjs 
 - `cem-qa` エージェントが利用可能
 - dev server が起動している（`npm run dev` で 3020 ポート）— 視覚検証に使用
 
+### 運用方針: 新規キーワードページは作らない
+
+総監キーワードページ（pe-comprehensive-management/ 配下）の **新規作成は禁止**。既存ページの補強・統合で対応する（2026-04-18 決定、memory: no-new-keyword-pages）。
+
+- **キーワード集 2026 の真実源**: `.local/r2/posts/pe-comprehensive-management/keyword-2026/article.mdx`
+- 過去問で言及されるが既存ページに無い用語を発見した場合:
+  - **カタログに存在する** → 既存ページで補強（通常のサイクル対象）
+  - **カタログに存在しない** → 既存ページ本文内で触れるか、過去問解説側の言及で済ませる。**新規ページは起こさない**
+- 本スキルの Phase 3 / 重大な発見のいずれでも「新規キーワードページ追加」を提案してはならない
+
 ## フェーズ構成（6 段階）
 
 ### Phase 1: 起点過去問の特定と論点抽出
@@ -329,9 +339,13 @@ PR 作成後、`index.json` と `progress.json` の `pr` フィールドに PR �
 
 - 過去問 MDX 自体に OCR エラーがある（設問文・選択肢の破損）
 - 過去問の解答表（`/add-exam-answers`）の反映漏れ
-- キーワードページが存在すべきなのにない
+- **カタログに存在するのにキーワードページが欠落している**（`keyword-2026/article.mdx` を先に検索して確認すること）
 
 Issue ラベル: `content-quality`, `auto-generated`（PSI 違反 Issue と同パターン）
+
+### 起こしてはならない Issue / 提案
+
+- 「新規キーワードページ追加を検討」—— 運用方針により新規作成は禁止。カタログ外の用語は既存ページ本文での言及で済ませる（前提条件「運用方針: 新規キーワードページは作らない」参照）
 
 ## 参照
 


### PR DESCRIPTION
## 背景

R04 Ⅰ-1-9 サイクル（PR #100）で **勤務間インターバル制度**（技術士総監キーワード集 2026 の 3.2 に不在）を「新規ページ追加検討」として重大発見に挙げる誤りを犯した。memory: `no-new-keyword-pages`（2026-04-18 決定）の方針が SKILL.md に反映されておらず、毎回 memory を照合しない限り同じ誤りが再発する構造だった。

## 修正内容

### `前提条件` に「運用方針: 新規キーワードページは作らない」節を追加

- カタログ真実源 (`keyword-2026/article.mdx`) を明示
- カタログ内外の用語に対する分岐ルール:
  - **カタログに存在する** → 既存ページで補強
  - **カタログに存在しない** → 既存ページ本文内で言及、過去問解説側で済ます。新規ページは起こさない

### `重大な発見の扱い` を更新

- 「キーワードページが存在すべきなのにない」→「**カタログに存在するのに** 欠落」と限定
- 「**起こしてはならない Issue / 提案**」節を追加し、新規ページ提案を明示的に禁止

## 効果

SKILL.md は skill 起動時に必ず読まれるため、memory を参照し忘れても誤った提案を物理的に防げる。

## 検証

- [x] MDX lint（本 PR は .md のみで対象外）
- [x] type-check / tests（変更は SKILL.md のみで影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)