### PR TITLE
perf(lcp): Wave 2 — Noto Sans JP の preload off で mobile LCP 短縮（#84）

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,11 +20,14 @@ const inter = Inter({
   preload: true,
 });
 
+// Wave 2 (#84): preload: false に変更。日本語サブセット指定のない Noto Sans JP は
+// mobile で巨大ペイロードを critical path に乗せ LCP の主要ボトルネックとなっていた。
+// preload off + display:swap で system font フォールバックによる早期描画を狙う（FOUT 許容）。
 const notoSansJP = Noto_Sans_JP({
   subsets: ["latin"],
   variable: "--font-noto-sans-jp",
   display: "swap",
-  preload: true,
+  preload: false,
 });
 
 // Serif/Mincho フォント（2026-04-22 追加）: 本文フォント切替の基盤として導入。


### PR DESCRIPTION
## 概要

Issue #84 (mobile LCP 6968ms / 閾値 2500ms の 2.8 倍) に対する **Wave 2**。
日本語フォント (Noto Sans JP) を critical render path から外し、system font fallback で早期描画を狙う。

## 変更

`src/app/layout.tsx`:
- `notoSansJP.preload: true → false`

Inter（latin、軽量）の preload は維持。Source Serif 4・Noto Serif JP は元から preload: false。

## 仮説

- Hero h1（テキストのみ、画像なし）が LCP candidate
- `subsets: ["latin"]` 指定の Noto Sans JP は日本語グリフのサブセットが効きにくく、preload で critical path に大きなペイロードが乗る
- `preload: false` + `display: swap` の組み合わせで system font に即フォールバック → LCP 短縮（FOUT を許容）

## 期待効果

- mobile LCP **6968ms → 3000ms 以下** 目標
- Performance スコア **64 → 75+** 目標

## 副作用観察項目

- 初回表示時の日本語が system font（FOUT）
- フォント読込後の re-render で軽微な CLS（現状 CLS=0 のため要観察）

## 検証

- [x] type-check 通過
- [ ] CI build 成功
- [ ] develop マージ → main デプロイ後の PSI 再計測
- [ ] LCP ≤ 3000ms / Performance ≥ 75 達成なら #84 を close 候補

## 関連

- Wave 1 (PR #133/#134, GA4 lazyOnload): 効果なし、ロールバックは保留
- Refs: #84, #82 (Weekly Metrics PDCA Umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)