### PR TITLE
perf(ga4): Script strategy を lazyOnload に変更 (#84 Wave 1)

### DIFF
--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -12,15 +12,18 @@ export default function GoogleAnalytics() {
     return null;
   }
 
+  // Issue #84 Wave 1: strategy を "afterInteractive" から "lazyOnload" へ変更。
+  // gtag.js のダウンロードと実行を LCP 発火後に遅延させ、mobile main thread の
+  // 占有を解消して LCP / TBT を短縮する。
   return (
     <>
       <Script
-        strategy="afterInteractive"
+        strategy="lazyOnload"
         src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
       />
       <Script
         id="google-analytics"
-        strategy="afterInteractive"
+        strategy="lazyOnload"
         dangerouslySetInnerHTML={{
           __html: `
             window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Summary

Issue #84 の mobile LCP 改善 **Wave 1**。GA4 Script の strategy を `afterInteractive` → `lazyOnload` に変更し、gtag.js のダウンロード・実行を LCP 発火後まで遅延させる。

## Baseline (2026-04-25)

| URL | Strategy | LCP | FCP | TBT | Performance |
|---|---|---|---|---|---|
| / | mobile | **4828 ms** | 3168 ms | 78 ms | 76 |

## 狙いと予想効果

- GA4 の gtag.js 実行を後ろ倒しにして mobile main thread の占有を解消
- 予想効果: LCP −500〜1000ms、Performance +5〜10

## 副作用監視

- GA4 の pageview 計測漏れ（初回訪問直後に離脱したユーザー）が発生する可能性
- 48h GA4 コンソールで観察し、著しい欠損がなければそのまま運用

## 関連

- Issue #84 (Weekly/2026-W16 PSI Critical LCP)
- PR #127 (先行対策、disableTransitionOnChange + _headers)

## Test plan

- [x] `npm run type-check` 通過
- [x] `npm run build` 通過 (779 ページ SSG 成功)
- [ ] develop merge → main deploy 後に PSI 再計測
- [ ] Issue #84 に Before/After 記録
- [ ] `.claude/state/experiments.json` に history entry 追加

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)