### PR TITLE
content(civil-1): 19 件の short description を SEO 推奨字数に拡充

### DIFF
--- a/.local/r2/posts/civil-construction-1/primary-r04-a/article.mdx
+++ b/.local/r2/posts/civil-construction-1/primary-r04-a/article.mdx
@@ -2,7 +2,7 @@
 id: r04-a
 title: 令和4年度 第1次検定 問題A
 sidebar_label: R4 問題A
-description: 1級土木施工管理技士 令和4年度第1次検定 問題A（土木一般・専門土木・法規）の全問と解説。
+description: 1級土木施工管理技士 令和4年度第1次検定 問題A（土木一般・専門土木・法規）の全問と解答解説。出題傾向分析・得点戦略付きで第1次検定突破を支援する過去問演習教材。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/primary-r04-b/article.mdx
+++ b/.local/r2/posts/civil-construction-1/primary-r04-b/article.mdx
@@ -2,7 +2,7 @@
 id: r04-b
 title: 令和4年度 第1次検定 問題B
 sidebar_label: R4 問題B
-description: 1級土木施工管理技士 令和4年度第1次検定 問題B（施工管理）の全問と解説。
+description: 1級土木施工管理技士 令和4年度第1次検定 問題B（施工管理）の全問と解答解説。工程・品質・安全・環境保全の4大管理と施工計画の頻出論点を網羅した過去問演習。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/primary-r05-a/article.mdx
+++ b/.local/r2/posts/civil-construction-1/primary-r05-a/article.mdx
@@ -2,7 +2,7 @@
 id: r05-a
 title: 令和5年度 第1次検定 問題A
 sidebar_label: R5 問題A
-description: 1級土木施工管理技士 令和5年度第1次検定 問題A（土木一般・専門土木・法規）の全問と解説。
+description: 1級土木施工管理技士 令和5年度第1次検定 問題A（土木一般・専門土木・法規）の全問と解答解説。出題傾向分析・得点戦略付きで第1次検定突破を支援する過去問演習教材。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/primary-r05-b/article.mdx
+++ b/.local/r2/posts/civil-construction-1/primary-r05-b/article.mdx
@@ -2,7 +2,7 @@
 id: r05-b
 title: 令和5年度 第1次検定 問題B
 sidebar_label: R5 問題B
-description: 1級土木施工管理技士 令和5年度第1次検定 問題B（施工管理）の全問と解説。
+description: 1級土木施工管理技士 令和5年度第1次検定 問題B（施工管理）の全問と解答解説。工程・品質・安全・環境保全の4大管理と施工計画の頻出論点を網羅した過去問演習。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/primary-r06-a/article.mdx
+++ b/.local/r2/posts/civil-construction-1/primary-r06-a/article.mdx
@@ -2,7 +2,7 @@
 id: r06-a
 title: 令和6年度 第1次検定 問題A
 sidebar_label: R6 問題A
-description: 1級土木施工管理技士 令和6年度第1次検定 問題A（土木一般・専門土木・法規）の全問と解説。
+description: 1級土木施工管理技士 令和6年度第1次検定 問題A（土木一般・専門土木・法規）の全問と解答解説。出題傾向分析・得点戦略付きで第1次検定突破を支援する過去問演習教材。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/primary-r06-b/article.mdx
+++ b/.local/r2/posts/civil-construction-1/primary-r06-b/article.mdx
@@ -2,7 +2,7 @@
 id: r06-b
 title: 令和6年度 第1次検定 問題B
 sidebar_label: R6 問題B
-description: 1級土木施工管理技士 令和6年度第1次検定 問題B（施工管理）の全問と解説。
+description: 1級土木施工管理技士 令和6年度第1次検定 問題B（施工管理）の全問と解答解説。工程・品質・安全・環境保全の4大管理と施工計画の頻出論点を網羅した過去問演習。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/primary-r07-a/article.mdx
+++ b/.local/r2/posts/civil-construction-1/primary-r07-a/article.mdx
@@ -2,7 +2,7 @@
 id: r07-a
 title: 令和7年度 第1次検定 問題A
 sidebar_label: R7 問題A
-description: 1級土木施工管理技士 令和7年度第1次検定 問題A（土木一般・専門土木・法規）の全問と解説。
+description: 1級土木施工管理技士 令和7年度第1次検定 問題A（土木一般・専門土木・法規）の全問と解答解説。出題傾向分析・得点戦略付きで第1次検定突破を支援する過去問演習教材。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/primary-r07-b/article.mdx
+++ b/.local/r2/posts/civil-construction-1/primary-r07-b/article.mdx
@@ -2,7 +2,7 @@
 id: r07-b
 title: 令和7年度 第1次検定 問題B
 sidebar_label: R7 問題B
