### PR TITLE
deploy: Wave 1 GA4 lazyOnload (#84)

### DIFF
--- a/.claude/state/metrics/psi/latest-report.md
+++ b/.claude/state/metrics/psi/latest-report.md
@@ -1,161 +1,158 @@
 # PSI 計測レポート — 2026-04-24
 
 - 計測対象: 22 URL × 2 strategy
-- しきい値違反: **87件**
+- しきい値違反: **78件**
 
 ## スコアサマリー
 
 | URL | Strategy | Perf | A11y | BP | SEO | LCP | CLS |
 |---|---|---|---|---|---|---|---|
-| / | desktop | 95 | 96 | 100 | 92 | 1318 | 0.026 |
-| /search | desktop | 74 | 93 | 100 | 83⚠ | 1312 | 0.026 |
-| /category | desktop | 99 | 92 | 96 | 75⚠ | 648 | 0 |
-| /docs/civil-construction-1-guide-strategy | desktop | 63⚠ | 96 | 100 | 92 | 1787 | 0.026 |
-| /docs/civil-construction-1-guide-four-management | desktop | 90 | 96 | 100 | 92 | 1741 | 0.027 |
-| /docs/civil-construction-1-primary-r07-a | desktop | 70 | 96 | 100 | 92 | 2489 | 0.214⚠ |
-| /docs/civil-construction-1-primary-h26-a | desktop | 67⚠ | 96 | 100 | 92 | 1404 | 0.026 |
-| /docs/civil-construction-1-secondary-r07 | desktop | 85 | 96 | 100 | 92 | 1791 | 0.112⚠ |
-| /docs/civil-construction-1-secondary-concrete-basics | desktop | 82 | 96 | 100 | 92 | 2142 | 0.07 |
-| /docs/civil-construction-1-secondary-experience-writing-guide | desktop | 83 | 96 | 100 | 92 | 2222 | 0.032 |
-| /docs/civil-construction-1-textbook-quality-management-text | desktop | 52⚠ | 96 | 100 | 92 | 1981 | 0.057 |
-| /docs/civil-construction-1-textbook-schedule-management | desktop | 85 | 96 | 100 | 92 | 1878 | 0.031 |
-| /docs/pe-comprehensive-management-exam-index | desktop | 90 | 96 | 100 | 92 | 1681 | 0.07 |
-| /docs/pe-comprehensive-management-exam-passing-strategy | desktop | 89 | 95 | 100 | 92 | 1801 | 0.063 |
-| https://doboku-note.com/docs/pe-comprehensive-management-r07-primary | desktop | ERROR | | | | | |
-| /docs/pe-comprehensive-management-r05-primary | desktop | 67⚠ | 96 | 100 | 92 | 1861 | 0.05 |
-| /docs/pe-comprehensive-management-r07-secondary | desktop | 91 | 96 | 100 | 92 | 1586 | 0.035 |
-| /docs/pe-comprehensive-management-followership | desktop | 85 | 92 | 100 | 92 | 1535 | 0.182⚠ |
-| /docs/pe-comprehensive-management-agile | desktop | 86 | 93 | 100 | 92 | 1586 | 0.053 |
-| /docs/pe-comprehensive-management-activity-abc | desktop | 83 | 91 | 100 | 92 | 1656 | 0.029 |
-| /docs/pe-comprehensive-management-agenda-21 | desktop | 93 | 91 | 100 | 92 | 1581 | 0.026 |
-| https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle | desktop | ERROR | | | | | |
-| / | mobile | 60⚠ | 92 | 100 | 92 | 8526⚠ | 0 |
-| /search | mobile | 64⚠ | 91 | 100 | 83⚠ | 7022⚠ | 0 |
-| /category | mobile | 67⚠ | 92 | 96 | 75⚠ | 3322⚠ | 0 |
-| /docs/civil-construction-1-guide-strategy | mobile | 55⚠ | 93 | 100 | 92 | 12902⚠ | 0 |
-| /docs/civil-construction-1-guide-four-management | mobile | 50⚠ | 93 | 100 | 92 | 12076⚠ | 0.009 |
-| /docs/civil-construction-1-primary-r07-a | mobile | 47⚠ | 93 | 100 | 92 | 12902⚠ | 0.051 |
-| /docs/civil-construction-1-primary-h26-a | mobile | 48⚠ | 92 | 100 | 92 | 16126⚠ | 0.009 |
-| /docs/civil-construction-1-secondary-r07 | mobile | 53⚠ | 93 | 100 | 92 | 12676⚠ | 0 |
-| /docs/civil-construction-1-secondary-concrete-basics | mobile | 53⚠ | 93 | 100 | 92 | 15376⚠ | 0.009 |
-| /docs/civil-construction-1-secondary-experience-writing-guide | mobile | 54⚠ | 93 | 100 | 92 | 14950⚠ | 0.009 |
-| /docs/civil-construction-1-textbook-quality-management-text | mobile | 56⚠ | 93 | 100 | 92 | 12122⚠ | 0.009 |
-| /docs/civil-construction-1-textbook-schedule-management | mobile | 37⚠ | 93 | 100 | 92 | 11347⚠ | 0.009 |
-| /docs/pe-comprehensive-management-exam-index | mobile | 52⚠ | 93 | 100 | 92 | 12227⚠ | 0 |
-| /docs/pe-comprehensive-management-exam-passing-strategy | mobile | 60⚠ | 91 | 100 | 92 | 10458⚠ | 0.011 |
-| /docs/pe-comprehensive-management-r07-primary | mobile | 53⚠ | 93 | 100 | 92 | 11326⚠ | 0.009 |
-| /docs/pe-comprehensive-management-r05-primary | mobile | 56⚠ | 93 | 100 | 92 | 13427⚠ | 0.016 |
-| /docs/pe-comprehensive-management-r07-secondary | mobile | 53⚠ | 92 | 100 | 92 | 9152⚠ | 0.009 |
-| /docs/pe-comprehensive-management-followership | mobile | 57⚠ | 93 | 100 | 92 | 11102⚠ | 0 |
-| /docs/pe-comprehensive-management-agile | mobile | 60⚠ | 93 | 100 | 92 | 8902⚠ | 0.012 |
-| /docs/pe-comprehensive-management-activity-abc | mobile | 55⚠ | 91 | 100 | 92 | 11845⚠ | 0 |
-| https://doboku-note.com/docs/pe-comprehensive-management-agenda-21 | mobile | ERROR | | | | | |
-| /docs/pe-comprehensive-management-alarp-principle | mobile | 54⚠ | 91 | 100 | 92 | 11178⚠ | 0 |
+| / | desktop | 98 | 96 | 100 | 92 | 1115 | 0.026 |
+| /search | desktop | 81 | 93 | 100 | 83⚠ | 1417 | 0.026 |
+| /category | desktop | 98 | 92 | 96 | 75⚠ | 694 | 0 |
+| /docs/civil-construction-1-guide-strategy | desktop | 87 | 96 | 100 | 92 | 1762 | 0.027 |
+| /docs/civil-construction-1-guide-four-management | desktop | 91 | 96 | 100 | 92 | 1661 | 0.027 |
+| /docs/civil-construction-1-primary-r07-a | desktop | 69⚠ | 96 | 100 | 92 | 2741⚠ | 0.181⚠ |
+| /docs/civil-construction-1-primary-h26-a | desktop | 82 | 96 | 100 | 92 | 2021 | 0.032 |
+| /docs/civil-construction-1-secondary-r07 | desktop | 90 | 96 | 100 | 92 | 1754 | 0.027 |
+| /docs/civil-construction-1-secondary-concrete-basics | desktop | 80 | 96 | 100 | 92 | 2337 | 0.07 |
+| https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide | desktop | ERROR | | | | | |
+| /docs/civil-construction-1-textbook-quality-management-text | desktop | 87 | 96 | 100 | 92 | 1660 | 0.07 |
+| /docs/civil-construction-1-textbook-schedule-management | desktop | 86 | 96 | 100 | 92 | 1941 | 0.031 |
+| /docs/pe-comprehensive-management-exam-index | desktop | 91 | 96 | 100 | 92 | 1654 | 0.071 |
+| /docs/pe-comprehensive-management-exam-passing-strategy | desktop | 90 | 95 | 100 | 92 | 1807 | 0.026 |
+| /docs/pe-comprehensive-management-r07-primary | desktop | 83 | 96 | 100 | 92 | 2181 | 0.027 |
+| /docs/pe-comprehensive-management-r05-primary | desktop | 84 | 96 | 100 | 92 | 1901 | 0.05 |
+| /docs/pe-comprehensive-management-r07-secondary | desktop | 92 | 96 | 100 | 92 | 1602 | 0.035 |
+| /docs/pe-comprehensive-management-followership | desktop | 71 | 92 | 100 | 92 | 1410 | 0.155⚠ |
+| /docs/pe-comprehensive-management-agile | desktop | 92 | 93 | 100 | 92 | 1581 | 0.053 |
+| https://doboku-note.com/docs/pe-comprehensive-management-activity-abc | desktop | ERROR | | | | | |
+| /docs/pe-comprehensive-management-agenda-21 | desktop | 65⚠ | 91 | 100 | 92 | 1481 | 0.026 |
+| /docs/pe-comprehensive-management-alarp-principle | desktop | 94 | 91 | 100 | 92 | 1462 | 0.032 |
+| / | mobile | 74 | 92 | 100 | 92 | 4828⚠ | 0.001 |
+| /search | mobile | 50⚠ | 91 | 100 | 83⚠ | 6488⚠ | 0.009 |
+| /category | mobile | 67⚠ | 92 | 96 | 75⚠ | 5755⚠ | 0 |
+| /docs/civil-construction-1-guide-strategy | mobile | 58⚠ | 93 | 100 | 92 | 10052⚠ | 0.013 |
+| /docs/civil-construction-1-guide-four-management | mobile | 58⚠ | 93 | 100 | 92 | 9868⚠ | 0.009 |
+| https://doboku-note.com/docs/civil-construction-1-primary-r07-a | mobile | ERROR | | | | | |
+| /docs/civil-construction-1-primary-h26-a | mobile | 55⚠ | 92 | 100 | 92 | 12076⚠ | 0.009 |
+| /docs/civil-construction-1-secondary-r07 | mobile | 52⚠ | 93 | 100 | 92 | 12827⚠ | 0 |
+| /docs/civil-construction-1-secondary-concrete-basics | mobile | 42⚠ | 93 | 100 | 92 | 15451⚠ | 0.009 |
+| /docs/civil-construction-1-secondary-experience-writing-guide | mobile | 56⚠ | 93 | 100 | 92 | 12231⚠ | 0.009 |
+| /docs/civil-construction-1-textbook-quality-management-text | mobile | 52⚠ | 93 | 100 | 92 | 13860⚠ | 0 |
+| /docs/civil-construction-1-textbook-schedule-management | mobile | 57⚠ | 93 | 100 | 92 | 11813⚠ | 0 |
+| /docs/pe-comprehensive-management-exam-index | mobile | 51⚠ | 93 | 100 | 92 | 12226⚠ | 0 |
+| https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy | mobile | ERROR | | | | | |
+| /docs/pe-comprehensive-management-r07-primary | mobile | 58⚠ | 93 | 100 | 92 | 7877⚠ | 0.009 |
+| /docs/pe-comprehensive-management-r05-primary | mobile | 55⚠ | 93 | 100 | 92 | 14252⚠ | 0 |
+| /docs/pe-comprehensive-management-r07-secondary | mobile | 61⚠ | 92 | 100 | 92 | 8926⚠ | 0 |
+| /docs/pe-comprehensive-management-followership | mobile | 55⚠ | 93 | 100 | 92 | 11327⚠ | 0 |
+| /docs/pe-comprehensive-management-agile | mobile | 35⚠ | 93 | 100 | 92 | 9001⚠ | 0.009 |
+| /docs/pe-comprehensive-management-activity-abc | mobile | 57⚠ | 91 | 100 | 92 | 10478⚠ | 0.009 |
+| /docs/pe-comprehensive-management-agenda-21 | mobile | 55⚠ | 91 | 100 | 92 | 11030⚠ | 0 |
+| /docs/pe-comprehensive-management-alarp-principle | mobile | 50⚠ | 91 | 100 | 92 | 10916⚠ | 0.009 |
 
 ## しきい値違反
 
 - `https://doboku-note.com/search` (desktop): **SEO** = 83 (閾値: ≥90)
-- `https://doboku-note.com/search` (desktop): **TBT** = 535ms (閾値: ≤300ms)
+- `https://doboku-note.com/search` (desktop): **TBT** = 348ms (閾値: ≤300ms)
 - `https://doboku-note.com/category` (desktop): **SEO** = 75 (閾値: ≥90)
-- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (desktop): **Performance** = 63 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (desktop): **TBT** = 689ms (閾値: ≤300ms)
-- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **CLS** = 0.214 (閾値: ≤0.1)
-- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (desktop): **Performance** = 67 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (desktop): **TBT** = 780ms (閾値: ≤300ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (desktop): **CLS** = 0.112 (閾値: ≤0.1)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (desktop): **Performance** = 52 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (desktop): **TBT** = 2848ms (閾値: ≤300ms)
-- ❌ `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (desktop): PSI API 500: {
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **Performance** = 69 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **LCP** = 2741ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **CLS** = 0.181 (閾値: ≤0.1)
+- ❌ `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (desktop): PSI API 500: {
   "error": {
     "code": 500,
     "message": "Lighthouse returned error: Something went wrong.",
     "errors": [
       {
         "message": "Lighthouse returned error: Something went wr
-- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (desktop): **Performance** = 67 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (desktop): **TBT** = 455ms (閾値: ≤300ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (desktop): **CLS** = 0.182 (閾値: ≤0.1)
-- ❌ `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (desktop): PSI API 500: {
+- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (desktop): **CLS** = 0.155 (閾値: ≤0.1)
+- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (desktop): **TBT** = 391ms (閾値: ≤300ms)
+- ❌ `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (desktop): PSI API 500: {
   "error": {
     "code": 500,
     "message": "Lighthouse returned error: Something went wrong.",
     "errors": [
       {
         "message": "Lighthouse returned error: Something went wr
-- `https://doboku-note.com/` (mobile): **Performance** = 60 (閾値: ≥70)
-- `https://doboku-note.com/` (mobile): **LCP** = 8526ms (閾値: ≤2500ms)
-- `https://doboku-note.com/` (mobile): **FCP** = 5284ms (閾値: ≤1800ms)
-- `https://doboku-note.com/search` (mobile): **Performance** = 64 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (desktop): **Performance** = 65 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (desktop): **TBT** = 808ms (閾値: ≤300ms)
+- `https://doboku-note.com/` (mobile): **LCP** = 4828ms (閾値: ≤2500ms)
+- `https://doboku-note.com/` (mobile): **FCP** = 3168ms (閾値: ≤1800ms)
+- `https://doboku-note.com/search` (mobile): **Performance** = 50 (閾値: ≥70)
 - `https://doboku-note.com/search` (mobile): **SEO** = 83 (閾値: ≥90)
-- `https://doboku-note.com/search` (mobile): **LCP** = 7022ms (閾値: ≤2500ms)
-- `https://doboku-note.com/search` (mobile): **FCP** = 4487ms (閾値: ≤1800ms)
+- `https://doboku-note.com/search` (mobile): **LCP** = 6488ms (閾値: ≤2500ms)
+- `https://doboku-note.com/search` (mobile): **TBT** = 1601ms (閾値: ≤300ms)
 - `https://doboku-note.com/category` (mobile): **Performance** = 67 (閾値: ≥70)
 - `https://doboku-note.com/category` (mobile): **SEO** = 75 (閾値: ≥90)
-- `https://doboku-note.com/category` (mobile): **LCP** = 3322ms (閾値: ≤2500ms)
-- `https://doboku-note.com/category` (mobile): **FCP** = 2263ms (閾値: ≤1800ms)
-- `https://doboku-note.com/category` (mobile): **TBT** = 1056ms (閾値: ≤300ms)
-- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **Performance** = 55 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **LCP** = 12902ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **FCP** = 9096ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **Performance** = 50 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **LCP** = 12076ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **FCP** = 8829ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (mobile): **Performance** = 47 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (mobile): **LCP** = 12902ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (mobile): **FCP** = 3901ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (mobile): **TBT** = 711ms (閾値: ≤300ms)
-- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **Performance** = 48 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **LCP** = 16126ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **FCP** = 12759ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **TBT** = 341ms (閾値: ≤300ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **Performance** = 53 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **LCP** = 12676ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **FCP** = 8957ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **Performance** = 53 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **LCP** = 15376ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **FCP** = 10351ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **Performance** = 54 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **LCP** = 14950ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **FCP** = 10480ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **Performance** = 56 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **LCP** = 12122ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **FCP** = 8912ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **Performance** = 37 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **LCP** = 11347ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **FCP** = 7714ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **TBT** = 767ms (閾値: ≤300ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **Performance** = 52 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **LCP** = 12227ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **FCP** = 8526ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy` (mobile): **Performance** = 60 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy` (mobile): **LCP** = 10458ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy` (mobile): **FCP** = 6301ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **Performance** = 53 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **LCP** = 11326ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **FCP** = 8551ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **Performance** = 56 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **LCP** = 13427ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **FCP** = 9826ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **Performance** = 53 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **LCP** = 9152ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **FCP** = 5701ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **TBT** = 342ms (閾値: ≤300ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **Performance** = 57 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **LCP** = 11102ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **FCP** = 7290ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **Performance** = 60 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **LCP** = 8902ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **FCP** = 5565ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): **Performance** = 55 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): **LCP** = 11845ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): **FCP** = 7039ms (閾値: ≤1800ms)
-- ❌ `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): PSI API 500: {
+- `https://doboku-note.com/category` (mobile): **LCP** = 5755ms (閾値: ≤2500ms)
+- `https://doboku-note.com/category` (mobile): **FCP** = 4632ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **Performance** = 58 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **LCP** = 10052ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **FCP** = 6901ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **Performance** = 58 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **LCP** = 9868ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **FCP** = 6601ms (閾値: ≤1800ms)
+- ❌ `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (mobile): PSI API 500: {
   "error": {
     "code": 500,
     "message": "Lighthouse returned error: Something went wrong.",
     "errors": [
       {
         "message": "Lighthouse returned error: Something went wr
-- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **Performance** = 54 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **LCP** = 11178ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **FCP** = 6896ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **Performance** = 55 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **LCP** = 12076ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **FCP** = 9751ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **Performance** = 52 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **LCP** = 12827ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **FCP** = 8378ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **Performance** = 42 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **LCP** = 15451ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **FCP** = 10801ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **TBT** = 531ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **Performance** = 56 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **LCP** = 12231ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **FCP** = 8705ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **Performance** = 52 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **LCP** = 13860ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **FCP** = 9363ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **Performance** = 57 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **LCP** = 11813ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **FCP** = 8159ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **Performance** = 51 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **LCP** = 12226ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **FCP** = 8376ms (閾値: ≤1800ms)
+- ❌ `https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy` (mobile): PSI API 500: {
+  "error": {
+    "code": 500,
+    "message": "Lighthouse returned error: Something went wrong.",
+    "errors": [
+      {
+        "message": "Lighthouse returned error: Something went wr
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **Performance** = 58 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **LCP** = 7877ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **FCP** = 5252ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **Performance** = 55 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **LCP** = 14252ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **FCP** = 9842ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **Performance** = 61 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **LCP** = 8926ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **FCP** = 5701ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **Performance** = 55 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **LCP** = 11327ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **FCP** = 6875ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **Performance** = 35 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **LCP** = 9001ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **FCP** = 5551ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **TBT** = 1317ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): **Performance** = 57 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): **LCP** = 10478ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): **FCP** = 7029ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **Performance** = 55 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **LCP** = 11030ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **FCP** = 6732ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **Performance** = 50 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **LCP** = 10916ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **FCP** = 7552ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **TBT** = 341ms (閾値: ≤300ms)

--- a/.claude/state/metrics/psi/latest-report.md
+++ b/.claude/state/metrics/psi/latest-report.md
@@ -1,65 +1,82 @@
 # PSI 計測レポート — 2026-04-24
 
 - 計測対象: 22 URL × 2 strategy
-- しきい値違反: **78件**
+- しきい値違反: **85件**
 
 ## スコアサマリー
 
 | URL | Strategy | Perf | A11y | BP | SEO | LCP | CLS |
 |---|---|---|---|---|---|---|---|
-| / | desktop | 98 | 96 | 100 | 92 | 1115 | 0.026 |
-| /search | desktop | 81 | 93 | 100 | 83⚠ | 1417 | 0.026 |
-| /category | desktop | 98 | 92 | 96 | 75⚠ | 694 | 0 |
-| /docs/civil-construction-1-guide-strategy | desktop | 87 | 96 | 100 | 92 | 1762 | 0.027 |
-| /docs/civil-construction-1-guide-four-management | desktop | 91 | 96 | 100 | 92 | 1661 | 0.027 |
-| /docs/civil-construction-1-primary-r07-a | desktop | 69⚠ | 96 | 100 | 92 | 2741⚠ | 0.181⚠ |
-| /docs/civil-construction-1-primary-h26-a | desktop | 82 | 96 | 100 | 92 | 2021 | 0.032 |
-| /docs/civil-construction-1-secondary-r07 | desktop | 90 | 96 | 100 | 92 | 1754 | 0.027 |
-| /docs/civil-construction-1-secondary-concrete-basics | desktop | 80 | 96 | 100 | 92 | 2337 | 0.07 |
+| https://doboku-note.com/ | desktop | ERROR | | | | | |
+| /search | desktop | 90 | 93 | 100 | 83⚠ | 1372 | 0.026 |
+| /category | desktop | 94 | 92 | 96 | 75⚠ | 872 | 0 |
+| /docs/civil-construction-1-guide-strategy | desktop | 68⚠ | 96 | 100 | 92 | 1542 | 0.026 |
+| /docs/civil-construction-1-guide-four-management | desktop | 88 | 96 | 100 | 92 | 1786 | 0.027 |
+| /docs/civil-construction-1-primary-r07-a | desktop | 40⚠ | 96 | 100 | 92 | 2926⚠ | 0.134⚠ |
+| https://doboku-note.com/docs/civil-construction-1-primary-h26-a | desktop | ERROR | | | | | |
+| /docs/civil-construction-1-secondary-r07 | desktop | 90 | 96 | 100 | 92 | 1717 | 0.044 |
+| /docs/civil-construction-1-secondary-concrete-basics | desktop | 72 | 96 | 100 | 92 | 2542⚠ | 0.07 |
 | https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide | desktop | ERROR | | | | | |
-| /docs/civil-construction-1-textbook-quality-management-text | desktop | 87 | 96 | 100 | 92 | 1660 | 0.07 |
-| /docs/civil-construction-1-textbook-schedule-management | desktop | 86 | 96 | 100 | 92 | 1941 | 0.031 |
-| /docs/pe-comprehensive-management-exam-index | desktop | 91 | 96 | 100 | 92 | 1654 | 0.071 |
-| /docs/pe-comprehensive-management-exam-passing-strategy | desktop | 90 | 95 | 100 | 92 | 1807 | 0.026 |
-| /docs/pe-comprehensive-management-r07-primary | desktop | 83 | 96 | 100 | 92 | 2181 | 0.027 |
-| /docs/pe-comprehensive-management-r05-primary | desktop | 84 | 96 | 100 | 92 | 1901 | 0.05 |
-| /docs/pe-comprehensive-management-r07-secondary | desktop | 92 | 96 | 100 | 92 | 1602 | 0.035 |
-| /docs/pe-comprehensive-management-followership | desktop | 71 | 92 | 100 | 92 | 1410 | 0.155⚠ |
-| /docs/pe-comprehensive-management-agile | desktop | 92 | 93 | 100 | 92 | 1581 | 0.053 |
-| https://doboku-note.com/docs/pe-comprehensive-management-activity-abc | desktop | ERROR | | | | | |
-| /docs/pe-comprehensive-management-agenda-21 | desktop | 65⚠ | 91 | 100 | 92 | 1481 | 0.026 |
-| /docs/pe-comprehensive-management-alarp-principle | desktop | 94 | 91 | 100 | 92 | 1462 | 0.032 |
-| / | mobile | 74 | 92 | 100 | 92 | 4828⚠ | 0.001 |
-| /search | mobile | 50⚠ | 91 | 100 | 83⚠ | 6488⚠ | 0.009 |
-| /category | mobile | 67⚠ | 92 | 96 | 75⚠ | 5755⚠ | 0 |
-| /docs/civil-construction-1-guide-strategy | mobile | 58⚠ | 93 | 100 | 92 | 10052⚠ | 0.013 |
-| /docs/civil-construction-1-guide-four-management | mobile | 58⚠ | 93 | 100 | 92 | 9868⚠ | 0.009 |
-| https://doboku-note.com/docs/civil-construction-1-primary-r07-a | mobile | ERROR | | | | | |
-| /docs/civil-construction-1-primary-h26-a | mobile | 55⚠ | 92 | 100 | 92 | 12076⚠ | 0.009 |
-| /docs/civil-construction-1-secondary-r07 | mobile | 52⚠ | 93 | 100 | 92 | 12827⚠ | 0 |
-| /docs/civil-construction-1-secondary-concrete-basics | mobile | 42⚠ | 93 | 100 | 92 | 15451⚠ | 0.009 |
-| /docs/civil-construction-1-secondary-experience-writing-guide | mobile | 56⚠ | 93 | 100 | 92 | 12231⚠ | 0.009 |
-| /docs/civil-construction-1-textbook-quality-management-text | mobile | 52⚠ | 93 | 100 | 92 | 13860⚠ | 0 |
-| /docs/civil-construction-1-textbook-schedule-management | mobile | 57⚠ | 93 | 100 | 92 | 11813⚠ | 0 |
-| /docs/pe-comprehensive-management-exam-index | mobile | 51⚠ | 93 | 100 | 92 | 12226⚠ | 0 |
-| https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy | mobile | ERROR | | | | | |
-| /docs/pe-comprehensive-management-r07-primary | mobile | 58⚠ | 93 | 100 | 92 | 7877⚠ | 0.009 |
-| /docs/pe-comprehensive-management-r05-primary | mobile | 55⚠ | 93 | 100 | 92 | 14252⚠ | 0 |
-| /docs/pe-comprehensive-management-r07-secondary | mobile | 61⚠ | 92 | 100 | 92 | 8926⚠ | 0 |
-| /docs/pe-comprehensive-management-followership | mobile | 55⚠ | 93 | 100 | 92 | 11327⚠ | 0 |
-| /docs/pe-comprehensive-management-agile | mobile | 35⚠ | 93 | 100 | 92 | 9001⚠ | 0.009 |
-| /docs/pe-comprehensive-management-activity-abc | mobile | 57⚠ | 91 | 100 | 92 | 10478⚠ | 0.009 |
-| /docs/pe-comprehensive-management-agenda-21 | mobile | 55⚠ | 91 | 100 | 92 | 11030⚠ | 0 |
-| /docs/pe-comprehensive-management-alarp-principle | mobile | 50⚠ | 91 | 100 | 92 | 10916⚠ | 0.009 |
+| /docs/civil-construction-1-textbook-quality-management-text | desktop | 82 | 96 | 100 | 92 | 2078 | 0.083 |
+| /docs/civil-construction-1-textbook-schedule-management | desktop | 79 | 96 | 100 | 92 | 1810 | 0.031 |
+| /docs/pe-comprehensive-management-exam-index | desktop | 90 | 96 | 100 | 92 | 1781 | 0.026 |
+| /docs/pe-comprehensive-management-exam-passing-strategy | desktop | 86 | 95 | 100 | 92 | 1842 | 0.063 |
+| https://doboku-note.com/docs/pe-comprehensive-management-r07-primary | desktop | ERROR | | | | | |
+| /docs/pe-comprehensive-management-r05-primary | desktop | 85 | 96 | 100 | 92 | 1981 | 0.03 |
+| /docs/pe-comprehensive-management-r07-secondary | desktop | 91 | 96 | 100 | 92 | 1621 | 0.035 |
+| /docs/pe-comprehensive-management-followership | desktop | 80 | 92 | 100 | 92 | 1538 | 0.182⚠ |
+| /docs/pe-comprehensive-management-agile | desktop | 92 | 93 | 100 | 92 | 1582 | 0.053 |
+| /docs/pe-comprehensive-management-activity-abc | desktop | 93 | 91 | 100 | 92 | 1621 | 0.029 |
+| /docs/pe-comprehensive-management-agenda-21 | desktop | 94 | 91 | 100 | 92 | 1261 | 0.028 |
+| /docs/pe-comprehensive-management-alarp-principle | desktop | 94 | 91 | 100 | 92 | 1461 | 0.032 |
+| / | mobile | 53⚠ | 92 | 100 | 92 | 8525⚠ | 0 |
+| /search | mobile | 63⚠ | 91 | 100 | 83⚠ | 6969⚠ | 0 |
+| https://doboku-note.com/category | mobile | ERROR | | | | | |
+| /docs/civil-construction-1-guide-strategy | mobile | 48⚠ | 93 | 100 | 92 | 12452⚠ | 0.009 |
+| /docs/civil-construction-1-guide-four-management | mobile | 47⚠ | 93 | 100 | 92 | 10051⚠ | 0.009 |
+| /docs/civil-construction-1-primary-r07-a | mobile | 55⚠ | 93 | 100 | 92 | 16878⚠ | 0.06 |
+| /docs/civil-construction-1-primary-h26-a | mobile | 51⚠ | 92 | 100 | 92 | 15826⚠ | 0.009 |
+| /docs/civil-construction-1-secondary-r07 | mobile | 51⚠ | 93 | 100 | 92 | 12601⚠ | 0.009 |
+| /docs/civil-construction-1-secondary-concrete-basics | mobile | 43⚠ | 93 | 100 | 92 | 15526⚠ | 0.009 |
+| /docs/civil-construction-1-secondary-experience-writing-guide | mobile | 56⚠ | 93 | 100 | 92 | 14851⚠ | 0.009 |
+| /docs/civil-construction-1-textbook-quality-management-text | mobile | 52⚠ | 93 | 100 | 92 | 13845⚠ | 0.009 |
+| /docs/civil-construction-1-textbook-schedule-management | mobile | 54⚠ | 93 | 100 | 92 | 12739⚠ | 0 |
+| /docs/pe-comprehensive-management-exam-index | mobile | 50⚠ | 93 | 100 | 92 | 12377⚠ | 0 |
+| /docs/pe-comprehensive-management-exam-passing-strategy | mobile | 43⚠ | 91 | 100 | 92 | 10127⚠ | 0.009 |
+| /docs/pe-comprehensive-management-r07-primary | mobile | 47⚠ | 93 | 100 | 92 | 14476⚠ | 0 |
+| /docs/pe-comprehensive-management-r05-primary | mobile | 56⚠ | 93 | 100 | 92 | 11819⚠ | 0.009 |
+| /docs/pe-comprehensive-management-r07-secondary | mobile | 52⚠ | 92 | 100 | 92 | 11776⚠ | 0 |
+| /docs/pe-comprehensive-management-followership | mobile | 60⚠ | 93 | 100 | 92 | 8361⚠ | 0.094 |
+| /docs/pe-comprehensive-management-agile | mobile | 61⚠ | 93 | 100 | 92 | 9106⚠ | 0.012 |
+| https://doboku-note.com/docs/pe-comprehensive-management-activity-abc | mobile | ERROR | | | | | |
+| /docs/pe-comprehensive-management-agenda-21 | mobile | 30⚠ | 91 | 100 | 92 | 7877⚠ | 0.009 |
+| /docs/pe-comprehensive-management-alarp-principle | mobile | 49⚠ | 91 | 100 | 92 | 8417⚠ | 0.009 |
 
 ## しきい値違反
 
+- ❌ `https://doboku-note.com/` (desktop): PSI API 500: {
+  "error": {
+    "code": 500,
+    "message": "Lighthouse returned error: Something went wrong.",
+    "errors": [
+      {
+        "message": "Lighthouse returned error: Something went wr
 - `https://doboku-note.com/search` (desktop): **SEO** = 83 (閾値: ≥90)
-- `https://doboku-note.com/search` (desktop): **TBT** = 348ms (閾値: ≤300ms)
 - `https://doboku-note.com/category` (desktop): **SEO** = 75 (閾値: ≥90)
-- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **Performance** = 69 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **LCP** = 2741ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **CLS** = 0.181 (閾値: ≤0.1)
+- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (desktop): **Performance** = 68 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (desktop): **TBT** = 487ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **Performance** = 40 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **LCP** = 2926ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **CLS** = 0.134 (閾値: ≤0.1)
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (desktop): **TBT** = 3365ms (閾値: ≤300ms)
+- ❌ `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (desktop): PSI API 500: {
+  "error": {
+    "code": 500,
+    "message": "Lighthouse returned error: Something went wrong.",
+    "errors": [
+      {
+        "message": "Lighthouse returned error: Something went wr
+- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (desktop): **LCP** = 2542ms (閾値: ≤2500ms)
 - ❌ `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (desktop): PSI API 500: {
   "error": {
     "code": 500,
@@ -67,92 +84,94 @@
     "errors": [
       {
         "message": "Lighthouse returned error: Something went wr
-- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (desktop): **CLS** = 0.155 (閾値: ≤0.1)
-- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (desktop): **TBT** = 391ms (閾値: ≤300ms)
-- ❌ `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (desktop): PSI API 500: {
+- ❌ `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (desktop): PSI API 500: {
   "error": {
     "code": 500,
     "message": "Lighthouse returned error: Something went wrong.",
     "errors": [
       {
         "message": "Lighthouse returned error: Something went wr
-- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (desktop): **Performance** = 65 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (desktop): **TBT** = 808ms (閾値: ≤300ms)
-- `https://doboku-note.com/` (mobile): **LCP** = 4828ms (閾値: ≤2500ms)
-- `https://doboku-note.com/` (mobile): **FCP** = 3168ms (閾値: ≤1800ms)
-- `https://doboku-note.com/search` (mobile): **Performance** = 50 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (desktop): **CLS** = 0.182 (閾値: ≤0.1)
+- `https://doboku-note.com/` (mobile): **Performance** = 53 (閾値: ≥70)
+- `https://doboku-note.com/` (mobile): **LCP** = 8525ms (閾値: ≤2500ms)
+- `https://doboku-note.com/` (mobile): **FCP** = 5417ms (閾値: ≤1800ms)
+- `https://doboku-note.com/` (mobile): **TBT** = 335ms (閾値: ≤300ms)
+- `https://doboku-note.com/search` (mobile): **Performance** = 63 (閾値: ≥70)
 - `https://doboku-note.com/search` (mobile): **SEO** = 83 (閾値: ≥90)
-- `https://doboku-note.com/search` (mobile): **LCP** = 6488ms (閾値: ≤2500ms)
-- `https://doboku-note.com/search` (mobile): **TBT** = 1601ms (閾値: ≤300ms)
-- `https://doboku-note.com/category` (mobile): **Performance** = 67 (閾値: ≥70)
-- `https://doboku-note.com/category` (mobile): **SEO** = 75 (閾値: ≥90)
-- `https://doboku-note.com/category` (mobile): **LCP** = 5755ms (閾値: ≤2500ms)
-- `https://doboku-note.com/category` (mobile): **FCP** = 4632ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **Performance** = 58 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **LCP** = 10052ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **FCP** = 6901ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **Performance** = 58 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **LCP** = 9868ms (閾値: ≤2500ms)
+- `https://doboku-note.com/search` (mobile): **LCP** = 6969ms (閾値: ≤2500ms)
+- `https://doboku-note.com/search` (mobile): **FCP** = 5072ms (閾値: ≤1800ms)
+- ❌ `https://doboku-note.com/category` (mobile): PSI API 500: {
+  "error": {
+    "code": 500,
+    "message": "Lighthouse returned error: Something went wrong.",
+    "errors": [
+      {
+        "message": "Lighthouse returned error: Something went wr
+- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **Performance** = 48 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **LCP** = 12452ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **FCP** = 9184ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-guide-strategy` (mobile): **TBT** = 358ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **Performance** = 47 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **LCP** = 10051ms (閾値: ≤2500ms)
 - `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **FCP** = 6601ms (閾値: ≤1800ms)
-- ❌ `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (mobile): PSI API 500: {
-  "error": {
-    "code": 500,
-    "message": "Lighthouse returned error: Something went wrong.",
-    "errors": [
-      {
-        "message": "Lighthouse returned error: Something went wr
-- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **Performance** = 55 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **LCP** = 12076ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **FCP** = 9751ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **Performance** = 52 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **LCP** = 12827ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **FCP** = 8378ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **Performance** = 42 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **LCP** = 15451ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **FCP** = 10801ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **TBT** = 531ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/civil-construction-1-guide-four-management` (mobile): **TBT** = 458ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (mobile): **Performance** = 55 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (mobile): **LCP** = 16878ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-primary-r07-a` (mobile): **FCP** = 12151ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **Performance** = 51 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **LCP** = 15826ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-primary-h26-a` (mobile): **FCP** = 12709ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **Performance** = 51 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **LCP** = 12601ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-r07` (mobile): **FCP** = 8396ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **Performance** = 43 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **LCP** = 15526ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **FCP** = 10849ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics` (mobile): **TBT** = 515ms (閾値: ≤300ms)
 - `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **Performance** = 56 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **LCP** = 12231ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **FCP** = 8705ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **LCP** = 14851ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide` (mobile): **FCP** = 10319ms (閾値: ≤1800ms)
 - `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **Performance** = 52 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **LCP** = 13860ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **FCP** = 9363ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **Performance** = 57 (閾値: ≥70)
-- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **LCP** = 11813ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **LCP** = 13845ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text` (mobile): **FCP** = 9819ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **Performance** = 54 (閾値: ≥70)
+- `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **LCP** = 12739ms (閾値: ≤2500ms)
 - `https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management` (mobile): **FCP** = 8159ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **Performance** = 51 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **LCP** = 12226ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **FCP** = 8376ms (閾値: ≤1800ms)
-- ❌ `https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy` (mobile): PSI API 500: {
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **Performance** = 50 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **LCP** = 12377ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-index` (mobile): **FCP** = 8570ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy` (mobile): **Performance** = 43 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy` (mobile): **LCP** = 10127ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy` (mobile): **FCP** = 6302ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy` (mobile): **TBT** = 659ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **Performance** = 47 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **LCP** = 14476ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **FCP** = 10900ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **TBT** = 375ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **Performance** = 56 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **LCP** = 11819ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **FCP** = 8103ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **Performance** = 52 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **LCP** = 11776ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **FCP** = 8083ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **Performance** = 60 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **LCP** = 8361ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **FCP** = 5101ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **Performance** = 61 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **LCP** = 9106ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **FCP** = 5551ms (閾値: ≤1800ms)
+- ❌ `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): PSI API 500: {
   "error": {
     "code": 500,
     "message": "Lighthouse returned error: Something went wrong.",
     "errors": [
       {
         "message": "Lighthouse returned error: Something went wr
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **Performance** = 58 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **LCP** = 7877ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-primary` (mobile): **FCP** = 5252ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **Performance** = 55 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **LCP** = 14252ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r05-primary` (mobile): **FCP** = 9842ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **Performance** = 61 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **LCP** = 8926ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary` (mobile): **FCP** = 5701ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **Performance** = 55 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **LCP** = 11327ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-followership` (mobile): **FCP** = 6875ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **Performance** = 35 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **LCP** = 9001ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **FCP** = 5551ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agile` (mobile): **TBT** = 1317ms (閾値: ≤300ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): **Performance** = 57 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): **LCP** = 10478ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-activity-abc` (mobile): **FCP** = 7029ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **Performance** = 55 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **LCP** = 11030ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **FCP** = 6732ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **Performance** = 50 (閾値: ≥70)
-- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **LCP** = 10916ms (閾値: ≤2500ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **FCP** = 7552ms (閾値: ≤1800ms)
-- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **TBT** = 341ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **Performance** = 30 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **LCP** = 7877ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **FCP** = 4802ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-agenda-21` (mobile): **TBT** = 3495ms (閾値: ≤300ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **Performance** = 49 (閾値: ≥70)
+- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **LCP** = 8417ms (閾値: ≤2500ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **FCP** = 5102ms (閾値: ≤1800ms)
+- `https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle` (mobile): **TBT** = 519ms (閾値: ≤300ms)

--- a/.claude/state/metrics/psi/psi-batch-2026-04-24T07-51-20.json
+++ b/.claude/state/metrics/psi/psi-batch-2026-04-24T07-51-20.json
@@ -1,0 +1,576 @@
+{
+  "version": 1,
+  "generated_at": "2026-04-24T07:51:20.319Z",
+  "results": [
+    {
+      "url": "https://doboku-note.com/",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:43:20.039Z",
+      "scores": {
+        "performance": 74,
+        "accessibility": 92,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 4827.971328796122,
+        "TBT_ms": 169.44952214660225,
+        "CLS": 0.00072,
+        "FCP_ms": 3168.081841570877,
+        "TTI_ms": 6566.467297366902,
+        "SI_ms": 3168.081841570877
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:43:06.182Z",
+      "final_url": "https://doboku-note.com/"
+    },
+    {
+      "url": "https://doboku-note.com/search",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:44:01.156Z",
+      "scores": {
+        "performance": 50,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 83
+      },
+      "lab_data": {
+        "LCP_ms": 6487.871502537739,
+        "TBT_ms": 1601.0000000000018,
+        "CLS": 0.008698,
+        "FCP_ms": 1357.2951345796134,
+        "TTI_ms": 6931.233140361265,
+        "SI_ms": 2912.1691715230827
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:43:30.620Z",
+      "final_url": "https://doboku-note.com/search"
+    },
+    {
+      "url": "https://doboku-note.com/category",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:44:16.103Z",
+      "scores": {
+        "performance": 67,
+        "accessibility": 92,
+        "best_practices": 96,
+        "seo": 75
+      },
+      "lab_data": {
+        "LCP_ms": 5754.679930147249,
+        "TBT_ms": 107,
+        "CLS": 0,
+        "FCP_ms": 4632.182971034029,
+        "TTI_ms": 5754.679930147249,
+        "SI_ms": 4632.182971034029
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:44:05.395Z",
+      "final_url": "https://doboku-note.com/category"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-guide-strategy",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:44:32.237Z",
+      "scores": {
+        "performance": 58,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 10051.52805735523,
+        "TBT_ms": 30.5,
+        "CLS": 0.012575,
+        "FCP_ms": 6901.357454209696,
+        "TTI_ms": 11171.43086309075,
+        "SI_ms": 6901.357454209696
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:44:19.035Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-guide-strategy"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-guide-four-management",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:44:52.907Z",
+      "scores": {
+        "performance": 58,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 9867.616098898821,
+        "TBT_ms": 104,
+        "CLS": 0.008698,
+        "FCP_ms": 6601.40749848426,
+        "TTI_ms": 10952.810244567949,
+        "SI_ms": 6601.40749848426
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:44:35.999Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-guide-four-management"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-primary-r07-a",
+      "strategy": "mobile",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-primary-h26-a",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:45:16.540Z",
+      "scores": {
+        "performance": 55,
+        "accessibility": 92,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 12076.066150064162,
+        "TBT_ms": 141,
+        "CLS": 0.008698,
+        "FCP_ms": 9751.053088586526,
+        "TTI_ms": 14834.87841099962,
+        "SI_ms": 9751.053088586526
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:44:57.129Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-primary-h26-a"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-r07",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:45:40.775Z",
+      "scores": {
+        "performance": 52,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 12827.276392247479,
+        "TBT_ms": 247,
+        "CLS": 0,
+        "FCP_ms": 8377.810165139124,
+        "TTI_ms": 12909.784799621564,
+        "SI_ms": 8377.810165139124
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:45:20.522Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-r07"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:46:09.227Z",
+      "scores": {
+        "performance": 42,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 15451.04245989467,
+        "TBT_ms": 531.0010509874919,
+        "CLS": 0.008698,
+        "FCP_ms": 10801.029427649768,
+        "TTI_ms": 15631.042964368666,
+        "SI_ms": 10801.029427649768
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:45:45.964Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:46:30.830Z",
+      "scores": {
+        "performance": 56,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 12231.0763837071,
+        "TBT_ms": 81,
+        "CLS": 0.008698,
+        "FCP_ms": 8704.575817454057,
+        "TTI_ms": 13465.478663170683,
+        "SI_ms": 8704.575817454057
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:46:13.029Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:46:50.891Z",
+      "scores": {
+        "performance": 52,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 13859.941110744294,
+        "TBT_ms": 241,
+        "CLS": 0,
+        "FCP_ms": 9362.927001616286,
+        "TTI_ms": 13897.715806584361,
+        "SI_ms": 9362.927001616286
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:46:34.487Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-textbook-quality-overview"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:47:10.268Z",
+      "scores": {
+        "performance": 57,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 11812.712206180171,
+        "TBT_ms": 73,
+        "CLS": 0,
+        "FCP_ms": 8158.772892708538,
+        "TTI_ms": 11835.297127986061,
+        "SI_ms": 8158.772892708538
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:46:54.172Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-overview"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-index",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:47:30.620Z",
+      "scores": {
+        "performance": 51,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 12226.47006338168,
+        "TBT_ms": 283.00886912040914,
+        "CLS": 0,
+        "FCP_ms": 8376.313375587784,
+        "TTI_ms": 12308.973315392495,
+        "SI_ms": 8376.313375587784
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:47:13.953Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-index"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy",
+      "strategy": "mobile",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-primary",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:48:12.614Z",
+      "scores": {
+        "performance": 58,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 7876.981476615965,
+        "TBT_ms": 234,
+        "CLS": 0.008698,
+        "FCP_ms": 5251.641360956968,
+        "TTI_ms": 11717.120711695587,
+        "SI_ms": 5251.641360956968
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:47:36.832Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-primary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r05-primary",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:48:35.318Z",
+      "scores": {
+        "performance": 55,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 14252.192200751568,
+        "TBT_ms": 145,
+        "CLS": 0,
+        "FCP_ms": 9841.807619863963,
+        "TTI_ms": 14327.19861043303,
+        "SI_ms": 9841.807619863963
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:48:15.785Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r05-primary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:48:51.197Z",
+      "scores": {
+        "performance": 61,
+        "accessibility": 92,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 8926.33715488438,
+        "TBT_ms": 43.5,
+        "CLS": 0.00024,
+        "FCP_ms": 5701.211088275439,
+        "TTI_ms": 10090.02233626362,
+        "SI_ms": 5701.211088275439
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:48:38.468Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-followership",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:49:12.592Z",
+      "scores": {
+        "performance": 55,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 11326.659720143452,
+        "TBT_ms": 202,
+        "CLS": 0,
+        "FCP_ms": 6875.385958723377,
+        "TTI_ms": 11409.164656824798,
+        "SI_ms": 6875.385958723377
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:48:54.768Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-followership"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-agile",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:50:08.313Z",
+      "scores": {
+        "performance": 35,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 9001.31634267084,
+        "TBT_ms": 1317,
+        "CLS": 0.008698,
+        "FCP_ms": 5551.1908964393,
+        "TTI_ms": 9091.319615181228,
+        "SI_ms": 6408.682506576222
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:49:25.558Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-agile"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-activity-abc",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:50:29.952Z",
+      "scores": {
+        "performance": 57,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 10477.585710897627,
+        "TBT_ms": 126.5,
+        "CLS": 0.008698,
+        "FCP_ms": 7029.381796733269,
+        "TTI_ms": 10972.614345652622,
+        "SI_ms": 7029.381796733269
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:50:12.063Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-activity-abc"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-agenda-21",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:50:50.388Z",
+      "scores": {
+        "performance": 55,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 11029.977702547787,
+        "TBT_ms": 212,
+        "CLS": 0,
+        "FCP_ms": 6732.33655254555,
+        "TTI_ms": 11112.508300259695,
+        "SI_ms": 6732.33655254555
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:50:33.581Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-agenda-21"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T07:51:20.318Z",
+      "scores": {
+        "performance": 50,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 10916.273079648086,
+        "TBT_ms": 340.785624678354,
+        "CLS": 0.008698,
+        "FCP_ms": 7551.706221051972,
+        "TTI_ms": 10999.087266794277,
+        "SI_ms": 7551.706221051972
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:50:55.756Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle"
+    }
+  ]
+}

--- a/.claude/state/metrics/psi/psi-batch-2026-04-24T08-02-15.json
+++ b/.claude/state/metrics/psi/psi-batch-2026-04-24T08-02-15.json
@@ -1,0 +1,576 @@
+{
+  "version": 1,
+  "generated_at": "2026-04-24T08:02:15.261Z",
+  "results": [
+    {
+      "url": "https://doboku-note.com/",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:51:35.812Z",
+      "scores": {
+        "performance": 98,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1114.7847050988953,
+        "TBT_ms": 50,
+        "CLS": 0.026498,
+        "FCP_ms": 612.6909621038928,
+        "TTI_ms": 1441.9819242077856,
+        "SI_ms": 741.6956631002006
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:51:24.900Z",
+      "final_url": "https://doboku-note.com/"
+    },
+    {
+      "url": "https://doboku-note.com/search",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:52:10.731Z",
+      "scores": {
+        "performance": 81,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 83
+      },
+      "lab_data": {
+        "LCP_ms": 1417.4804514394257,
+        "TBT_ms": 348.39921805757706,
+        "CLS": 0.026498,
+        "FCP_ms": 408.193744460616,
+        "TTI_ms": 1744.0413115760912,
+        "SI_ms": 564.5924281221487
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:51:52.496Z",
+      "final_url": "https://doboku-note.com/search"
+    },
+    {
+      "url": "https://doboku-note.com/category",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:52:27.191Z",
+      "scores": {
+        "performance": 98,
+        "accessibility": 92,
+        "best_practices": 96,
+        "seo": 75
+      },
+      "lab_data": {
+        "LCP_ms": 694.4843611566412,
+        "TBT_ms": 113,
+        "CLS": 0.000323,
+        "FCP_ms": 489.98957410442733,
+        "TTI_ms": 1216.0791482088548,
+        "SI_ms": 585.5203221023572
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:52:14.741Z",
+      "final_url": "https://doboku-note.com/category"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-guide-strategy",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:52:59.065Z",
+      "scores": {
+        "performance": 87,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1762,
+        "TBT_ms": 140,
+        "CLS": 0.026751,
+        "FCP_ms": 1201,
+        "TTI_ms": 2392.75,
+        "SI_ms": 1242.98560116911
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:52:31.890Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-guide-strategy"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-guide-four-management",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:53:22.780Z",
+      "scores": {
+        "performance": 91,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1661.0819918196064,
+        "TBT_ms": 38.5,
+        "CLS": 0.026751,
+        "FCP_ms": 1161.05604504125,
+        "TTI_ms": 2131.791955382495,
+        "SI_ms": 1161.05604504125
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:53:02.683Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-guide-four-management"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-primary-r07-a",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:53:51.342Z",
+      "scores": {
+        "performance": 69,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 2741.073200240083,
+        "TBT_ms": 37.5,
+        "CLS": 0.181067,
+        "FCP_ms": 1641.0429294641096,
+        "TTI_ms": 2805.9707785780056,
+        "SI_ms": 1641.0429294641096
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:53:26.042Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-primary-r07-a"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-primary-h26-a",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:55:19.168Z",
+      "scores": {
+        "performance": 82,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 2021.036659965545,
+        "TBT_ms": 106.5,
+        "CLS": 0.032476000000000005,
+        "FCP_ms": 1601.0287232719734,
+        "TTI_ms": 2944.3438029897607,
+        "SI_ms": 1712.0796378574373
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:54:42.959Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-primary-h26-a"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-r07",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:55:39.765Z",
+      "scores": {
+        "performance": 90,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1754.2847156362175,
+        "TBT_ms": 21.499999999999886,
+        "CLS": 0.026751,
+        "FCP_ms": 1161.192183054447,
+        "TTI_ms": 2108.169237407109,
+        "SI_ms": 1161.192183054447
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:55:22.242Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-r07"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:56:09.862Z",
+      "scores": {
+        "performance": 80,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 2337.1326752404907,
+        "TBT_ms": 40.99999999999977,
+        "CLS": 0.070076,
+        "FCP_ms": 1521.0852912260298,
+        "TTI_ms": 2600.4314906401296,
+        "SI_ms": 1521.0852912260298
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:55:43.062Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide",
+      "strategy": "desktop",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:56:38.699Z",
+      "scores": {
+        "performance": 87,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1659.6636817782296,
+        "TBT_ms": 85.05047787133844,
+        "CLS": 0.069582,
+        "FCP_ms": 1438.6684604916206,
+        "TTI_ms": 2460.596687207618,
+        "SI_ms": 1438.6684604916206
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:56:14.494Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-textbook-quality-overview"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:57:59.836Z",
+      "scores": {
+        "performance": 86,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1940.629017008141,
+        "TBT_ms": 71.05082538362626,
+        "CLS": 0.031169000000000002,
+        "FCP_ms": 1359.8488262151716,
+        "TTI_ms": 2295.868156784395,
+        "SI_ms": 1359.8488262151716
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:57:41.794Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-overview"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-index",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:58:20.205Z",
+      "scores": {
+        "performance": 91,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1654.4448539246537,
+        "TBT_ms": 58.499999999999886,
+        "CLS": 0.07147400000000001,
+        "FCP_ms": 881.2655844326295,
+        "TTI_ms": 2214.6322938685385,
+        "SI_ms": 1299.1568979677822
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:58:03.427Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-index"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:58:37.615Z",
+      "scores": {
+        "performance": 90,
+        "accessibility": 95,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1807.3340892618476,
+        "TBT_ms": 40.499999999999886,
+        "CLS": 0.026498,
+        "FCP_ms": 1121.2118614831222,
+        "TTI_ms": 2132.3617942250253,
+        "SI_ms": 1121.2118614831222
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:58:23.519Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-primary",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:59:06.041Z",
+      "scores": {
+        "performance": 83,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 2181.016193962015,
+        "TBT_ms": 52.00000000000023,
+        "CLS": 0.026826,
+        "FCP_ms": 1481.0107959746772,
+        "TTI_ms": 2513.8164715727926,
+        "SI_ms": 1481.0107959746772
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:58:40.388Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-primary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r05-primary",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T07:59:42.986Z",
+      "scores": {
+        "performance": 84,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1901.0335700554206,
+        "TBT_ms": 111.99999999999977,
+        "CLS": 0.049569,
+        "FCP_ms": 1441.0250853161385,
+        "TTI_ms": 2756.638255107111,
+        "SI_ms": 1441.0250853161385
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:59:10.795Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r05-primary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T08:00:11.581Z",
+      "scores": {
+        "performance": 92,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1601.581155949226,
+        "TBT_ms": 66.50000000000023,
+        "CLS": 0.034602,
+        "FCP_ms": 1041.3670458626696,
+        "TTI_ms": 2159.8316247553435,
+        "SI_ms": 1041.3670458626696
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T07:59:47.401Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-followership",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T08:00:45.526Z",
+      "scores": {
+        "performance": 71,
+        "accessibility": 92,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1410.248183010961,
+        "TBT_ms": 391.4806107022689,
+        "CLS": 0.155141,
+        "FCP_ms": 921.1628701009431,
+        "TTI_ms": 2803.4582898339277,
+        "SI_ms": 1165.2015423782
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T08:00:16.756Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-followership"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-agile",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T08:01:06.141Z",
+      "scores": {
+        "performance": 92,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1581.3384296623926,
+        "TBT_ms": 33.49999999999977,
+        "CLS": 0.053192,
+        "FCP_ms": 1001.2075701929347,
+        "TTI_ms": 2031.7276875032296,
+        "SI_ms": 1001.2075701929347
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T08:00:49.141Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-agile"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-activity-abc",
+      "strategy": "desktop",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-agenda-21",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T08:01:51.985Z",
+      "scores": {
+        "performance": 65,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1481.4687629298237,
+        "TBT_ms": 807.7857083749382,
+        "CLS": 0.026498,
+        "FCP_ms": 881.2678645313273,
+        "TTI_ms": 2783.789293693834,
+        "SI_ms": 1633.9388270468498
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T08:01:19.490Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-agenda-21"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T08:02:15.260Z",
+      "scores": {
+        "performance": 94,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1462.05013039078,
+        "TBT_ms": 78.5,
+        "CLS": 0.032237,
+        "FCP_ms": 921.6392098030833,
+        "TTI_ms": 2008.9325381357044,
+        "SI_ms": 921.6392098030833
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T08:01:55.934Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle"
+    }
+  ]
+}

--- a/.claude/state/metrics/psi/psi-batch-2026-04-24T17-30-49.json
+++ b/.claude/state/metrics/psi/psi-batch-2026-04-24T17-30-49.json
@@ -1,0 +1,576 @@
+{
+  "version": 1,
+  "generated_at": "2026-04-24T17:30:49.616Z",
+  "results": [
+    {
+      "url": "https://doboku-note.com/",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:20:14.546Z",
+      "scores": {
+        "performance": 53,
+        "accessibility": 92,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 8524.99790173471,
+        "TBT_ms": 335,
+        "CLS": 0,
+        "FCP_ms": 5416.769410192861,
+        "TTI_ms": 8607.9923759724,
+        "SI_ms": 5743.789710251459
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:19:58.502Z",
+      "final_url": "https://doboku-note.com/"
+    },
+    {
+      "url": "https://doboku-note.com/search",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:20:29.683Z",
+      "scores": {
+        "performance": 63,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 83
+      },
+      "lab_data": {
+        "LCP_ms": 6968.864378188675,
+        "TBT_ms": 114,
+        "CLS": 0,
+        "FCP_ms": 5071.873066435339,
+        "TTI_ms": 6968.864378188676,
+        "SI_ms": 5071.873066435339
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:20:17.873Z",
+      "final_url": "https://doboku-note.com/search"
+    },
+    {
+      "url": "https://doboku-note.com/category",
+      "strategy": "mobile",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-guide-strategy",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:20:56.686Z",
+      "scores": {
+        "performance": 48,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 12451.580109660503,
+        "TBT_ms": 357.50358092382976,
+        "CLS": 0.008698,
+        "FCP_ms": 9184.415387164308,
+        "TTI_ms": 12526.583690584335,
+        "SI_ms": 9184.415387164308
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:20:34.789Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-guide-strategy"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-guide-four-management",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:21:38.825Z",
+      "scores": {
+        "performance": 47,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 10051.17602884566,
+        "TBT_ms": 458,
+        "CLS": 0.008698,
+        "FCP_ms": 6601.113741715653,
+        "TTI_ms": 10141.177653727314,
+        "SI_ms": 7361.6738826860965
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:21:01.283Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-guide-four-management"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-primary-r07-a",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:22:30.478Z",
+      "scores": {
+        "performance": 55,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 16878.09226820102,
+        "TBT_ms": 14,
+        "CLS": 0.059659,
+        "FCP_ms": 12151.064078293657,
+        "TTI_ms": 17167.39215470922,
+        "SI_ms": 16709.501905311176
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:21:44.014Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-primary-r07-a"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-primary-h26-a",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:22:57.442Z",
+      "scores": {
+        "performance": 51,
+        "accessibility": 92,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 15826.363874927436,
+        "TBT_ms": 226.5,
+        "CLS": 0.008698,
+        "FCP_ms": 12709.281255982556,
+        "TTI_ms": 15908.865808562317,
+        "SI_ms": 12709.281255982556
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:22:34.813Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-primary-h26-a"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-r07",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:23:22.371Z",
+      "scores": {
+        "performance": 51,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 12601.44531640595,
+        "TBT_ms": 285.008146031817,
+        "CLS": 0.008698,
+        "FCP_ms": 8396.287826457505,
+        "TTI_ms": 12676.44803174989,
+        "SI_ms": 8396.287826457505
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:23:01.490Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-r07"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:23:52.512Z",
+      "scores": {
+        "performance": 43,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 15526.062925110436,
+        "TBT_ms": 514.5012399036532,
+        "CLS": 0.008698,
+        "FCP_ms": 10849.041536772398,
+        "TTI_ms": 15653.563452069491,
+        "SI_ms": 10849.041536772398
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:23:26.093Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:24:15.608Z",
+      "scores": {
+        "performance": 56,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 14851.123991013796,
+        "TBT_ms": 87.5,
+        "CLS": 0.008698,
+        "FCP_ms": 10319.084365019697,
+        "TTI_ms": 14941.12475796852,
+        "SI_ms": 10319.084365019697
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:23:56.093Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:24:37.426Z",
+      "scores": {
+        "performance": 52,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 13844.976584308683,
+        "TBT_ms": 227,
+        "CLS": 0.008698,
+        "FCP_ms": 9818.645264040793,
+        "TTI_ms": 14290.811718890087,
+        "SI_ms": 9818.645264040793
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:24:19.074Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-textbook-quality-overview"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:24:55.531Z",
+      "scores": {
+        "performance": 54,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 12738.700258908502,
+        "TBT_ms": 193.5,
+        "CLS": 0,
+        "FCP_ms": 8158.736749551736,
+        "TTI_ms": 12769.080015637548,
+        "SI_ms": 8158.736749551736
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:24:40.361Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-overview"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-index",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:25:16.792Z",
+      "scores": {
+        "performance": 50,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 12376.611196925796,
+        "TBT_ms": 295,
+        "CLS": 0,
+        "FCP_ms": 8570.402402944932,
+        "TTI_ms": 12459.115372805414,
+        "SI_ms": 8570.402402944932
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:24:59.649Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-index"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:25:53.631Z",
+      "scores": {
+        "performance": 43,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 10126.99512067985,
+        "TBT_ms": 659.0000000000009,
+        "CLS": 0.008698,
+        "FCP_ms": 6301.607707285412,
+        "TTI_ms": 10209.503476655027,
+        "SI_ms": 6301.607707285412
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:25:26.150Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-primary",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:26:22.520Z",
+      "scores": {
+        "performance": 47,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 14476.077130012462,
+        "TBT_ms": 375,
+        "CLS": 0,
+        "FCP_ms": 10900.055500961347,
+        "TTI_ms": 14558.577578917297,
+        "SI_ms": 10900.055500961347
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:25:57.908Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-primary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r05-primary",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:26:49.888Z",
+      "scores": {
+        "performance": 56,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 11818.89190688972,
+        "TBT_ms": 110.5,
+        "CLS": 0.008698,
+        "FCP_ms": 8102.96574063092,
+        "TTI_ms": 12542.688303786044,
+        "SI_ms": 8102.96574063092
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:26:26.783Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r05-primary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:28:11.240Z",
+      "scores": {
+        "performance": 52,
+        "accessibility": 92,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 11776.46195922558,
+        "TBT_ms": 256.50905802403213,
+        "CLS": 0,
+        "FCP_ms": 8083.301934134363,
+        "TTI_ms": 11858.96528050106,
+        "SI_ms": 8083.301934134363
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:27:56.159Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-followership",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:28:28.288Z",
+      "scores": {
+        "performance": 60,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 8361.433953187217,
+        "TBT_ms": 57,
+        "CLS": 0.093972,
+        "FCP_ms": 5101.259560784878,
+        "TTI_ms": 9510.83262083438,
+        "SI_ms": 5101.259560784878
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:28:14.315Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-followership"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-agile",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:28:44.807Z",
+      "scores": {
+        "performance": 61,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 9106.275111796163,
+        "TBT_ms": 34,
+        "CLS": 0.011883999999999999,
+        "FCP_ms": 5551.164596801124,
+        "TTI_ms": 9914.09650938031,
+        "SI_ms": 5551.164596801124
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:28:31.167Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-agile"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-activity-abc",
+      "strategy": "mobile",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-agenda-21",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:30:13.841Z",
+      "scores": {
+        "performance": 30,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 7877.143570051673,
+        "TBT_ms": 3495.339674272772,
+        "CLS": 0.008698,
+        "FCP_ms": 4801.679348545546,
+        "TTI_ms": 11548.183652145375,
+        "SI_ms": 7555.641093725073
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:29:15.610Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-agenda-21"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle",
+      "strategy": "mobile",
+      "fetched_at": "2026-04-24T17:30:49.615Z",
+      "scores": {
+        "performance": 49,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 8417.233133156667,
+        "TBT_ms": 518.5,
+        "CLS": 0.008698,
+        "FCP_ms": 5101.737574972212,
+        "TTI_ms": 11060.636230371812,
+        "SI_ms": 5101.737574972212
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:30:20.655Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle"
+    }
+  ]
+}

--- a/.claude/state/metrics/psi/psi-batch-2026-04-24T17-42-05.json
+++ b/.claude/state/metrics/psi/psi-batch-2026-04-24T17-42-05.json
@@ -1,0 +1,530 @@
+{
+  "version": 1,
+  "generated_at": "2026-04-24T17:42:05.761Z",
+  "results": [
+    {
+      "url": "https://doboku-note.com/",
+      "strategy": "desktop",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/search",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:31:37.162Z",
+      "scores": {
+        "performance": 90,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 83
+      },
+      "lab_data": {
+        "LCP_ms": 1372.3706337770755,
+        "TBT_ms": 204.5,
+        "CLS": 0.026498,
+        "FCP_ms": 408.19096423910014,
+        "TTI_ms": 1560.4206337770756,
+        "SI_ms": 464.50538037442277
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:31:20.852Z",
+      "final_url": "https://doboku-note.com/search"
+    },
+    {
+      "url": "https://doboku-note.com/category",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:31:59.725Z",
+      "scores": {
+        "performance": 94,
+        "accessibility": 92,
+        "best_practices": 96,
+        "seo": 75
+      },
+      "lab_data": {
+        "LCP_ms": 872.3888790519588,
+        "TBT_ms": 188.7048654147681,
+        "CLS": 0.000323,
+        "FCP_ms": 489.9930494074742,
+        "TTI_ms": 1293.2860988149487,
+        "SI_ms": 954.451092511935
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:31:43.034Z",
+      "final_url": "https://doboku-note.com/category"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-guide-strategy",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:32:30.498Z",
+      "scores": {
+        "performance": 68,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1542.3291028727413,
+        "TBT_ms": 487.1260693439506,
+        "CLS": 0.026498,
+        "FCP_ms": 1202.0195857653907,
+        "TTI_ms": 2388.1065651679787,
+        "SI_ms": 1770.083322214428
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:32:05.652Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-guide-strategy"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-guide-four-management",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:33:56.933Z",
+      "scores": {
+        "performance": 88,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1786.078931962964,
+        "TBT_ms": 111.99334308746097,
+        "CLS": 0.026751,
+        "FCP_ms": 1161.0513533253018,
+        "TTI_ms": 2292.9353035792515,
+        "SI_ms": 1161.0513533253018
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:33:34.223Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-guide-four-management"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-primary-r07-a",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:35:27.611Z",
+      "scores": {
+        "performance": 40,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 2926.0609682388604,
+        "TBT_ms": 3364.9999999999986,
+        "CLS": 0.134026,
+        "FCP_ms": 445.0096774982317,
+        "TTI_ms": 5986.50967749823,
+        "SI_ms": 3803.7529882346066
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:34:19.907Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-primary-r07-a"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-primary-h26-a",
+      "strategy": "desktop",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-r07",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:35:58.792Z",
+      "scores": {
+        "performance": 90,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1717.428609159249,
+        "TBT_ms": 61.49999999999977,
+        "CLS": 0.043639,
+        "FCP_ms": 1161.29297334936,
+        "TTI_ms": 2272.186661285881,
+        "SI_ms": 1161.29297334936
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:35:32.520Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-r07"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:37:09.371Z",
+      "scores": {
+        "performance": 72,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 2541.932013646105,
+        "TBT_ms": 176.5,
+        "CLS": 0.070076,
+        "FCP_ms": 1521.5455689635735,
+        "TTI_ms": 2575.944895135523,
+        "SI_ms": 2015.5288663697534
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:36:29.989Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-secondary-concrete-basics"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-secondary-experience-writing-guide",
+      "strategy": "desktop",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-quality-management-text",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:37:32.595Z",
+      "scores": {
+        "performance": 82,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 2077.674977843618,
+        "TBT_ms": 27.000000000000455,
+        "CLS": 0.083099,
+        "FCP_ms": 1562.3812333827134,
+        "TTI_ms": 2550.436928268311,
+        "SI_ms": 1562.3812333827134
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:37:13.498Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-textbook-quality-overview"
+    },
+    {
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-management",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:38:31.163Z",
+      "scores": {
+        "performance": 79,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1809.8103366699365,
+        "TBT_ms": 205,
+        "CLS": 0.031169000000000002,
+        "FCP_ms": 1359.8703719703142,
+        "TTI_ms": 2638.0471327713203,
+        "SI_ms": 1835.3951777206294
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:38:02.788Z",
+      "final_url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-overview"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-index",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:38:50.450Z",
+      "scores": {
+        "performance": 90,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1781.2415550022379,
+        "TBT_ms": 30.000000000000114,
+        "CLS": 0.026498,
+        "FCP_ms": 1121.1477748248985,
+        "TTI_ms": 2090.30235393175,
+        "SI_ms": 1121.1477748248985
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:38:34.583Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-index"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:39:18.938Z",
+      "scores": {
+        "performance": 86,
+        "accessibility": 95,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1842.4667278834652,
+        "TBT_ms": 142.5,
+        "CLS": 0.062642,
+        "FCP_ms": 1121.2855276463556,
+        "TTI_ms": 2452.704615205769,
+        "SI_ms": 1155.373443258213
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:38:55.265Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-exam-passing-strategy"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-primary",
+      "strategy": "desktop",
+      "error": "PSI API 500: {\n  \"error\": {\n    \"code\": 500,\n    \"message\": \"Lighthouse returned error: Something went wrong.\",\n    \"errors\": [\n      {\n        \"message\": \"Lighthouse returned error: Something went wr"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r05-primary",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:39:52.993Z",
+      "scores": {
+        "performance": 85,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1981.0288619512853,
+        "TBT_ms": 43,
+        "CLS": 0.030163000000000002,
+        "FCP_ms": 1441.02065908092,
+        "TTI_ms": 2482.5815050984033,
+        "SI_ms": 1441.02065908092
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:39:28.871Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r05-primary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:40:16.108Z",
+      "scores": {
+        "performance": 91,
+        "accessibility": 96,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1621.318602508071,
+        "TBT_ms": 91.96689844071977,
+        "CLS": 0.034602,
+        "FCP_ms": 1041.1986093556807,
+        "TTI_ms": 2165.992601138549,
+        "SI_ms": 1041.1986093556807
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:39:56.342Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-r07-secondary"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-followership",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:40:42.040Z",
+      "scores": {
+        "performance": 80,
+        "accessibility": 92,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1538.4313498156544,
+        "TBT_ms": 177.95282111391293,
+        "CLS": 0.181639,
+        "FCP_ms": 921.283073316523,
+        "TTI_ms": 2278.787165317307,
+        "SI_ms": 1012.5233404634007
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:40:20.423Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-followership"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-agile",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:41:03.165Z",
+      "scores": {
+        "performance": 92,
+        "accessibility": 93,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1581.9237805017074,
+        "TBT_ms": 58.5,
+        "CLS": 0.053192,
+        "FCP_ms": 1001.56658537438,
+        "TTI_ms": 2114.719853673886,
+        "SI_ms": 1001.56658537438
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:40:45.360Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-agile"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-activity-abc",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:41:23.429Z",
+      "scores": {
+        "performance": 93,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1620.8543352447161,
+        "TBT_ms": 42.5,
+        "CLS": 0.029066,
+        "FCP_ms": 961.2410123093621,
+        "TTI_ms": 2009.3986115485613,
+        "SI_ms": 961.2410123093621
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:41:06.445Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-activity-abc"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-agenda-21",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:41:47.559Z",
+      "scores": {
+        "performance": 94,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1261.3762094118804,
+        "TBT_ms": 137,
+        "CLS": 0.028267,
+        "FCP_ms": 881.2550572283939,
+        "TTI_ms": 2154.095448666154,
+        "SI_ms": 881.2550572283939
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:41:27.928Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-agenda-21"
+    },
+    {
+      "url": "https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle",
+      "strategy": "desktop",
+      "fetched_at": "2026-04-24T17:42:05.761Z",
+      "scores": {
+        "performance": 94,
+        "accessibility": 91,
+        "best_practices": 100,
+        "seo": 92
+      },
+      "lab_data": {
+        "LCP_ms": 1461.4662143700994,
+        "TBT_ms": 33,
+        "CLS": 0.032237,
+        "FCP_ms": 921.28378266006,
+        "TTI_ms": 1877.3885113811148,
+        "SI_ms": 921.28378266006
+      },
+      "field_data": {
+        "LCP": null,
+        "INP": null,
+        "CLS": null,
+        "FCP": null,
+        "TTFB": null
+      },
+      "analysis_utc": "2026-04-24T17:41:50.699Z",
+      "final_url": "https://doboku-note.com/docs/pe-comprehensive-management-alarp-principle"
+    }
+  ]
+}

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -12,15 +12,18 @@ export default function GoogleAnalytics() {
     return null;
   }
 
+  // Issue #84 Wave 1: strategy を "afterInteractive" から "lazyOnload" へ変更。
+  // gtag.js のダウンロードと実行を LCP 発火後に遅延させ、mobile main thread の
+  // 占有を解消して LCP / TBT を短縮する。
   return (
     <>
       <Script
-        strategy="afterInteractive"
+        strategy="lazyOnload"
         src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
       />
       <Script
         id="google-analytics"
-        strategy="afterInteractive"
+        strategy="lazyOnload"
         dangerouslySetInnerHTML={{
           __html: `
             window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Summary

Issue #84 Wave 1 の main 反映。develop から main へ 3 commit 昇格。

### 含まれる変更

- **perf(ga4)**: Script strategy を lazyOnload に変更 (#133) — Wave 1 本体
- **chore(metrics)**: psi daily audit 2026-04-24T08:02Z [skip ci] — 自動計測
- **chore(metrics)**: psi daily audit 2026-04-24T17:42Z [skip ci] — 自動計測

## Deploy 後の確認

- Cloudflare Pages 反映（通常 2〜3 分）
- `npm run fetch-psi-data -- --url https://doboku-note.com/ --strategy mobile` で after 計測
- Issue #84 に Before (4828ms) / After 比較を記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)