### PR TITLE
feat(skill): exam-keyword-cycle 対象年度を R02/R01 に拡張

### DIFF
--- a/.claude/skills/content/exam-keyword-cycle/scripts/lib/umbrella-builder.mjs
+++ b/.claude/skills/content/exam-keyword-cycle/scripts/lib/umbrella-builder.mjs
@@ -28,6 +28,8 @@ export const TARGET_YEARS = [
   'pe-comprehensive-management-r05-primary',
   'pe-comprehensive-management-r04-primary',
   'pe-comprehensive-management-r03-primary',
+  'pe-comprehensive-management-r02-primary',
+  'pe-comprehensive-management-r01-primary',
 ];
 
 /** 受験直結のため cem-qa 閾値を引き上げる exam。未指定は 2.0。 */
@@ -227,7 +229,7 @@ export function buildParentUmbrellaBody(progress, catalog) {
   body += `- 本 Issue は **永続**（close しない）\n`;
   body += `- 各年度 Umbrella は全問 full-cycle で close → 次年度 Umbrella を作成\n`;
   body += `- 週次 \`/weekly-review\` Agent F が本 Issue のサマリを \`[PDCA] YYYY-Www\` に埋め込む\n`;
-  body += `- 対象年度は直近 5 年（R07〜R03 primary）。追加年度が必要なら \`umbrella-builder.mjs\` の \`TARGET_YEARS\` を拡張\n\n`;
+  body += `- 対象年度は直近 7 年（R07〜R01 primary）。追加年度が必要なら \`umbrella-builder.mjs\` の \`TARGET_YEARS\` を拡張\n\n`;
 
   body += `## 参照\n\n`;
   body += `- スキル: \`.claude/skills/content/exam-keyword-cycle/SKILL.md\`\n`;

--- a/.claude/state/exam-keyword-cycles/progress.json
+++ b/.claude/state/exam-keyword-cycles/progress.json
@@ -7,7 +7,9 @@
     "pe-comprehensive-management-r05-primary": 38,
     "pe-comprehensive-management-r04-primary": 39,
     "pe-comprehensive-management-r03-primary": 40,
-    "parent": 41
+    "parent": 41,
+    "pe-comprehensive-management-r02-primary": 114,
+    "pe-comprehensive-management-r01-primary": 115
   },
   "covered": {
     "pe-comprehensive-management-r07-primary": {


### PR DESCRIPTION
## Summary

- `TARGET_YEARS` に R02-primary / R01-primary を追加（直近 5 年 → 直近 7 年）
- Umbrella Issue #114 (R02) / #115 (R01) を新規発行（各 0/40 full-cycle）
- 親 Umbrella #41 を再同期（全体進捗 80/280 full-cycle = 28.6%）

## Why

- iOS アプリの過去問カバレッジを R01 まで拡張し、受験者向け学習量を底上げ
- SEO 的にも R01/R02 の過去問ページからキーワードページへの内部リンクが増え、キーワード群全体のオーソリティが向上
- 既存スキル（`full_cycle_complete` バイナリ判定）をそのまま流用できるため、追加コストは Umbrella Issue 2 本のみ

## 変更ファイル

- `.claude/skills/content/exam-keyword-cycle/scripts/lib/umbrella-builder.mjs` — TARGET_YEARS 拡張、footer 文言「直近 7 年」に更新
- `.claude/state/exam-keyword-cycles/progress.json` — umbrella_issues に #114 / #115 を記録

## Test plan

- [x] dry-run で 0/40 表示確認済み（R02/R01 各 40 問）
- [x] Issue #114 / #115 が正常発行され、checkbox 40 問並んでいる
- [x] 親 Umbrella #41 が 280 問ベース（80/280）で更新されている
- [ ] 次サイクル実行で `verify-cycle-completeness.mjs` が R02/R01 で従来通り動作

## Follow-up

R02/R01 計 80 問の実校正は別タスクで `/exam-keyword-cycle` を回しながら進める。

🤖 Generated with [Claude Code](https://claude.com/claude-code)