### PR TITLE
fix(ga4): Wave 1 lazyOnload を revert + gtag ガード追加 (#84 hotfix)

### DIFF
--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -12,18 +12,15 @@ export default function GoogleAnalytics() {
     return null;
   }
 
-  // Issue #84 Wave 1: strategy を "afterInteractive" から "lazyOnload" へ変更。
-  // gtag.js のダウンロードと実行を LCP 発火後に遅延させ、mobile main thread の
-  // 占有を解消して LCP / TBT を短縮する。
   return (
     <>
       <Script
-        strategy="lazyOnload"
+        strategy="afterInteractive"
         src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
       />
       <Script
         id="google-analytics"
-        strategy="lazyOnload"
+        strategy="afterInteractive"
         dangerouslySetInnerHTML={{
           __html: `
             window.dataLayer = window.dataLayer || [];

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -20,8 +20,13 @@ declare global {
 }
 
 // ページビューを送信
+// Issue #84 hotfix (2026-04-25): gtag.js 未ロード時のガードを追加。
+// 将来 Script strategy を lazyOnload 等に変更しても、hydration 直後の
+// AnalyticsProvider から呼ばれる本関数が TypeError を投げて React tree を
+// クラッシュさせないようにする。
 export const pageview = (url: string) => {
   if (!GA_ID) return;
+  if (typeof window === "undefined" || typeof window.gtag !== "function") return;
   window.gtag("config", GA_ID, {
     page_path: url,
   });
@@ -52,5 +57,6 @@ export const event = ({
     eventParams.value = value;
   }
 
+  if (typeof window === "undefined" || typeof window.gtag !== "function") return;
   window.gtag("event", action, eventParams);
 };


### PR DESCRIPTION
## Summary

**本番障害の緊急修正**。Issue #84 Wave 1 (PR #133/#134) の `lazyOnload` 化で mobile サイト全体がクラッシュしていた。Playwright + mobile viewport (360x800) で確認した結果、"This page couldn't load" の Next.js エラー画面に置き換わっていた。

## 真因

- `src/components/providers/AnalyticsProvider.tsx:18` が hydration 直後に `gtag.pageview()` を呼ぶ
- `src/lib/gtag.ts:25` が無条件に `window.gtag("config", ...)` を呼ぶ
- **`lazyOnload`** では gtag.js ロードが page load 後まで遅延 → `useEffect` 実行時に `window.gtag` 未定義 → TypeError
- React tree がクラッシュして Next.js の error UI に置き換わる
- Desktop PSI (983ms, Performance 96) が通っていたのは hydration 順序が異なるため

## 修正内容

1. **`src/components/GoogleAnalytics.tsx`** — Script strategy を `lazyOnload` → `afterInteractive` に revert
2. **`src/lib/gtag.ts`** — `pageview` / `event` に `typeof window.gtag !== "function"` の早期 return ガードを追加
   - 将来 lazyOnload 再試行や他の遅延戦略に変更しても React tree をクラッシュさせない

## 影響範囲

- **発覚前**: mobile ユーザーはサイト全体が使えない状態（Issue #84 の PSI 5130ms は実はエラー画面の H1 を LCP 計測していた可能性）
- **影響時間**: 2026-04-24T23:04Z (PR #134 deploy) 〜 本 PR deploy まで
- **Desktop ユーザー**: 影響なし

## Test plan

- [x] `npm run type-check` 通過
- [x] `npm run build` 通過 (779 ページ SSG 成功)
- [ ] main deploy 後に Playwright mobile viewport で正常レンダー確認
- [ ] PSI mobile 再計測（エラー画面除去後の真の LCP 値を取る）

## 関連

- Issue #84 (Weekly/2026-W16 PSI Critical LCP)
- PR #133 (Wave 1 本体、本 PR で部分 revert)
- PR #134 (前回 main deploy)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)