### PR TITLE
perf(lcp): mobile LCP 6628ms 対策（next-themes + Cloudflare _headers）

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,32 @@
+# Cloudflare Pages のキャッシュ制御
+# Issue #73 / Issue #84 の LCP 6628ms 対策。
+# 出典: performance-auditor 調査 2026-04-24
+
+# HTML は毎回検証して最新を返す
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+# Next.js が hash 付きで出力する静的アセットは immutable として 1 年キャッシュ
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# ビルドハッシュが付く JS / CSS は長期キャッシュ
+/*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.css
+  Cache-Control: public, max-age=31536000, immutable
+
+# 画像・フォントは中期キャッシュ（更新頻度低めだが immutable にはしない）
+/*.webp
+  Cache-Control: public, max-age=2592000
+/*.png
+  Cache-Control: public, max-age=2592000
+/*.jpg
+  Cache-Control: public, max-age=2592000
+/*.svg
+  Cache-Control: public, max-age=2592000
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable
+/*.woff
+  Cache-Control: public, max-age=31536000, immutable

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -69,7 +69,7 @@ export default function RootLayout({
           attribute="class"
           defaultTheme="system"
           enableSystem={true}
-          disableTransitionOnChange={false}
+          disableTransitionOnChange={true}
           storageKey="doboku-note-theme"
         >
           <div className="min-h-screen bg-neutral-50 dark:bg-gray-900 transition-colors duration-300">


### PR DESCRIPTION
## Summary

- `src/app/layout.tsx:72` の ThemeProvider を `disableTransitionOnChange={true}` に変更（mobile でのハイドレーション待ち短縮）
- `public/_headers` を新規作成（Cloudflare Pages のキャッシュ制御）

## Why

W16 の PSI 計測で mobile LCP が **6628ms（閾値の 2.6 倍）**、Performance スコア 61 に悪化。desktop は 976ms / 98 点で正常という非対称性から、performance-auditor の調査で以下を特定:

1. **next-themes の `disableTransitionOnChange={false}`** — mobile シミュレーション（低速 CPU + 4G throttling）で JS 実行ブロックが顕在化し LCP/FCP を直撃
2. **キャッシュ制御未設定** — `_next/static/` 配下の JS/CSS/フォントが Cloudflare のデフォルトキャッシュに委ねられ、コールドスタート遅延が発生（Issue #73 の未対応が直接影響）

### 時系列の悪化点

| 計測日 | strategy | Performance | LCP |
|---|---|---|---|
| 2026-04-14 | mobile | 95 | 2866ms |
| 2026-04-21 | mobile | 62 | 7695ms |
| 2026-04-23 | mobile | 64 | 7120ms |
| 2026-04-23 | desktop | 98 | 976ms |

4/14 → 4/21 の間に 2.7 倍悪化。本 PR はこの差分を埋める最小修正。

## 変更範囲

| ファイル | 変更 |
|---|---|
| `src/app/layout.tsx` | `disableTransitionOnChange` を true に |
| `public/_headers` | 新規作成（HTML must-revalidate、_next/static immutable 1 年、画像 30 日） |

## 期待効果

- mobile LCP: 7000ms 台 → 3000ms 前後（4/14 水準への復帰が目安）
- 副作用は最小（テーマ切替時のみ transition 無効化、視覚挙動は維持）

## 見送り（次 PR or 受験後）

- Noto Sans JP `preload: false` — A/B 検証が必要なため別 PR
- `images.unoptimized` 解除 / webp 一括変換（#79 P8） — 工数大で受験後

## Test plan

- [x] ローカルで `next build` が通る（pre-commit 経由で `gray-matter` 検査通過）
- [ ] main マージ後の Cloudflare Pages デプロイで PSI 再計測し、mobile LCP が閾値 2500ms 以下に戻ることを確認
- [ ] `public/_headers` が Cloudflare Pages に正しく適用されていること（応答ヘッダに Cache-Control が付いていることを確認）

## Related Issues

- Closes #84（効果検証後に close 判断）
- Closes #73（`_headers` 導入要件を満たす）