-description: 1級土木施工管理技士 令和7年度第1次検定 問題B（施工管理）の全問と解説。
+description: 1級土木施工管理技士 令和7年度第1次検定 問題B（施工管理）の全問と解答解説。工程・品質・安全・環境保全の4大管理と施工計画の頻出論点を網羅した過去問演習。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/secondary-r03/article.mdx
+++ b/.local/r2/posts/civil-construction-1/secondary-r03/article.mdx
@@ -2,7 +2,7 @@
 id: secondary-r03
 title: 令和3年度 第2次検定
 sidebar_label: R3 第2次
-description: 1級土木施工管理技士 令和3年度第2次検定の全問。 経験記述・施工管理の記述式問題。
+description: 1級土木施工管理技士 令和3年度第2次検定の全問と模範解答。経験記述・コンクリート工・土工・品質管理・施工計画の記述式過去問で第2次検定対策。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/secondary-r04/article.mdx
+++ b/.local/r2/posts/civil-construction-1/secondary-r04/article.mdx
@@ -2,7 +2,7 @@
 id: secondary-r04
 title: 令和4年度 第2次検定
 sidebar_label: R4 第2次
-description: 1級土木施工管理技士 令和4年度第2次検定の全問。 経験記述・施工管理の記述式問題。
+description: 1級土木施工管理技士 令和4年度第2次検定の全問と模範解答。経験記述・コンクリート工・土工・品質管理・施工計画の記述式過去問で第2次検定対策。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/secondary-r05/article.mdx
+++ b/.local/r2/posts/civil-construction-1/secondary-r05/article.mdx
@@ -2,7 +2,7 @@
 id: secondary-r05
 title: 令和5年度 第2次検定
 sidebar_label: R5 第2次
-description: 1級土木施工管理技士 令和5年度第2次検定の全問。 経験記述・施工管理の記述式問題。
+description: 1級土木施工管理技士 令和5年度第2次検定の全問と模範解答。経験記述・コンクリート工・土工・品質管理・施工計画の記述式過去問で第2次検定対策。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/secondary-r06/article.mdx
+++ b/.local/r2/posts/civil-construction-1/secondary-r06/article.mdx
@@ -2,7 +2,7 @@
 id: secondary-r06
 title: 令和6年度 第2次検定
 sidebar_label: R6 第2次
-description: 1級土木施工管理技士 令和6年度第2次検定の全問。 経験記述・施工管理の記述式問題。
+description: 1級土木施工管理技士 令和6年度第2次検定の全問と模範解答。経験記述・コンクリート工・土工・品質管理・施工計画の記述式過去問で第2次検定対策。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/secondary-r07/article.mdx
+++ b/.local/r2/posts/civil-construction-1/secondary-r07/article.mdx
@@ -2,7 +2,7 @@
 id: secondary-r07
 title: 令和7年度 第2次検定
 sidebar_label: R7 第2次
-description: 1級土木施工管理技士 令和7年度第2次検定の全問。 経験記述・施工管理の記述式問題。
+description: 1級土木施工管理技士 令和7年度第2次検定の全問と模範解答。経験記述・コンクリート工・土工・品質管理・施工計画の記述式過去問で第2次検定対策。
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 exams:

--- a/.local/r2/posts/civil-construction-1/textbook-building-standards/article.mdx
+++ b/.local/r2/posts/civil-construction-1/textbook-building-standards/article.mdx
@@ -3,7 +3,7 @@ title: "建築基準法"
 shortTitle: "建築基準法"
 subtitle: "仮設建築物の規制緩和と建築確認"
 description: >-
-  1級土木施工管理技士テキスト — 建築基準法の解説。建築確認・仮設建築物・工作物の確認申請を解説。
+  1級土木施工管理技士テキスト — 建築基準法の解説。建築確認・仮設建築物・工作物の確認申請制度、第1次検定 法規分野の頻出ポイントを整理。
 category: civil-construction-1
 group: textbook
 tags:

--- a/.local/r2/posts/civil-construction-1/textbook-construction-business/article.mdx
+++ b/.local/r2/posts/civil-construction-1/textbook-construction-business/article.mdx
@@ -3,7 +3,7 @@ title: "建設業法"
 shortTitle: "建設業法"
 subtitle: "許可制度・技術者配置・一括下請負禁止"
 description: >-
-  1級土木施工管理技士テキスト — 建設業法の解説。許可制度・技術者配置・一括下請負の禁止を解説。
+  1級土木施工管理技士テキスト — 建設業法の解説。許可制度・技術者配置・一括下請負禁止・主任/監理技術者の職務、建設業許可の要件を整理。
 category: civil-construction-1
 group: textbook
 tags:

--- a/.local/r2/posts/civil-construction-1/textbook-demolition/article.mdx
+++ b/.local/r2/posts/civil-construction-1/textbook-demolition/article.mdx
@@ -3,7 +3,7 @@ title: "解体工事"
 shortTitle: "解体工事"
 subtitle: "リサイクル法・解体工法・安全確認"
 description: >-
-  1級土木施工管理技士テキスト — 解体工事の解説。解体工法の種類・施工要領・安全確認事項を解説。
+  1級土木施工管理技士テキスト — 解体工事の解説。解体工法の種類・施工要領・安全確認事項、建設リサイクル法との関係を整理。
 category: civil-construction-1
 group: textbook
 tags:

--- a/.local/r2/posts/civil-construction-1/textbook-explosives-act/article.mdx
+++ b/.local/r2/posts/civil-construction-1/textbook-explosives-act/article.mdx
@@ -3,7 +3,7 @@ title: "火薬類取締法"
 shortTitle: "火薬類取締法"
 subtitle: "貯蔵・運搬・消費と保安責任者"
 description: >-
-  1級土木施工管理技士テキスト — 火薬類取締法の解説。火薬類の貯蔵・運搬・消費の規制と手続を解説。
+  1級土木施工管理技士テキスト — 火薬類取締法の解説。火薬類の貯蔵・運搬・消費の規制手続と保安責任者・火薬取扱所の設置基準を整理。
 category: civil-construction-1
 group: textbook
 tags:

--- a/.local/r2/posts/civil-construction-1/textbook-machinery-structure/article.mdx
+++ b/.local/r2/posts/civil-construction-1/textbook-machinery-structure/article.mdx
@@ -3,7 +3,7 @@ title: "建設機械の構造"
 shortTitle: "建設機械の構造"
 subtitle: "原動機・動力伝達・油圧装置の仕組み"
 description: >-
-  1級土木施工管理技士テキスト — 建設機械の構造。原動機・動力伝達装置・油圧装置の仕組みを解説。
+  1級土木施工管理技士テキスト — 建設機械の構造。原動機・動力伝達装置・油圧装置の仕組み、走行装置と作業装置の分類・特徴を整理。
 category: civil-construction-1
 group: textbook
 tags:

--- a/.local/r2/posts/civil-construction-1/textbook-surveying-basics/article.mdx
+++ b/.local/r2/posts/civil-construction-1/textbook-surveying-basics/article.mdx
@@ -3,7 +3,7 @@ title: "測量の基本"
 shortTitle: "測量の基本"
 subtitle: "測量法区分・基準点・誤差の取扱い"
 description: >-
-  1級土木施工管理技士テキスト — 測量の基本。測量の分類・基準点・誤差の取り扱いを解説。
+  1級土木施工管理技士テキスト — 測量の基本。測量法の区分・基準点・誤差の取扱い、トラバース測量の誤差処理と水準測量の許容較差を整理。
 category: civil-construction-1
 group: textbook
 tags:


### PR DESCRIPTION
## Summary

civil-construction-1 配下の過去問・2 次検定・教科書 19 件で description が 50 字未満だったため、SEO 推奨の 50-160 字に拡充。

## Why

Issue #74 の全件 description 付与は完了していた（773/773）が、civil-construction-1 の以下 19 件は 38〜49 字と pre-commit MEDIUM warning（`desc-short`）の閾値 50 字に満たず、Google SERP スニペットとしての情報密度も不足していた。

- primary (第 1 次検定過去問): R04〜R07 問題A/問題B の 8 件
- secondary (第 2 次検定過去問): R03〜R07 の 5 件
- textbook: 建築基準法・建設業法・解体工事・火薬類取締法・建設機械の構造・測量の基本 の 6 件

## 変更の性格

- description のみ拡充、他 frontmatter フィールドは一切触っていない
- ファイル本文（MDX 本体）にも変更なし
- 19 ファイルすべて 2 行差分（+1 / -1）

## 規約

| 種別 | パターン |
|---|---|
| primary-r0X-a | 「...問題A（土木一般・専門土木・法規）の全問と解答解説。出題傾向分析・得点戦略付きで第1次検定突破を支援する過去問演習教材。」 |
| primary-r0X-b | 「...問題B（施工管理）の全問と解答解説。工程・品質・安全・環境保全の4大管理と施工計画の頻出論点を網羅した過去問演習。」 |
| secondary-r0X | 「...令和X年度第2次検定の全問と模範解答。経験記述・コンクリート工・土工・品質管理・施工計画の記述式過去問で第2次検定対策。」 |
| textbook-* | 各法令・技術要素の試験頻出ポイントを個別追補 |

## Test plan

- [x] 全 19 件が 50-100 字に収まり、pre-commit `desc-short` warning 解消（0 件）
- [x] >160 字の description も 0 件
- [x] U+FFFD（文字化け）混入なし
- [x] CRLF 改行コード維持（19/19）
- [x] pre-commit `scripts/pre-commit-mdx.mjs` 通過（既存の publishedAt / image 警告は本 PR 無関係）

## Related

- Issue #74 とは別スコープ（#74 は全件 description 付与で完了・close 済）
- #72 SEO Umbrella の P3 延長線（本体 #74 完了後の仕上げ作業）