### PR TITLE
feat(audit): PDF-vs-MDX 突合 R01-R07 全 14 PDF 実行 (#128 Phase 3)

### DIFF
--- a/.claude/scripts/audit-pdf-vs-mdx.mjs
+++ b/.claude/scripts/audit-pdf-vs-mdx.mjs
@@ -1,0 +1,420 @@
+#!/usr/bin/env node
+// .claude/scripts/audit-pdf-vs-mdx.mjs
+//
+// 過去問 PDF を Tesseract OCR (日本語) でテキスト化し、対応する MDX 本文と
+// 突合する。MDX に存在する 2-5 文字の漢字熟語が PDF の OCR 結果に
+// 一切現れない場合、それは MDX 化時の OCR 誤読の可能性が高い「候補」
+// として出力する。
+//
+// 設計の前提:
+//   - PDF はスキャン画像（テキストレイヤなし）。pdftotext は使えない
+//   - Tesseract jpn は完璧ではないが、市販 PDF 化と異なる OCR エンジンの結果
+//     を別ルートで取れるので、両者が disagree する場所が浮上できる
+//   - 真因の最終判断は人手で原典 PDF を視覚突合（候補の数を絞ることが目的）
+//
+// 入力:
+//   docs/textbook/技術士（総監）/過去問/{year}/{year}_試験問題_{択一式|記述式}.pdf
+//   .local/r2/posts/pe-comprehensive-management/{year-lower}-{primary|secondary}/article.mdx
+//
+// 出力:
+//   .claude/state/pdf-mdx-audit/YYYY-MM-DD.json
+//   .tmp/ocr-cache/{year}-{kind}/page-XXX.{png,txt}
+//   .tmp/ocr-cache/{year}-{kind}-fullocr.txt
+//
+// 使い方:
+//   node .claude/scripts/audit-pdf-vs-mdx.mjs            # 全年度
+//   node .claude/scripts/audit-pdf-vs-mdx.mjs R07        # 特定年度のみ
+//   node .claude/scripts/audit-pdf-vs-mdx.mjs --skip-ocr # OCR cache を再利用
+//
+// 必要ツール: pdftoppm, tesseract (with jpn data)
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, relative, basename, dirname } from 'node:path';
+import { spawnSync, spawn } from 'node:child_process';
+
+const ROOT = process.cwd();
+const PDF_ROOT = join(ROOT, 'docs/textbook/技術士（総監）/過去問');
+const MDX_ROOT = join(ROOT, '.local/r2/posts/pe-comprehensive-management');
+const TMP_DIR = join(ROOT, '.tmp/ocr-cache');
+const OUTPUT_DIR = join(ROOT, '.claude/state/pdf-mdx-audit');
+const TODAY = new Date().toISOString().slice(0, 10);
+
+const args = process.argv.slice(2);
+const SKIP_OCR = args.includes('--skip-ocr');
+const ONLY_YEARS = args.filter((a) => /^R\d+|^H\d+$/i.test(a)).map((a) => a.toUpperCase());
+
+const TARGET_YEARS = ['R07', 'R06', 'R05', 'R04', 'R03', 'R02', 'R01'];
+const KINDS = [
+  { name: 'primary', pdf_name: '択一式', mdx_dir_suffix: '-primary' },
+  { name: 'secondary', pdf_name: '記述式', mdx_dir_suffix: '-secondary' },
+];
+
+const OCR_PARALLEL = 4; // 並行 OCR プロセス数
+const PDF_DPI = 200;     // PNG 解像度
+
+// ── ユーティリティ ────────────────────────────────────
+
+function log(msg) {
+  console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
+}
+
+function fileExists(p) {
+  return existsSync(p) && statSync(p).isFile();
+}
+
+function pdfPath(year, kind) {
+  return join(PDF_ROOT, year, `${year}_試験問題_${kind.pdf_name}.pdf`);
+}
+
+function mdxPath(year, kind) {
+  const lower = year.toLowerCase();
+  return join(MDX_ROOT, `${lower}${kind.mdx_dir_suffix}`, 'article.mdx');
+}
+
+function ocrDir(year, kind) {
+  return join(TMP_DIR, `${year}-${kind.name}`);
+}
+
+function ocrFullText(year, kind) {
+  return join(TMP_DIR, `${year}-${kind.name}-fullocr.txt`);
+}
+
+// ── PDF → PNG ──────────────────────────────────────
+
+function convertPdfToPngs(pdf, outDir) {
+  mkdirSync(outDir, { recursive: true });
+  const existing = readdirSync(outDir).filter((f) => f.endsWith('.png'));
+  if (existing.length > 0) {
+    log(`  pdftoppm: skip (${existing.length} PNGs already exist)`);
+    return existing.length;
+  }
+  log(`  pdftoppm -r ${PDF_DPI} ...`);
+  const result = spawnSync('pdftoppm', ['-r', String(PDF_DPI), '-png', pdf, join(outDir, 'page')], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.status !== 0) {
+    throw new Error(`pdftoppm failed: ${result.stderr?.toString()}`);
+  }
+  const pngs = readdirSync(outDir).filter((f) => f.endsWith('.png'));
+  log(`  pdftoppm -> ${pngs.length} PNGs`);
+  return pngs.length;
+}
+
+// ── Tesseract OCR (parallel) ─────────────────────────
+
+async function ocrPng(png, outBase) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('tesseract', [png, outBase, '-l', 'jpn', '--psm', '6'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    proc.stderr.on('data', (d) => (stderr += d.toString()));
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`tesseract failed: ${stderr}`));
+    });
+  });
+}
+
+async function ocrAllPngs(outDir) {
+  const pngs = readdirSync(outDir).filter((f) => f.endsWith('.png')).sort();
+  const tasks = [];
+  let inProgress = 0;
+  let done = 0;
+  let nextIdx = 0;
+
+  return new Promise((resolve, reject) => {
+    function tick() {
+      while (inProgress < OCR_PARALLEL && nextIdx < pngs.length) {
+        const png = pngs[nextIdx++];
+        const fullPath = join(outDir, png);
+        const base = fullPath.replace(/\.png$/, '');
+        const txtPath = `${base}.txt`;
+        if (fileExists(txtPath)) {
+          done++;
+          continue;
+        }
+        inProgress++;
+        ocrPng(fullPath, base)
+          .then(() => {
+            done++;
+            inProgress--;
+            if (done % 5 === 0) log(`    OCR ${done}/${pngs.length}`);
+            if (done === pngs.length) resolve(done);
+            else tick();
+          })
+          .catch((err) => reject(err));
+      }
+      if (done === pngs.length) resolve(done);
+    }
+    tick();
+  });
+}
+
+function concatOcrText(outDir, fullTextPath) {
+  const txts = readdirSync(outDir).filter((f) => f.endsWith('.txt')).sort();
+  let combined = '';
+  for (const t of txts) {
+    combined += readFileSync(join(outDir, t), 'utf-8') + '\n';
+  }
+  writeFileSync(fullTextPath, combined);
+  return combined.length;
+}
+
+// ── MDX 本文抽出 ─────────────────────────────────────
+
+function extractMdxText(raw) {
+  const lines = raw.replace(/\r\n/g, '\n').split('\n');
+  const result = [];
+  let inFrontmatter = false;
+  let frontmatterClosed = false;
+  let inCodeFence = false;
+  let inDetails = false;     // 解答・解説 (<details>...</details>) は OCR と比較しないため skip
+  let inJsxProp = false;     // <ExamPoint items={[...]}> 等 JSX prop 配列を skip
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (trimmed === '---') {
+      if (!frontmatterClosed && !inFrontmatter) inFrontmatter = true;
+      else if (inFrontmatter) { inFrontmatter = false; frontmatterClosed = true; }
+      continue;
+    }
+    if (inFrontmatter) continue;
+    if (/^```/.test(line)) { inCodeFence = !inCodeFence; continue; }
+    if (inCodeFence) continue;
+
+    // <details> ブロックの開閉を追跡
+    if (/<details(\s|>)/i.test(trimmed)) { inDetails = true; continue; }
+    if (/<\/details>/i.test(trimmed)) { inDetails = false; continue; }
+    if (inDetails) continue;
+
+    // JSX prop で配列リテラルが複数行に渡るケース
+    // <ExamPoint summary="..." items={[
+    //   "string1",
+    //   "string2",
+    // ]}/>
+    if (/=\{\[\s*$/.test(trimmed)) { inJsxProp = true; continue; }
+    if (inJsxProp) {
+      if (/\]\s*\}/.test(trimmed)) inJsxProp = false;
+      continue;
+    }
+
+    // タイトル行（# 見出し）も MDX 独自のため OCR には無い → skip
+    if (/^#+\s/.test(trimmed)) continue;
+
+    // 単独の JSX タグ行（<ExamPoint .../>, <RelatedKeywords .../> 等）は skip
+    if (/^<[A-Z][A-Za-z0-9]*(\s|\/?>)/.test(trimmed)) continue;
+    if (/^<\/[A-Z][A-Za-z0-9]*>\s*$/.test(trimmed)) continue;
+
+    // インライン属性のみの継続行（よくある: items={[\n "..."\n ]}/>）
+    if (/^[\w-]+=/.test(trimmed)) continue;
+    if (trimmed === '/>' || trimmed === '>') continue;
+
+    let text = line
+      .replace(/<[^>]+>/g, '')
+      .replace(/\{[^}]*\}/g, '')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+    if (!text.trim()) continue;
+    result.push({ lineNo: i + 1, text });
+  }
+  return result;
+}
+
+// ── 候補抽出 ─────────────────────────────────────────
+
+/**
+ * 文字列から長さ 2-5 の漢字連続を抽出。
+ * 同じ文字列が複数回出ても一意化して返す（位置別にあとで再検索）。
+ */
+function extractKanjiNGrams(text, minLen = 2, maxLen = 5) {
+  const set = new Set();
+  const re = /[一-鿿㐀-䶿々〆〤]+/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const run = m[0];
+    for (let len = minLen; len <= Math.min(maxLen, run.length); len++) {
+      for (let i = 0; i + len <= run.length; i++) {
+        set.add(run.slice(i, i + len));
+      }
+    }
+  }
+  return set;
+}
+
+/**
+ * OCR テキスト内に含まれる漢字 n-gram のセット（高速検索用）。
+ */
+function buildOcrKanjiSet(ocrText) {
+  return extractKanjiNGrams(ocrText, 2, 5);
+}
+
+/**
+ * MDX 各行で OCR に存在しない n-gram を探す。
+ * 信頼度: 長い (4-5字) の missing は high、短い (2字) は low。
+ */
+function findOcrMismatches(mdxLines, ocrSet, ocrText) {
+  const candidates = [];
+  for (const { lineNo, text } of mdxLines) {
+    // 行から漢字 n-gram を抽出
+    const seen = new Set();
+    const re = /[一-鿿㐀-䶿々〆〤]{2,}/g;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      const run = m[0];
+      // この run の中で「OCR set にない最長の連続」を探す
+      // greedy: 一番長く missing な部分文字列を見つける
+      for (let len = Math.min(5, run.length); len >= 3; len--) {
+        for (let i = 0; i + len <= run.length; i++) {
+          const sub = run.slice(i, i + len);
+          if (seen.has(sub)) continue;
+          seen.add(sub);
+          if (!ocrSet.has(sub)) {
+            // 長さ 3 以上で missing なものを候補に
+            // 信頼度: len で粗く分類
+            const confidence = len >= 5 ? 'high' : len >= 4 ? 'medium' : 'low';
+            const ctxStart = Math.max(0, text.indexOf(sub) - 25);
+            const ctxEnd = Math.min(text.length, text.indexOf(sub) + sub.length + 25);
+            candidates.push({
+              line: lineNo,
+              missing: sub,
+              missing_len: len,
+              context: text.slice(ctxStart, ctxEnd),
+              confidence,
+            });
+          }
+        }
+      }
+    }
+  }
+  // 重複（同じ missing で複数行ヒット）はそのまま残す（位置情報を保持）
+  // 同じ行内の同じ missing は 1 件に絞る
+  const unique = [];
+  const key = (c) => `${c.line}\t${c.missing}`;
+  const seen = new Set();
+  for (const c of candidates) {
+    if (seen.has(key(c))) continue;
+    seen.add(key(c));
+    unique.push(c);
+  }
+  return unique;
+}
+
+// ── 図参照のヒューリスティック（OCR 側） ──────────────
+
+/**
+ * OCR テキスト中から「図」「表」のキャプションを検出。
+ * 例: 「図1」「図 1」「図-1」「表1」「表-1」「Fig.1」など
+ */
+function findFigureCaptionsInOcr(ocrText) {
+  const captions = [];
+  const re = /(図|表|Fig\.?|Tab\.?)\s*[-－―]?\s*\d{1,2}/g;
+  let m;
+  while ((m = re.exec(ocrText)) !== null) {
+    captions.push(m[0]);
+  }
+  return captions;
+}
+
+// ── メイン処理 ──────────────────────────────────────
+
+async function main() {
+  const years = ONLY_YEARS.length > 0
+    ? TARGET_YEARS.filter((y) => ONLY_YEARS.includes(y))
+    : TARGET_YEARS;
+
+  log(`Target years: ${years.join(', ')}`);
+  log(`SKIP_OCR: ${SKIP_OCR}`);
+
+  const reportEntries = [];
+
+  for (const year of years) {
+    for (const kind of KINDS) {
+      const pdf = pdfPath(year, kind);
+      const mdx = mdxPath(year, kind);
+      const outDir = ocrDir(year, kind);
+      const fullText = ocrFullText(year, kind);
+
+      if (!fileExists(pdf)) {
+        log(`${year}/${kind.name}: PDF not found (${relative(ROOT, pdf)})`);
+        continue;
+      }
+      if (!fileExists(mdx)) {
+        log(`${year}/${kind.name}: MDX not found (${relative(ROOT, mdx)})`);
+        continue;
+      }
+
+      log(`=== ${year}/${kind.name} ===`);
+
+      // OCR phase
+      if (!SKIP_OCR || !fileExists(fullText)) {
+        convertPdfToPngs(pdf, outDir);
+        await ocrAllPngs(outDir);
+        const len = concatOcrText(outDir, fullText);
+        log(`  OCR full text: ${len} chars`);
+      } else {
+        log(`  OCR cache: ${fullText} (skipped)`);
+      }
+
+      // Comparison phase
+      const ocrText = readFileSync(fullText, 'utf-8');
+      const ocrSet = buildOcrKanjiSet(ocrText);
+
+      const mdxRaw = readFileSync(mdx, 'utf-8');
+      const mdxLines = extractMdxText(mdxRaw);
+
+      const mismatches = findOcrMismatches(mdxLines, ocrSet, ocrText);
+      const ocrFigCaptions = findFigureCaptionsInOcr(ocrText);
+
+      // 信頼度別にカウント
+      const byConf = { high: 0, medium: 0, low: 0 };
+      for (const m of mismatches) byConf[m.confidence]++;
+
+      log(`  candidates: ${mismatches.length} (high=${byConf.high} medium=${byConf.medium} low=${byConf.low})`);
+      log(`  OCR figure captions found: ${ocrFigCaptions.length}`);
+
+      reportEntries.push({
+        year,
+        kind: kind.name,
+        pdf: relative(ROOT, pdf),
+        mdx: relative(ROOT, mdx),
+        ocr_text_len: ocrText.length,
+        mdx_text_lines: mdxLines.length,
+        ocr_kanji_ngrams: ocrSet.size,
+        mismatch_total: mismatches.length,
+        mismatch_by_confidence: byConf,
+        ocr_figure_captions: ocrFigCaptions,
+        ocr_figure_caption_count: ocrFigCaptions.length,
+        candidates: mismatches.sort((a, b) => {
+          // confidence 降順 → 行番号昇順
+          const rank = { high: 0, medium: 1, low: 2 };
+          return rank[a.confidence] - rank[b.confidence] || a.line - b.line;
+        }),
+      });
+    }
+  }
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const outPath = join(OUTPUT_DIR, `${TODAY}.json`);
+  const summary = {
+    generated_at: new Date().toISOString(),
+    target_years: years,
+    pipeline: {
+      pdf_dpi: PDF_DPI,
+      ocr_engine: 'tesseract jpn',
+      ocr_psm: 6,
+      n_gram_min: 3,
+      n_gram_max: 5,
+    },
+    note: '本スクリプトは MDX に存在する漢字 n-gram (3-5字) で OCR 結果に一切現れないものを「候補」として出力する。Tesseract も完璧でないため、両 OCR が disagree する場所を浮上させて人手レビューに回すのが目的。candidates が多くても全て誤読ではない。',
+    entries: reportEntries,
+  };
+  writeFileSync(outPath, JSON.stringify(summary, null, 2));
+  log(`Output: ${relative(ROOT, outPath)}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.claude/state/pdf-mdx-audit/2026-04-24.json
+++ b/.claude/state/pdf-mdx-audit/2026-04-24.json
@@ -1,0 +1,19004 @@
+{
+  "generated_at": "2026-04-24T23:54:23.262Z",
+  "target_years": [
+    "R07",
+    "R06",
+    "R05",
+    "R04",
+    "R03",
+    "R02",
+    "R01"
+  ],
+  "pipeline": {
+    "pdf_dpi": 200,
+    "ocr_engine": "tesseract jpn",
+    "ocr_psm": 6,
+    "n_gram_min": 3,
+    "n_gram_max": 5
+  },
+  "note": "本スクリプトは MDX に存在する漢字 n-gram (3-5字) で OCR 結果に一切現れないものを「候補」として出力する。Tesseract も完璧でないため、両 OCR が disagree する場所を浮上させて人手レビューに回すのが目的。candidates が多くても全て誤読ではない。",
+  "entries": [
+    {
+      "year": "R07",
+      "kind": "primary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R07/R07_試験問題_択一式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r07-primary/article.mdx",
+      "ocr_text_len": 19897,
+      "mdx_text_lines": 276,
+      "ocr_kanji_ngrams": 4004,
+      "mismatch_total": 280,
+      "mismatch_by_confidence": {
+        "high": 51,
+        "medium": 96,
+        "low": 133
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 26,
+          "missing": "取機的手象",
+          "missing_len": 5,
+          "context": "事業継続に関する取機的手象の教訓、関連制度の整備、経済・社会の変化等を踏まえ",
+          "confidence": "high"
+        },
+        {
+          "line": 162,
+          "missing": "修理作業等",
+          "missing_len": 5,
+          "context": "保全活動を見直すことで、設備故障の発生による生じる修理作業等の時間を短縮した。",
+          "confidence": "high"
+        },
+        {
+          "line": 287,
+          "missing": "社会貢献活",
+          "missing_len": 5,
+          "context": "ッシュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャッシュ・フロー の3つの部分から構成さ",
+          "confidence": "high"
+        },
+        {
+          "line": 287,
+          "missing": "会貢献活動",
+          "missing_len": 5,
+          "context": "シュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャッシュ・フロー の3つの部分から構成され",
+          "confidence": "high"
+        },
+        {
+          "line": 378,
+          "missing": "所属労働基",
+          "missing_len": 5,
+          "context": "5. 災害等による臨時の必要がある場合、使用者は、所属労働基準監督官の許可を受けて時間外・休日の労働時間の上限",
+          "confidence": "high"
+        },
+        {
+          "line": 378,
+          "missing": "属労働基準",
+          "missing_len": 5,
+          "context": ". 災害等による臨時の必要がある場合、使用者は、所属労働基準監督官の許可を受けて時間外・休日の労働時間の上限規",
+          "confidence": "high"
+        },
+        {
+          "line": 378,
+          "missing": "基準監督官",
+          "missing_len": 5,
+          "context": "害等による臨時の必要がある場合、使用者は、所属労働基準監督官の許可を受けて時間外・休日の労働時間の上限規制を超",
+          "confidence": "high"
+        },
+        {
+          "line": 418,
+          "missing": "労働者等集",
+          "missing_len": 5,
+          "context": "業主は、その雇用する短時間労働者等について、通常の労働者等集を行う場合の募集内容の周囲、通常の労働者のポストを",
+          "confidence": "high"
+        },
+        {
+          "line": 419,
+          "missing": "同一短時間",
+          "missing_len": 5,
+          "context": "力を有している場合を除き、職務内容が通常の労働者と同一短時間労働者等に対しても実施しなければならない。",
+          "confidence": "high"
+        },
+        {
+          "line": 419,
+          "missing": "一短時間労",
+          "missing_len": 5,
+          "context": "を有している場合を除き、職務内容が通常の労働者と同一短時間労働者等に対しても実施しなければならない。",
+          "confidence": "high"
+        },
+        {
+          "line": 500,
+          "missing": "日雇労働者",
+          "missing_len": 5,
+          "context": "には、一定の要件を満たした、季節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 500,
+          "missing": "雇労働者及",
+          "missing_len": 5,
+          "context": "は、一定の要件を満たした、季節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 500,
+          "missing": "高年齢労働",
+          "missing_len": 5,
+          "context": "、季節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 500,
+          "missing": "年齢労働者",
+          "missing_len": 5,
+          "context": "季節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 540,
+          "missing": "用事可否格",
+          "missing_len": 5,
+          "context": "技術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "high"
+        },
+        {
+          "line": 540,
+          "missing": "事可否格付",
+          "missing_len": 5,
+          "context": "術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "high"
+        },
+        {
+          "line": 652,
+          "missing": "問題発生時",
+          "missing_len": 5,
+          "context": "メンター制度の正しい知識と必要なスキルを身につけ、問題発生時の対処法等を学ぶことであり、対象者はメンターとメン",
+          "confidence": "high"
+        },
+        {
+          "line": 781,
+          "missing": "人格的側面",
+          "missing_len": 5,
+          "context": "2. 肖像の人格的側面は、肖像権によって保護されている。",
+          "confidence": "high"
+        },
+        {
+          "line": 783,
+          "missing": "像権侵害否",
+          "missing_len": 5,
+          "context": "度でいる人間の姿が映っていても、受忍限度内として肖像権侵害否定されることが多い。",
+          "confidence": "high"
+        },
+        {
+          "line": 783,
+          "missing": "権侵害否定",
+          "missing_len": 5,
+          "context": "でいる人間の姿が映っていても、受忍限度内として肖像権侵害否定されることが多い。",
+          "confidence": "high"
+        },
+        {
+          "line": 819,
+          "missing": "絶修復時間",
+          "missing_len": 5,
+          "context": "る。運用開始から現時点までの絶時間（実際稼働時間と絶修復時間の和）、稼働率（絶時間に対する実際稼働時間の比）、",
+          "confidence": "high"
+        },
+        {
+          "line": 948,
+          "missing": "比較的最近",
+          "missing_len": 5,
+          "context": "、社会的受容という用語が用いられるようになったのは比較的最近のことではなく、例えば2000年以前に原子力などの",
+          "confidence": "high"
+        },
+        {
+          "line": 991,
+          "missing": "占禁止法違",
+          "missing_len": 5,
+          "context": "4. 独占禁止法違反への関与を自主的に申告し、社内調査に協力した者に",
+          "confidence": "high"
+        },
+        {
+          "line": 991,
+          "missing": "禁止法違反",
+          "missing_len": 5,
+          "context": "4. 独占禁止法違反への関与を自主的に申告し、社内調査に協力した者に対",
+          "confidence": "high"
+        },
+        {
+          "line": 992,
+          "missing": "占禁止法違",
+          "missing_len": 5,
+          "context": "5. 独占禁止法違反の疑いが生じた場合に、公正取引委員会からの指示を",
+          "confidence": "high"
+        },
+        {
+          "line": 992,
+          "missing": "禁止法違反",
+          "missing_len": 5,
+          "context": "5. 独占禁止法違反の疑いが生じた場合に、公正取引委員会からの指示を受",
+          "confidence": "high"
+        },
+        {
+          "line": 1029,
+          "missing": "情報流出防",
+          "missing_len": 5,
+          "context": "で内側と外側を遮断して、外部からの攻撃や内部からの情報流出防止しようとする考え方である。",
+          "confidence": "high"
+        },
+        {
+          "line": 1029,
+          "missing": "報流出防止",
+          "missing_len": 5,
+          "context": "内側と外側を遮断して、外部からの攻撃や内部からの情報流出防止しようとする考え方である。",
+          "confidence": "high"
+        },
+        {
+          "line": 1072,
+          "missing": "危機予知訓",
+          "missing_len": 5,
+          "context": "2. 危機予知訓練は、作業や職場におけもや危険性や害性等の危険要因",
+          "confidence": "high"
+        },
+        {
+          "line": 1072,
+          "missing": "機予知訓練",
+          "missing_len": 5,
+          "context": "2. 危機予知訓練は、作業や職場におけもや危険性や害性等の危険要因を",
+          "confidence": "high"
+        },
+        {
+          "line": 1115,
+          "missing": "労働災害對",
+          "missing_len": 5,
+          "context": "2. 企業の社会的責任として、労働災害對策に加え、環境や品質などを含めより広範な安全で安心",
+          "confidence": "high"
+        },
+        {
+          "line": 1115,
+          "missing": "働災害對策",
+          "missing_len": 5,
+          "context": "2. 企業の社会的責任として、労働災害對策に加え、環境や品質などを含めより広範な安全で安心な",
+          "confidence": "high"
+        },
+        {
+          "line": 1116,
+          "missing": "安全衛生上",
+          "missing_len": 5,
+          "context": "3. 企業経営者は事業運営の最高責任者として労働安全衛生上に関する方針を内外に示すとともに、それに基づいた各",
+          "confidence": "high"
+        },
+        {
+          "line": 1156,
+          "missing": "大規模地震",
+          "missing_len": 5,
+          "context": "性が相対的に高まったと評価されることなく、突発的に大規模地震が発生する可能性もあることから、地震対策は従来おお",
+          "confidence": "high"
+        },
+        {
+          "line": 1196,
+          "missing": "相当情報等",
+          "missing_len": 5,
+          "context": "が避難行動を判断する際に参考となる各種の警成レベル相当情報等を入手しやすくするための環境整備を進めるとともに、",
+          "confidence": "high"
+        },
+        {
+          "line": 1235,
+          "missing": "下水道管路",
+          "missing_len": 5,
+          "context": "朽化について、国土交通省は、所管する河川管理施設、下水道管路（管渠・マンホール）、道路橋、道路トンネル、道路附",
+          "confidence": "high"
+        },
+        {
+          "line": 1237,
+          "missing": "下水道管渠",
+          "missing_len": 5,
+          "context": "、建設後50年以上経過する施設の割合が最も高いのは下水道管渠である。",
+          "confidence": "high"
+        },
+        {
+          "line": 1282,
+          "missing": "信号機停止",
+          "missing_len": 5,
+          "context": "（ウ）信号機停止信号の場合に運転手がスリップして自動的にブレーキが",
+          "confidence": "high"
+        },
+        {
+          "line": 1282,
+          "missing": "号機停止信",
+          "missing_len": 5,
+          "context": "（ウ）信号機停止信号の場合に運転手がスリップして自動的にブレーキがか",
+          "confidence": "high"
+        },
+        {
+          "line": 1282,
+          "missing": "機停止信号",
+          "missing_len": 5,
+          "context": "（ウ）信号機停止信号の場合に運転手がスリップして自動的にブレーキがかか",
+          "confidence": "high"
+        },
+        {
+          "line": 1420,
+          "missing": "排出量削減",
+          "missing_len": 5,
+          "context": "関する国際枠組みである京都議定書では、温室効果ガス排出量削減の法的義務を先進国のみに課していたが、その後継とな",
+          "confidence": "high"
+        },
+        {
+          "line": 1460,
+          "missing": "経済効率性",
+          "missing_len": 5,
+          "context": "前提としたうえで、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、同",
+          "confidence": "high"
+        },
+        {
+          "line": 1462,
+          "missing": "需要関連情",
+          "missing_len": 5,
+          "context": "活用により、太陽光発電、風力発電などの分散型電源や需要関連情報を統合・活用して、高効率、高品質、高信頼度の電力",
+          "confidence": "high"
+        },
+        {
+          "line": 1462,
+          "missing": "要関連情報",
+          "missing_len": 5,
+          "context": "用により、太陽光発電、風力発電などの分散型電源や需要関連情報を統合・活用して、高効率、高品質、高信頼度の電力供",
+          "confidence": "high"
+        },
+        {
+          "line": 1504,
+          "missing": "野生生物観",
+          "missing_len": 5,
+          "context": "進する条約湿地のワイズユースには、エコツーリズムや野生生物観光に含まれるが、稲作などの農業や養殖などの漁業に含",
+          "confidence": "high"
+        },
+        {
+          "line": 1504,
+          "missing": "生生物観光",
+          "missing_len": 5,
+          "context": "する条約湿地のワイズユースには、エコツーリズムや野生生物観光に含まれるが、稲作などの農業や養殖などの漁業に含ま",
+          "confidence": "high"
+        },
+        {
+          "line": 1543,
+          "missing": "環共生圏生",
+          "missing_len": 5,
+          "context": "2. 地域循環共生圏生は、各地域が美しい自然景観等の地域資源を最大限活用",
+          "confidence": "high"
+        },
+        {
+          "line": 1583,
+          "missing": "廃棄物被害",
+          "missing_len": 5,
+          "context": "汚染、水質汚濁、土壌汚染、騒音、振動、地盤沈下及び廃棄物被害の7種類の公害",
+          "confidence": "high"
+        },
+        {
+          "line": 1585,
+          "missing": "窒素酸化物",
+          "missing_len": 5,
+          "context": "3. 光化学オキシダント：窒素酸化物や揮発性有機化合物を主体とする一次汚染物質が太陽光",
+          "confidence": "high"
+        },
+        {
+          "line": 1663,
+          "missing": "第六次環境",
+          "missing_len": 5,
+          "context": "第六次環境基本計画において環境政策の最上位の目的とされた「現",
+          "confidence": "high"
+        },
+        {
+          "line": 1663,
+          "missing": "六次環境基",
+          "missing_len": 5,
+          "context": "第六次環境基本計画において環境政策の最上位の目的とされた「現在",
+          "confidence": "high"
+        },
+        {
+          "line": 26,
+          "missing": "取機的手",
+          "missing_len": 4,
+          "context": "事業継続に関する取機的手象の教訓、関連制度の整備、経済・社会の変化等を踏ま",
+          "confidence": "medium"
+        },
+        {
+          "line": 26,
+          "missing": "機的手象",
+          "missing_len": 4,
+          "context": "事業継続に関する取機的手象の教訓、関連制度の整備、経済・社会の変化等を踏まえ",
+          "confidence": "medium"
+        },
+        {
+          "line": 32,
+          "missing": "被害防止",
+          "missing_len": 4,
+          "context": "・対策として、業務拠点に関しては拠点の建物や設備の被害防止・軽減など、要員確保に関しては重要業務の継続に不可",
+          "confidence": "medium"
+        },
+        {
+          "line": 32,
+          "missing": "代替要員",
+          "missing_len": 4,
+          "context": "確保に関しては重要業務の継続に不可欠な要員に対する代替要員の事前育成・確保などについて検討する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 32,
+          "missing": "事前育成",
+          "missing_len": 4,
+          "context": "ては重要業務の継続に不可欠な要員に対する代替要員の事前育成・確保などについて検討する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 162,
+          "missing": "設備故障",
+          "missing_len": 4,
+          "context": "2. 事後保全活動を見直すことで、設備故障の発生による生じる修理作業等の時間を短縮した。",
+          "confidence": "medium"
+        },
+        {
+          "line": 162,
+          "missing": "理作業等",
+          "missing_len": 4,
+          "context": "全活動を見直すことで、設備故障の発生による生じる修理作業等の時間を短縮した。",
+          "confidence": "medium"
+        },
+        {
+          "line": 163,
+          "missing": "作業者数",
+          "missing_len": 4,
+          "context": "より、段取作業による設備の停止時間を変えることなく作業者数を減らした。",
+          "confidence": "medium"
+        },
+        {
+          "line": 241,
+          "missing": "数値実験",
+          "missing_len": 4,
+          "context": "ンは、システムの動作をモデル化し、乱数を用いないで数値実験を何度も繰り返すことで予測や最適化を行う手法であり",
+          "confidence": "medium"
+        },
+        {
+          "line": 244,
+          "missing": "決定変数",
+          "missing_len": 4,
+          "context": "の等式あるいは不等式で与えられる線形制約のもとで、決定変数の積で表される目的関数を、最大化又は最小化する問題",
+          "confidence": "medium"
+        },
+        {
+          "line": 284,
+          "missing": "毎期見直",
+          "missing_len": 4,
+          "context": "る企業会計原則は、採用した処理の原則、手続、方法を毎期見直し、改定することを求めている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 285,
+          "missing": "必要経費",
+          "missing_len": 4,
+          "context": "資産の取得に要した金額を一定の方法によって各年分の必要経費として配分していく手続である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 287,
+          "missing": "投資活動",
+          "missing_len": 4,
+          "context": "ロー計算書は、営業活動におけるキャッシュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャッ",
+          "confidence": "medium"
+        },
+        {
+          "line": 287,
+          "missing": "社会貢献",
+          "missing_len": 4,
+          "context": "ッシュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャッシュ・フロー の3つの部分から構成",
+          "confidence": "medium"
+        },
+        {
+          "line": 287,
+          "missing": "会貢献活",
+          "missing_len": 4,
+          "context": "シュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャッシュ・フロー の3つの部分から構成さ",
+          "confidence": "medium"
+        },
+        {
+          "line": 287,
+          "missing": "貢献活動",
+          "missing_len": 4,
+          "context": "ュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャッシュ・フロー の3つの部分から構成され",
+          "confidence": "medium"
+        },
+        {
+          "line": 378,
+          "missing": "所属労働",
+          "missing_len": 4,
+          "context": "5. 災害等による臨時の必要がある場合、使用者は、所属労働基準監督官の許可を受けて時間外・休日の労働時間の上",
+          "confidence": "medium"
+        },
+        {
+          "line": 378,
+          "missing": "属労働基",
+          "missing_len": 4,
+          "context": ". 災害等による臨時の必要がある場合、使用者は、所属労働基準監督官の許可を受けて時間外・休日の労働時間の上限",
+          "confidence": "medium"
+        },
+        {
+          "line": 378,
+          "missing": "準監督官",
+          "missing_len": 4,
+          "context": "等による臨時の必要がある場合、使用者は、所属労働基準監督官の許可を受けて時間外・休日の労働時間の上限規制を超",
+          "confidence": "medium"
+        },
+        {
+          "line": 418,
+          "missing": "働者等集",
+          "missing_len": 4,
+          "context": "主は、その雇用する短時間労働者等について、通常の労働者等集を行う場合の募集内容の周囲、通常の労働者のポストを",
+          "confidence": "medium"
+        },
+        {
+          "line": 418,
+          "missing": "募集内容",
+          "missing_len": 4,
+          "context": "時間労働者等について、通常の労働者等集を行う場合の募集内容の周囲、通常の労働者のポストを社内公募する場合の応",
+          "confidence": "medium"
+        },
+        {
+          "line": 419,
+          "missing": "同一短時",
+          "missing_len": 4,
+          "context": "力を有している場合を除き、職務内容が通常の労働者と同一短時間労働者等に対しても実施しなければならない。",
+          "confidence": "medium"
+        },
+        {
+          "line": 419,
+          "missing": "一短時間",
+          "missing_len": 4,
+          "context": "を有している場合を除き、職務内容が通常の労働者と同一短時間労働者等に対しても実施しなければならない。",
+          "confidence": "medium"
+        },
+        {
+          "line": 457,
+          "missing": "常時雇用",
+          "missing_len": 4,
+          "context": "1. 常時雇用する労働者の数が50人以上の事業場では、事業者は、",
+          "confidence": "medium"
+        },
+        {
+          "line": 500,
+          "missing": "雇労働者",
+          "missing_len": 4,
+          "context": "は、一定の要件を満たした、季節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 500,
+          "missing": "高年齢労",
+          "missing_len": 4,
+          "context": "、季節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 500,
+          "missing": "年齢労働",
+          "missing_len": 4,
+          "context": "季節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 500,
+          "missing": "齢労働者",
+          "missing_len": 4,
+          "context": "節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 539,
+          "missing": "仕事意欲",
+          "missing_len": 4,
+          "context": "職務行動をとることで組織業績に貢献し、長期持続的な仕事意欲の維持が期待できる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 540,
+          "missing": "企業業績",
+          "missing_len": 4,
+          "context": "定分野における専門知識や技術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 540,
+          "missing": "貢献度並",
+          "missing_len": 4,
+          "context": "る専門知識や技術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 540,
+          "missing": "用事可否",
+          "missing_len": 4,
+          "context": "技術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 540,
+          "missing": "事可否格",
+          "missing_len": 4,
+          "context": "術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 540,
+          "missing": "可否格付",
+          "missing_len": 4,
+          "context": "の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 596,
+          "missing": "新人社員",
+          "missing_len": 4,
+          "context": "動スタイルを変えることなく接したため、経験の乏しい新人社員に対しては、タスク面への関心に直く置く指示型の行動",
+          "confidence": "medium"
+        },
+        {
+          "line": 652,
+          "missing": "題発生時",
+          "missing_len": 4,
+          "context": "ンター制度の正しい知識と必要なスキルを身につけ、問題発生時の対処法等を学ぶことであり、対象者はメンターとメン",
+          "confidence": "medium"
+        },
+        {
+          "line": 781,
+          "missing": "人格的側",
+          "missing_len": 4,
+          "context": "2. 肖像の人格的側面は、肖像権によって保護されている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 781,
+          "missing": "格的側面",
+          "missing_len": 4,
+          "context": "2. 肖像の人格的側面は、肖像権によって保護されている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 782,
+          "missing": "別途検討",
+          "missing_len": 4,
+          "context": "る場合、著作権を処理しても なお、肖像権については別途検討する必要がある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 783,
+          "missing": "権侵害否",
+          "missing_len": 4,
+          "context": "でいる人間の姿が映っていても、受忍限度内として肖像権侵害否定されることが多い。",
+          "confidence": "medium"
+        },
+        {
+          "line": 783,
+          "missing": "侵害否定",
+          "missing_len": 4,
+          "context": "いる人間の姿が映っていても、受忍限度内として肖像権侵害否定されることが多い。",
+          "confidence": "medium"
+        },
+        {
+          "line": 819,
+          "missing": "絶修復時",
+          "missing_len": 4,
+          "context": "る。運用開始から現時点までの絶時間（実際稼働時間と絶修復時間の和）、稼働率（絶時間に対する実際稼働時間の比）",
+          "confidence": "medium"
+        },
+        {
+          "line": 819,
+          "missing": "故障件数",
+          "missing_len": 4,
+          "context": "の和）、稼働率（絶時間に対する実際稼働時間の比）、故障件数を調べ、機種ごとに集計したところ下表が得られた。各",
+          "confidence": "medium"
+        },
+        {
+          "line": 821,
+          "missing": "故障件数",
+          "missing_len": 4,
+          "context": "| | 絶時間（時間） | 稼働率 | 故障件数（件） |",
+          "confidence": "medium"
+        },
+        {
+          "line": 870,
+          "missing": "国際規格",
+          "missing_len": 4,
+          "context": "、組織がISMSを構築するための要求事項をまとめた国際規格であり、このJIS規格がJIS Q 27001であ",
+          "confidence": "medium"
+        },
+        {
+          "line": 946,
+          "missing": "受興技術",
+          "missing_len": 4,
+          "context": "科学技術イノベーション受興技術の社会的受容に関する次の記述のうち、最も不適切なも",
+          "confidence": "medium"
+        },
+        {
+          "line": 948,
+          "missing": "比較的最",
+          "missing_len": 4,
+          "context": "、社会的受容という用語が用いられるようになったのは比較的最近のことではなく、例えば2000年以前に原子力など",
+          "confidence": "medium"
+        },
+        {
+          "line": 948,
+          "missing": "較的最近",
+          "missing_len": 4,
+          "context": "社会的受容という用語が用いられるようになったのは比較的最近のことではなく、例えば2000年以前に原子力などの",
+          "confidence": "medium"
+        },
+        {
+          "line": 989,
+          "missing": "常時雇用",
+          "missing_len": 4,
+          "context": "2. すべての事業者は、常時雇用する労働者の数に関わらず、公益通報に適切に対応する",
+          "confidence": "medium"
+        },
+        {
+          "line": 991,
+          "missing": "禁止法違",
+          "missing_len": 4,
+          "context": "4. 独占禁止法違反への関与を自主的に申告し、社内調査に協力した者に",
+          "confidence": "medium"
+        },
+        {
+          "line": 991,
+          "missing": "止法違反",
+          "missing_len": 4,
+          "context": "4. 独占禁止法違反への関与を自主的に申告し、社内調査に協力した者に対",
+          "confidence": "medium"
+        },
+        {
+          "line": 992,
+          "missing": "禁止法違",
+          "missing_len": 4,
+          "context": "5. 独占禁止法違反の疑いが生じた場合に、公正取引委員会からの指示を",
+          "confidence": "medium"
+        },
+        {
+          "line": 992,
+          "missing": "止法違反",
+          "missing_len": 4,
+          "context": "5. 独占禁止法違反の疑いが生じた場合に、公正取引委員会からの指示を受",
+          "confidence": "medium"
+        },
+        {
+          "line": 992,
+          "missing": "事実関係",
+          "missing_len": 4,
+          "context": "じた場合に、公正取引委員会からの指示を受ける前に、事実関係の社内調査に取り掛かってはならない。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1029,
+          "missing": "報流出防",
+          "missing_len": 4,
+          "context": "内側と外側を遮断して、外部からの攻撃や内部からの情報流出防止しようとする考え方である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1029,
+          "missing": "流出防止",
+          "missing_len": 4,
+          "context": "側と外側を遮断して、外部からの攻撃や内部からの情報流出防止しようとする考え方である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1072,
+          "missing": "危機予知",
+          "missing_len": 4,
+          "context": "2. 危機予知訓練は、作業や職場におけもや危険性や害性等の危険要",
+          "confidence": "medium"
+        },
+        {
+          "line": 1072,
+          "missing": "機予知訓",
+          "missing_len": 4,
+          "context": "2. 危機予知訓練は、作業や職場におけもや危険性や害性等の危険要因",
+          "confidence": "medium"
+        },
+        {
+          "line": 1115,
+          "missing": "働災害對",
+          "missing_len": 4,
+          "context": "2. 企業の社会的責任として、労働災害對策に加え、環境や品質などを含めより広範な安全で安心",
+          "confidence": "medium"
+        },
+        {
+          "line": 1115,
+          "missing": "災害對策",
+          "missing_len": 4,
+          "context": "2. 企業の社会的責任として、労働災害對策に加え、環境や品質などを含めより広範な安全で安心な",
+          "confidence": "medium"
+        },
+        {
+          "line": 1116,
+          "missing": "全衛生上",
+          "missing_len": 4,
+          "context": "3. 企業経営者は事業運営の最高責任者として労働安全衛生上に関する方針を内外に示すとともに、それに基づいた各",
+          "confidence": "medium"
+        },
+        {
+          "line": 1156,
+          "missing": "大規模地",
+          "missing_len": 4,
+          "context": "性が相対的に高まったと評価されることなく、突発的に大規模地震が発生する可能性もあることから、地震対策は従来お",
+          "confidence": "medium"
+        },
+        {
+          "line": 1196,
+          "missing": "当情報等",
+          "missing_len": 4,
+          "context": "避難行動を判断する際に参考となる各種の警成レベル相当情報等を入手しやすくするための環境整備を進めるとともに、",
+          "confidence": "medium"
+        },
+        {
+          "line": 1196,
+          "missing": "入手手段",
+          "missing_len": 4,
+          "context": "環境整備を進めるとともに、居住者等に対して、情報の入手手段や活用方法等について平時から周知しておくべきである",
+          "confidence": "medium"
+        },
+        {
+          "line": 1200,
+          "missing": "要配置者",
+          "missing_len": 4,
+          "context": "避難は、災害が発生し、避難に時間を要する高齢者等の要配置者を緊急に避難させる必要がある場合において、要配置者",
+          "confidence": "medium"
+        },
+        {
+          "line": 1235,
+          "missing": "水道管路",
+          "missing_len": 4,
+          "context": "化について、国土交通省は、所管する河川管理施設、下水道管路（管渠・マンホール）、道路橋、道路トンネル、道路附",
+          "confidence": "medium"
+        },
+        {
+          "line": 1237,
+          "missing": "水道管渠",
+          "missing_len": 4,
+          "context": "建設後50年以上経過する施設の割合が最も高いのは下水道管渠である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1238,
+          "missing": "更新費用",
+          "missing_len": 4,
+          "context": "2. インフラの将来の維持管理・更新費用は、事後保全の考え方を基本とするよりも、予防保全の",
+          "confidence": "medium"
+        },
+        {
+          "line": 1238,
+          "missing": "予防保全",
+          "missing_len": 4,
+          "context": "・更新費用は、事後保全の考え方を基本とするよりも、予防保全の考え方を基本とする方が少ないと推奨されている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1240,
+          "missing": "人口減少",
+          "missing_len": 4,
+          "context": "4. 人口減少、地球温暖化等の進展が見込まれる中、インフラに求め",
+          "confidence": "medium"
+        },
+        {
+          "line": 1241,
+          "missing": "実施可能",
+          "missing_len": 4,
+          "context": "るため、新設・更新時には、維持管理が容易かつ確実に実施可能な構造を採用する等、合理的な対策を選択することが必",
+          "confidence": "medium"
+        },
+        {
+          "line": 1278,
+          "missing": "共有領域",
+          "missing_len": 4,
+          "context": "全に加えて協調安全を適用することにより、人の領域、共有領域、機械の領域におけるリスクを最小化する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1282,
+          "missing": "信号機停",
+          "missing_len": 4,
+          "context": "（ウ）信号機停止信号の場合に運転手がスリップして自動的にブレーキ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1282,
+          "missing": "号機停止",
+          "missing_len": 4,
+          "context": "（ウ）信号機停止信号の場合に運転手がスリップして自動的にブレーキが",
+          "confidence": "medium"
+        },
+        {
+          "line": 1282,
+          "missing": "機停止信",
+          "missing_len": 4,
+          "context": "（ウ）信号機停止信号の場合に運転手がスリップして自動的にブレーキがか",
+          "confidence": "medium"
+        },
+        {
+          "line": 1282,
+          "missing": "保安制御",
+          "missing_len": 4,
+          "context": "運転手がスリップして自動的にブレーキがかかる鉄道の保安制御など、各産業界で固有の安全性技術が発達した。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1418,
+          "missing": "国際会議",
+          "missing_len": 4,
+          "context": "1世紀に向けた人類の取組に関する国際合意が得られた国際会議である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1420,
+          "missing": "排出量削",
+          "missing_len": 4,
+          "context": "関する国際枠組みである京都議定書では、温室効果ガス排出量削減の法的義務を先進国のみに課していたが、その後継と",
+          "confidence": "medium"
+        },
+        {
+          "line": 1420,
+          "missing": "出量削減",
+          "missing_len": 4,
+          "context": "する国際枠組みである京都議定書では、温室効果ガス排出量削減の法的義務を先進国のみに課していたが、その後継とな",
+          "confidence": "medium"
+        },
+        {
+          "line": 1421,
+          "missing": "達成目標",
+          "missing_len": 4,
+          "context": "ンダの中で掲げられた世界共通の目標で、2030年を達成目標とし、17のゴール等から構成されている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1460,
+          "missing": "経済効率",
+          "missing_len": 4,
+          "context": "前提としたうえで、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、",
+          "confidence": "medium"
+        },
+        {
+          "line": 1460,
+          "missing": "済効率性",
+          "missing_len": 4,
+          "context": "提としたうえで、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、同",
+          "confidence": "medium"
+        },
+        {
+          "line": 1462,
+          "missing": "需要関連",
+          "missing_len": 4,
+          "context": "活用により、太陽光発電、風力発電などの分散型電源や需要関連情報を統合・活用して、高効率、高品質、高信頼度の電",
+          "confidence": "medium"
+        },
+        {
+          "line": 1462,
+          "missing": "要関連情",
+          "missing_len": 4,
+          "context": "用により、太陽光発電、風力発電などの分散型電源や需要関連情報を統合・活用して、高効率、高品質、高信頼度の電力",
+          "confidence": "medium"
+        },
+        {
+          "line": 1462,
+          "missing": "関連情報",
+          "missing_len": 4,
+          "context": "により、太陽光発電、風力発電などの分散型電源や需要関連情報を統合・活用して、高効率、高品質、高信頼度の電力供",
+          "confidence": "medium"
+        },
+        {
+          "line": 1463,
+          "missing": "資金調達",
+          "missing_len": 4,
+          "context": "が、省エネルギー診断、設計・施工、運転・維持管理、資金調達などにかかるすべてのサービスを提供し、そのすべての",
+          "confidence": "medium"
+        },
+        {
+          "line": 1498,
+          "missing": "登録湿地",
+          "missing_len": 4,
+          "context": "か。なお、以下において、条約湿地はラムサール条約の登録湿地を指す。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1504,
+          "missing": "生生物観",
+          "missing_len": 4,
+          "context": "する条約湿地のワイズユースには、エコツーリズムや野生生物観光に含まれるが、稲作などの農業や養殖などの漁業に含",
+          "confidence": "medium"
+        },
+        {
+          "line": 1504,
+          "missing": "生物観光",
+          "missing_len": 4,
+          "context": "る条約湿地のワイズユースには、エコツーリズムや野生生物観光に含まれるが、稲作などの農業や養殖などの漁業に含ま",
+          "confidence": "medium"
+        },
+        {
+          "line": 1543,
+          "missing": "共生圏生",
+          "missing_len": 4,
+          "context": "2. 地域循環共生圏生は、各地域が美しい自然景観等の地域資源を最大限活用",
+          "confidence": "medium"
+        },
+        {
+          "line": 1583,
+          "missing": "廃棄物被",
+          "missing_len": 4,
+          "context": "汚染、水質汚濁、土壌汚染、騒音、振動、地盤沈下及び廃棄物被害の7種類の公害",
+          "confidence": "medium"
+        },
+        {
+          "line": 1583,
+          "missing": "棄物被害",
+          "missing_len": 4,
+          "context": "染、水質汚濁、土壌汚染、騒音、振動、地盤沈下及び廃棄物被害の7種類の公害",
+          "confidence": "medium"
+        },
+        {
+          "line": 1585,
+          "missing": "窒素酸化",
+          "missing_len": 4,
+          "context": "3. 光化学オキシダント：窒素酸化物や揮発性有機化合物を主体とする一次汚染物質が太陽",
+          "confidence": "medium"
+        },
+        {
+          "line": 1625,
+          "missing": "沈澱処理",
+          "missing_len": 4,
+          "context": "2. ALPS処理では、薬液による沈澱処理や活性炭・吸着材による吸着を繰り返して放射性物質を",
+          "confidence": "medium"
+        },
+        {
+          "line": 1663,
+          "missing": "第六次環",
+          "missing_len": 4,
+          "context": "第六次環境基本計画において環境政策の最上位の目的とされた「",
+          "confidence": "medium"
+        },
+        {
+          "line": 1663,
+          "missing": "六次環境",
+          "missing_len": 4,
+          "context": "第六次環境基本計画において環境政策の最上位の目的とされた「現",
+          "confidence": "medium"
+        },
+        {
+          "line": 26,
+          "missing": "取機的",
+          "missing_len": 3,
+          "context": "事業継続に関する取機的手象の教訓、関連制度の整備、経済・社会の変化等を踏",
+          "confidence": "low"
+        },
+        {
+          "line": 26,
+          "missing": "機的手",
+          "missing_len": 3,
+          "context": "事業継続に関する取機的手象の教訓、関連制度の整備、経済・社会の変化等を踏ま",
+          "confidence": "low"
+        },
+        {
+          "line": 26,
+          "missing": "的手象",
+          "missing_len": 3,
+          "context": "事業継続に関する取機的手象の教訓、関連制度の整備、経済・社会の変化等を踏まえ",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "委託先",
+          "missing_len": 3,
+          "context": "社の人的・物的被害の軽減が主である目的であるため、委託先・調達先・供給先などは、BCMの活動や対策の検討範",
+          "confidence": "low"
+        },
+        {
+          "line": 30,
+          "missing": "定量的",
+          "missing_len": 3,
+          "context": "場合の影響の大きさ及びその変化を時系列にできるだけ定量的に評価し、自社にとっての重要な製品・サービスを特定",
+          "confidence": "low"
+        },
+        {
+          "line": 32,
+          "missing": "被害防",
+          "missing_len": 3,
+          "context": "・対策として、業務拠点に関しては拠点の建物や設備の被害防止・軽減など、要員確保に関しては重要業務の継続に不",
+          "confidence": "low"
+        },
+        {
+          "line": 32,
+          "missing": "代替要",
+          "missing_len": 3,
+          "context": "確保に関しては重要業務の継続に不可欠な要員に対する代替要員の事前育成・確保などについて検討する。",
+          "confidence": "low"
+        },
+        {
+          "line": 32,
+          "missing": "替要員",
+          "missing_len": 3,
+          "context": "保に関しては重要業務の継続に不可欠な要員に対する代替要員の事前育成・確保などについて検討する。",
+          "confidence": "low"
+        },
+        {
+          "line": 32,
+          "missing": "前育成",
+          "missing_len": 3,
+          "context": "は重要業務の継続に不可欠な要員に対する代替要員の事前育成・確保などについて検討する。",
+          "confidence": "low"
+        },
+        {
+          "line": 162,
+          "missing": "設備故",
+          "missing_len": 3,
+          "context": "2. 事後保全活動を見直すことで、設備故障の発生による生じる修理作業等の時間を短縮した。",
+          "confidence": "low"
+        },
+        {
+          "line": 162,
+          "missing": "備故障",
+          "missing_len": 3,
+          "context": "2. 事後保全活動を見直すことで、設備故障の発生による生じる修理作業等の時間を短縮した。",
+          "confidence": "low"
+        },
+        {
+          "line": 162,
+          "missing": "作業等",
+          "missing_len": 3,
+          "context": "活動を見直すことで、設備故障の発生による生じる修理作業等の時間を短縮した。",
+          "confidence": "low"
+        },
+        {
+          "line": 163,
+          "missing": "作業者",
+          "missing_len": 3,
+          "context": "より、段取作業による設備の停止時間を変えることなく作業者数を減らした。",
+          "confidence": "low"
+        },
+        {
+          "line": 163,
+          "missing": "業者数",
+          "missing_len": 3,
+          "context": "り、段取作業による設備の停止時間を変えることなく作業者数を減らした。",
+          "confidence": "low"
+        },
+        {
+          "line": 203,
+          "missing": "簡素化",
+          "missing_len": 3,
+          "context": "はReuse（再利用）、「S」はSimplify（簡素化）を指す。",
+          "confidence": "low"
+        },
+        {
+          "line": 241,
+          "missing": "数値実",
+          "missing_len": 3,
+          "context": "ンは、システムの動作をモデル化し、乱数を用いないで数値実験を何度も繰り返すことで予測や最適化を行う手法であ",
+          "confidence": "low"
+        },
+        {
+          "line": 244,
+          "missing": "定変数",
+          "missing_len": 3,
+          "context": "等式あるいは不等式で与えられる線形制約のもとで、決定変数の積で表される目的関数を、最大化又は最小化する問題",
+          "confidence": "low"
+        },
+        {
+          "line": 284,
+          "missing": "期見直",
+          "missing_len": 3,
+          "context": "企業会計原則は、採用した処理の原則、手続、方法を毎期見直し、改定することを求めている。",
+          "confidence": "low"
+        },
+        {
+          "line": 285,
+          "missing": "必要経",
+          "missing_len": 3,
+          "context": "資産の取得に要した金額を一定の方法によって各年分の必要経費として配分していく手続である。",
+          "confidence": "low"
+        },
+        {
+          "line": 285,
+          "missing": "要経費",
+          "missing_len": 3,
+          "context": "産の取得に要した金額を一定の方法によって各年分の必要経費として配分していく手続である。",
+          "confidence": "low"
+        },
+        {
+          "line": 287,
+          "missing": "投資活",
+          "missing_len": 3,
+          "context": "ロー計算書は、営業活動におけるキャッシュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャ",
+          "confidence": "low"
+        },
+        {
+          "line": 287,
+          "missing": "社会貢",
+          "missing_len": 3,
+          "context": "ッシュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャッシュ・フロー の3つの部分から構",
+          "confidence": "low"
+        },
+        {
+          "line": 287,
+          "missing": "会貢献",
+          "missing_len": 3,
+          "context": "シュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャッシュ・フロー の3つの部分から構成",
+          "confidence": "low"
+        },
+        {
+          "line": 287,
+          "missing": "貢献活",
+          "missing_len": 3,
+          "context": "ュ・フロー、投資活動によるキャッシュ・フロー、社会貢献活動によるキャッシュ・フロー の3つの部分から構成さ",
+          "confidence": "low"
+        },
+        {
+          "line": 324,
+          "missing": "作業名",
+          "missing_len": 3,
+          "context": "| 作業名 | 先行作業 | 所要日数（日） |",
+          "confidence": "low"
+        },
+        {
+          "line": 378,
+          "missing": "所属労",
+          "missing_len": 3,
+          "context": "5. 災害等による臨時の必要がある場合、使用者は、所属労働基準監督官の許可を受けて時間外・休日の労働時間の",
+          "confidence": "low"
+        },
+        {
+          "line": 378,
+          "missing": "属労働",
+          "missing_len": 3,
+          "context": ". 災害等による臨時の必要がある場合、使用者は、所属労働基準監督官の許可を受けて時間外・休日の労働時間の上",
+          "confidence": "low"
+        },
+        {
+          "line": 378,
+          "missing": "監督官",
+          "missing_len": 3,
+          "context": "による臨時の必要がある場合、使用者は、所属労働基準監督官の許可を受けて時間外・休日の労働時間の上限規制を超",
+          "confidence": "low"
+        },
+        {
+          "line": 418,
+          "missing": "者等集",
+          "missing_len": 3,
+          "context": "は、その雇用する短時間労働者等について、通常の労働者等集を行う場合の募集内容の周囲、通常の労働者のポストを",
+          "confidence": "low"
+        },
+        {
+          "line": 418,
+          "missing": "募集内",
+          "missing_len": 3,
+          "context": "時間労働者等について、通常の労働者等集を行う場合の募集内容の周囲、通常の労働者のポストを社内公募する場合の",
+          "confidence": "low"
+        },
+        {
+          "line": 419,
+          "missing": "同一短",
+          "missing_len": 3,
+          "context": "力を有している場合を除き、職務内容が通常の労働者と同一短時間労働者等に対しても実施しなければならない。",
+          "confidence": "low"
+        },
+        {
+          "line": 419,
+          "missing": "一短時",
+          "missing_len": 3,
+          "context": "を有している場合を除き、職務内容が通常の労働者と同一短時間労働者等に対しても実施しなければならない。",
+          "confidence": "low"
+        },
+        {
+          "line": 457,
+          "missing": "常時雇",
+          "missing_len": 3,
+          "context": "1. 常時雇用する労働者の数が50人以上の事業場では、事業者は",
+          "confidence": "low"
+        },
+        {
+          "line": 457,
+          "missing": "時雇用",
+          "missing_len": 3,
+          "context": "1. 常時雇用する労働者の数が50人以上の事業場では、事業者は、",
+          "confidence": "low"
+        },
+        {
+          "line": 500,
+          "missing": "年齢労",
+          "missing_len": 3,
+          "context": "季節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 500,
+          "missing": "齢労働",
+          "missing_len": 3,
+          "context": "節的に雇用される者、日雇労働者及び65歳以上の高年齢労働者も含まれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 501,
+          "missing": "在職者",
+          "missing_len": 3,
+          "context": "要件を満たせば、離職後一定の期間内にある者のほか、在職者にも支給される。",
+          "confidence": "low"
+        },
+        {
+          "line": 539,
+          "missing": "仕事意",
+          "missing_len": 3,
+          "context": "職務行動をとることで組織業績に貢献し、長期持続的な仕事意欲の維持が期待できる。",
+          "confidence": "low"
+        },
+        {
+          "line": 539,
+          "missing": "事意欲",
+          "missing_len": 3,
+          "context": "務行動をとることで組織業績に貢献し、長期持続的な仕事意欲の維持が期待できる。",
+          "confidence": "low"
+        },
+        {
+          "line": 540,
+          "missing": "企業業",
+          "missing_len": 3,
+          "context": "定分野における専門知識や技術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "low"
+        },
+        {
+          "line": 540,
+          "missing": "献度並",
+          "missing_len": 3,
+          "context": "専門知識や技術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "low"
+        },
+        {
+          "line": 540,
+          "missing": "用事可",
+          "missing_len": 3,
+          "context": "技術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "low"
+        },
+        {
+          "line": 540,
+          "missing": "事可否",
+          "missing_len": 3,
+          "context": "術の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "low"
+        },
+        {
+          "line": 540,
+          "missing": "可否格",
+          "missing_len": 3,
+          "context": "の保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "low"
+        },
+        {
+          "line": 540,
+          "missing": "否格付",
+          "missing_len": 3,
+          "context": "保有状況、業務経験、企業業績への貢献度並びに用事可否格付けが検討される。",
+          "confidence": "low"
+        },
+        {
+          "line": 596,
+          "missing": "新人社",
+          "missing_len": 3,
+          "context": "動スタイルを変えることなく接したため、経験の乏しい新人社員に対しては、タスク面への関心に直く置く指示型の行",
+          "confidence": "low"
+        },
+        {
+          "line": 596,
+          "missing": "人社員",
+          "missing_len": 3,
+          "context": "スタイルを変えることなく接したため、経験の乏しい新人社員に対しては、タスク面への関心に直く置く指示型の行動",
+          "confidence": "low"
+        },
+        {
+          "line": 602,
+          "missing": "価値観",
+          "missing_len": 3,
+          "context": "ーを上意下達で納得させるのではなく、共感を得られる価値観を示し、部下の判断を尊重して合々の力を引き出すこと",
+          "confidence": "low"
+        },
+        {
+          "line": 650,
+          "missing": "検討及",
+          "missing_len": 3,
+          "context": "っては、課題整理と目的の設定、全体計画や推進方法の検討及び経営幹部の理解・協力が重要である。",
+          "confidence": "low"
+        },
+        {
+          "line": 652,
+          "missing": "発生時",
+          "missing_len": 3,
+          "context": "ター制度の正しい知識と必要なスキルを身につけ、問題発生時の対処法等を学ぶことであり、対象者はメンターとメン",
+          "confidence": "low"
+        },
+        {
+          "line": 781,
+          "missing": "格的側",
+          "missing_len": 3,
+          "context": "2. 肖像の人格的側面は、肖像権によって保護されている。",
+          "confidence": "low"
+        },
+        {
+          "line": 781,
+          "missing": "的側面",
+          "missing_len": 3,
+          "context": "2. 肖像の人格的側面は、肖像権によって保護されている。",
+          "confidence": "low"
+        },
+        {
+          "line": 782,
+          "missing": "別途検",
+          "missing_len": 3,
+          "context": "る場合、著作権を処理しても なお、肖像権については別途検討する必要がある。",
+          "confidence": "low"
+        },
+        {
+          "line": 783,
+          "missing": "侵害否",
+          "missing_len": 3,
+          "context": "いる人間の姿が映っていても、受忍限度内として肖像権侵害否定されることが多い。",
+          "confidence": "low"
+        },
+        {
+          "line": 783,
+          "missing": "害否定",
+          "missing_len": 3,
+          "context": "る人間の姿が映っていても、受忍限度内として肖像権侵害否定されることが多い。",
+          "confidence": "low"
+        },
+        {
+          "line": 819,
+          "missing": "絶時間",
+          "missing_len": 3,
+          "context": "）のサーバを使用している。運用開始から現時点までの絶時間（実際稼働時間と絶修復時間の和）、稼働率（絶時間に",
+          "confidence": "low"
+        },
+        {
+          "line": 819,
+          "missing": "絶修復",
+          "missing_len": 3,
+          "context": "る。運用開始から現時点までの絶時間（実際稼働時間と絶修復時間の和）、稼働率（絶時間に対する実際稼働時間の比",
+          "confidence": "low"
+        },
+        {
+          "line": 819,
+          "missing": "故障件",
+          "missing_len": 3,
+          "context": "の和）、稼働率（絶時間に対する実際稼働時間の比）、故障件数を調べ、機種ごとに集計したところ下表が得られた。",
+          "confidence": "low"
+        },
+        {
+          "line": 821,
+          "missing": "絶時間",
+          "missing_len": 3,
+          "context": "| | 絶時間（時間） | 稼働率 | 故障件数（件） |",
+          "confidence": "low"
+        },
+        {
+          "line": 821,
+          "missing": "故障件",
+          "missing_len": 3,
+          "context": "| | 絶時間（時間） | 稼働率 | 故障件数（件） |",
+          "confidence": "low"
+        },
+        {
+          "line": 870,
+          "missing": "際規格",
+          "missing_len": 3,
+          "context": "組織がISMSを構築するための要求事項をまとめた国際規格であり、このJIS規格がJIS Q 27001であ",
+          "confidence": "low"
+        },
+        {
+          "line": 907,
+          "missing": "各段階",
+          "missing_len": 3,
+          "context": "type）、「テスト」（test）の5つの段階と、各段階の説明の組合せとして、最も不適切なものはどれか。",
+          "confidence": "low"
+        },
+        {
+          "line": 946,
+          "missing": "受興技",
+          "missing_len": 3,
+          "context": "科学技術イノベーション受興技術の社会的受容に関する次の記述のうち、最も不適切な",
+          "confidence": "low"
+        },
+        {
+          "line": 948,
+          "missing": "比較的",
+          "missing_len": 3,
+          "context": "、社会的受容という用語が用いられるようになったのは比較的最近のことではなく、例えば2000年以前に原子力な",
+          "confidence": "low"
+        },
+        {
+          "line": 948,
+          "missing": "較的最",
+          "missing_len": 3,
+          "context": "社会的受容という用語が用いられるようになったのは比較的最近のことではなく、例えば2000年以前に原子力など",
+          "confidence": "low"
+        },
+        {
+          "line": 948,
+          "missing": "的最近",
+          "missing_len": 3,
+          "context": "会的受容という用語が用いられるようになったのは比較的最近のことではなく、例えば2000年以前に原子力などの",
+          "confidence": "low"
+        },
+        {
+          "line": 989,
+          "missing": "常時雇",
+          "missing_len": 3,
+          "context": "2. すべての事業者は、常時雇用する労働者の数に関わらず、公益通報に適切に対応す",
+          "confidence": "low"
+        },
+        {
+          "line": 989,
+          "missing": "時雇用",
+          "missing_len": 3,
+          "context": "2. すべての事業者は、常時雇用する労働者の数に関わらず、公益通報に適切に対応する",
+          "confidence": "low"
+        },
+        {
+          "line": 991,
+          "missing": "止法違",
+          "missing_len": 3,
+          "context": "4. 独占禁止法違反への関与を自主的に申告し、社内調査に協力した者に",
+          "confidence": "low"
+        },
+        {
+          "line": 991,
+          "missing": "法違反",
+          "missing_len": 3,
+          "context": "4. 独占禁止法違反への関与を自主的に申告し、社内調査に協力した者に対",
+          "confidence": "low"
+        },
+        {
+          "line": 992,
+          "missing": "止法違",
+          "missing_len": 3,
+          "context": "5. 独占禁止法違反の疑いが生じた場合に、公正取引委員会からの指示を",
+          "confidence": "low"
+        },
+        {
+          "line": 992,
+          "missing": "法違反",
+          "missing_len": 3,
+          "context": "5. 独占禁止法違反の疑いが生じた場合に、公正取引委員会からの指示を受",
+          "confidence": "low"
+        },
+        {
+          "line": 992,
+          "missing": "事実関",
+          "missing_len": 3,
+          "context": "じた場合に、公正取引委員会からの指示を受ける前に、事実関係の社内調査に取り掛かってはならない。",
+          "confidence": "low"
+        },
+        {
+          "line": 1029,
+          "missing": "流出防",
+          "missing_len": 3,
+          "context": "側と外側を遮断して、外部からの攻撃や内部からの情報流出防止しようとする考え方である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1029,
+          "missing": "出防止",
+          "missing_len": 3,
+          "context": "と外側を遮断して、外部からの攻撃や内部からの情報流出防止しようとする考え方である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1030,
+          "missing": "性懐説",
+          "missing_len": 3,
+          "context": "信頼しない、外部も内部も区別なく疑ってかかるという性懐説に基づいた考え方である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1072,
+          "missing": "危機予",
+          "missing_len": 3,
+          "context": "2. 危機予知訓練は、作業や職場におけもや危険性や害性等の危険",
+          "confidence": "low"
+        },
+        {
+          "line": 1072,
+          "missing": "機予知",
+          "missing_len": 3,
+          "context": "2. 危機予知訓練は、作業や職場におけもや危険性や害性等の危険要",
+          "confidence": "low"
+        },
+        {
+          "line": 1115,
+          "missing": "災害對",
+          "missing_len": 3,
+          "context": "2. 企業の社会的責任として、労働災害對策に加え、環境や品質などを含めより広範な安全で安心",
+          "confidence": "low"
+        },
+        {
+          "line": 1115,
+          "missing": "害對策",
+          "missing_len": 3,
+          "context": "2. 企業の社会的責任として、労働災害對策に加え、環境や品質などを含めより広範な安全で安心な",
+          "confidence": "low"
+        },
+        {
+          "line": 1116,
+          "missing": "衛生上",
+          "missing_len": 3,
+          "context": ". 企業経営者は事業運営の最高責任者として労働安全衛生上に関する方針を内外に示すとともに、それに基づいた各",
+          "confidence": "low"
+        },
+        {
+          "line": 1159,
+          "missing": "認識等",
+          "missing_len": 3,
+          "context": "巨大地震警戒）が発表された場合にも、地震へのリスク認識等、日常生活を行いつつ、個々の状況に応じて地震発生に",
+          "confidence": "low"
+        },
+        {
+          "line": 1196,
+          "missing": "情報等",
+          "missing_len": 3,
+          "context": "難行動を判断する際に参考となる各種の警成レベル相当情報等を入手しやすくするための環境整備を進めるとともに、",
+          "confidence": "low"
+        },
+        {
+          "line": 1196,
+          "missing": "入手手",
+          "missing_len": 3,
+          "context": "環境整備を進めるとともに、居住者等に対して、情報の入手手段や活用方法等について平時から周知しておくべきであ",
+          "confidence": "low"
+        },
+        {
+          "line": 1200,
+          "missing": "要配置",
+          "missing_len": 3,
+          "context": "避難は、災害が発生し、避難に時間を要する高齢者等の要配置者を緊急に避難させる必要がある場合において、要配置",
+          "confidence": "low"
+        },
+        {
+          "line": 1200,
+          "missing": "配置者",
+          "missing_len": 3,
+          "context": "難は、災害が発生し、避難に時間を要する高齢者等の要配置者を緊急に避難させる必要がある場合において、要配置者",
+          "confidence": "low"
+        },
+        {
+          "line": 1235,
+          "missing": "道管路",
+          "missing_len": 3,
+          "context": "について、国土交通省は、所管する河川管理施設、下水道管路（管渠・マンホール）、道路橋、道路トンネル、道路附",
+          "confidence": "low"
+        },
+        {
+          "line": 1237,
+          "missing": "道管渠",
+          "missing_len": 3,
+          "context": "設後50年以上経過する施設の割合が最も高いのは下水道管渠である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1238,
+          "missing": "新費用",
+          "missing_len": 3,
+          "context": "2. インフラの将来の維持管理・更新費用は、事後保全の考え方を基本とするよりも、予防保全の",
+          "confidence": "low"
+        },
+        {
+          "line": 1238,
+          "missing": "予防保",
+          "missing_len": 3,
+          "context": "・更新費用は、事後保全の考え方を基本とするよりも、予防保全の考え方を基本とする方が少ないと推奨されている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1238,
+          "missing": "防保全",
+          "missing_len": 3,
+          "context": "更新費用は、事後保全の考え方を基本とするよりも、予防保全の考え方を基本とする方が少ないと推奨されている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1240,
+          "missing": "人口減",
+          "missing_len": 3,
+          "context": "4. 人口減少、地球温暖化等の進展が見込まれる中、インフラに求",
+          "confidence": "low"
+        },
+        {
+          "line": 1240,
+          "missing": "口減少",
+          "missing_len": 3,
+          "context": "4. 人口減少、地球温暖化等の進展が見込まれる中、インフラに求め",
+          "confidence": "low"
+        },
+        {
+          "line": 1241,
+          "missing": "実施可",
+          "missing_len": 3,
+          "context": "るため、新設・更新時には、維持管理が容易かつ確実に実施可能な構造を採用する等、合理的な対策を選択することが",
+          "confidence": "low"
+        },
+        {
+          "line": 1241,
+          "missing": "施可能",
+          "missing_len": 3,
+          "context": "ため、新設・更新時には、維持管理が容易かつ確実に実施可能な構造を採用する等、合理的な対策を選択することが必",
+          "confidence": "low"
+        },
+        {
+          "line": 1278,
+          "missing": "共有領",
+          "missing_len": 3,
+          "context": "全に加えて協調安全を適用することにより、人の領域、共有領域、機械の領域におけるリスクを最小化する。",
+          "confidence": "low"
+        },
+        {
+          "line": 1278,
+          "missing": "有領域",
+          "missing_len": 3,
+          "context": "に加えて協調安全を適用することにより、人の領域、共有領域、機械の領域におけるリスクを最小化する。",
+          "confidence": "low"
+        },
+        {
+          "line": 1282,
+          "missing": "号機停",
+          "missing_len": 3,
+          "context": "（ウ）信号機停止信号の場合に運転手がスリップして自動的にブレーキ",
+          "confidence": "low"
+        },
+        {
+          "line": 1282,
+          "missing": "機停止",
+          "missing_len": 3,
+          "context": "（ウ）信号機停止信号の場合に運転手がスリップして自動的にブレーキが",
+          "confidence": "low"
+        },
+        {
+          "line": 1282,
+          "missing": "保安制",
+          "missing_len": 3,
+          "context": "運転手がスリップして自動的にブレーキがかかる鉄道の保安制御など、各産業界で固有の安全性技術が発達した。",
+          "confidence": "low"
+        },
+        {
+          "line": 1282,
+          "missing": "安制御",
+          "missing_len": 3,
+          "context": "転手がスリップして自動的にブレーキがかかる鉄道の保安制御など、各産業界で固有の安全性技術が発達した。",
+          "confidence": "low"
+        },
+        {
+          "line": 1417,
+          "missing": "紫外線",
+          "missing_len": 3,
+          "context": "1. オゾン層の保護のためのウィーン条約は、紫外線がオゾン層の変化により生ずる悪影響から人の健康及び",
+          "confidence": "low"
+        },
+        {
+          "line": 1417,
+          "missing": "悪影響",
+          "missing_len": 3,
+          "context": "ウィーン条約は、紫外線がオゾン層の変化により生ずる悪影響から人の健康及び環境を保護するために適当な措置をと",
+          "confidence": "low"
+        },
+        {
+          "line": 1418,
+          "missing": "国際会",
+          "missing_len": 3,
+          "context": "1世紀に向けた人類の取組に関する国際合意が得られた国際会議である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1418,
+          "missing": "際会議",
+          "missing_len": 3,
+          "context": "世紀に向けた人類の取組に関する国際合意が得られた国際会議である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1419,
+          "missing": "需要量",
+          "missing_len": 3,
+          "context": "るCO2を吸収したりするのに必要な生態系サービスの需要量を地球の面積で表した指標である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1420,
+          "missing": "排出量",
+          "missing_len": 3,
+          "context": "関する国際枠組みである京都議定書では、温室効果ガス排出量削減の法的義務を先進国のみに課していたが、その後継",
+          "confidence": "low"
+        },
+        {
+          "line": 1420,
+          "missing": "出量削",
+          "missing_len": 3,
+          "context": "する国際枠組みである京都議定書では、温室効果ガス排出量削減の法的義務を先進国のみに課していたが、その後継と",
+          "confidence": "low"
+        },
+        {
+          "line": 1420,
+          "missing": "量削減",
+          "missing_len": 3,
+          "context": "る国際枠組みである京都議定書では、温室効果ガス排出量削減の法的義務を先進国のみに課していたが、その後継とな",
+          "confidence": "low"
+        },
+        {
+          "line": 1421,
+          "missing": "達成目",
+          "missing_len": 3,
+          "context": "ンダの中で掲げられた世界共通の目標で、2030年を達成目標とし、17のゴール等から構成されている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1421,
+          "missing": "成目標",
+          "missing_len": 3,
+          "context": "ダの中で掲げられた世界共通の目標で、2030年を達成目標とし、17のゴール等から構成されている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1460,
+          "missing": "済効率",
+          "missing_len": 3,
+          "context": "提としたうえで、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、",
+          "confidence": "low"
+        },
+        {
+          "line": 1460,
+          "missing": "効率性",
+          "missing_len": 3,
+          "context": "としたうえで、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、同",
+          "confidence": "low"
+        },
+        {
+          "line": 1462,
+          "missing": "需要関",
+          "missing_len": 3,
+          "context": "活用により、太陽光発電、風力発電などの分散型電源や需要関連情報を統合・活用して、高効率、高品質、高信頼度の",
+          "confidence": "low"
+        },
+        {
+          "line": 1462,
+          "missing": "要関連",
+          "missing_len": 3,
+          "context": "用により、太陽光発電、風力発電などの分散型電源や需要関連情報を統合・活用して、高効率、高品質、高信頼度の電",
+          "confidence": "low"
+        },
+        {
+          "line": 1462,
+          "missing": "関連情",
+          "missing_len": 3,
+          "context": "により、太陽光発電、風力発電などの分散型電源や需要関連情報を統合・活用して、高効率、高品質、高信頼度の電力",
+          "confidence": "low"
+        },
+        {
+          "line": 1462,
+          "missing": "連情報",
+          "missing_len": 3,
+          "context": "より、太陽光発電、風力発電などの分散型電源や需要関連情報を統合・活用して、高効率、高品質、高信頼度の電力供",
+          "confidence": "low"
+        },
+        {
+          "line": 1463,
+          "missing": "金調達",
+          "missing_len": 3,
+          "context": "、省エネルギー診断、設計・施工、運転・維持管理、資金調達などにかかるすべてのサービスを提供し、そのすべての",
+          "confidence": "low"
+        },
+        {
+          "line": 1463,
+          "missing": "光熱費",
+          "missing_len": 3,
+          "context": "供し、そのすべての費用を省エネルギー改修で実現する光熱費の削減分で賄うことを基本とする事業である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1498,
+          "missing": "登録湿",
+          "missing_len": 3,
+          "context": "か。なお、以下において、条約湿地はラムサール条約の登録湿地を指す。",
+          "confidence": "low"
+        },
+        {
+          "line": 1498,
+          "missing": "録湿地",
+          "missing_len": 3,
+          "context": "。なお、以下において、条約湿地はラムサール条約の登録湿地を指す。",
+          "confidence": "low"
+        },
+        {
+          "line": 1502,
+          "missing": "沿沢地",
+          "missing_len": 3,
+          "context": "3. ラムサール条約は、淡水域、汽水域における沿沢地、温原、泥炭地及び水域を対象としており、我が国の条",
+          "confidence": "low"
+        },
+        {
+          "line": 1504,
+          "missing": "生物観",
+          "missing_len": 3,
+          "context": "る条約湿地のワイズユースには、エコツーリズムや野生生物観光に含まれるが、稲作などの農業や養殖などの漁業に含",
+          "confidence": "low"
+        },
+        {
+          "line": 1504,
+          "missing": "物観光",
+          "missing_len": 3,
+          "context": "条約湿地のワイズユースには、エコツーリズムや野生生物観光に含まれるが、稲作などの農業や養殖などの漁業に含ま",
+          "confidence": "low"
+        },
+        {
+          "line": 1543,
+          "missing": "生圏生",
+          "missing_len": 3,
+          "context": "2. 地域循環共生圏生は、各地域が美しい自然景観等の地域資源を最大限活用",
+          "confidence": "low"
+        },
+        {
+          "line": 1583,
+          "missing": "棄物被",
+          "missing_len": 3,
+          "context": "染、水質汚濁、土壌汚染、騒音、振動、地盤沈下及び廃棄物被害の7種類の公害",
+          "confidence": "low"
+        },
+        {
+          "line": 1583,
+          "missing": "物被害",
+          "missing_len": 3,
+          "context": "、水質汚濁、土壌汚染、騒音、振動、地盤沈下及び廃棄物被害の7種類の公害",
+          "confidence": "low"
+        },
+        {
+          "line": 1585,
+          "missing": "窒素酸",
+          "missing_len": 3,
+          "context": "3. 光化学オキシダント：窒素酸化物や揮発性有機化合物を主体とする一次汚染物質が太",
+          "confidence": "low"
+        },
+        {
+          "line": 1586,
+          "missing": "直接生",
+          "missing_len": 3,
+          "context": "m以下の小さい粒子で、自然由来ものや物の燃焼により直接生じるものと、SOx、NOx、VOC等のガス状物質が",
+          "confidence": "low"
+        },
+        {
+          "line": 1625,
+          "missing": "沈澱処",
+          "missing_len": 3,
+          "context": "2. ALPS処理では、薬液による沈澱処理や活性炭・吸着材による吸着を繰り返して放射性物質",
+          "confidence": "low"
+        },
+        {
+          "line": 1625,
+          "missing": "澱処理",
+          "missing_len": 3,
+          "context": "2. ALPS処理では、薬液による沈澱処理や活性炭・吸着材による吸着を繰り返して放射性物質を",
+          "confidence": "low"
+        },
+        {
+          "line": 1663,
+          "missing": "第六次",
+          "missing_len": 3,
+          "context": "第六次環境基本計画において環境政策の最上位の目的とされた",
+          "confidence": "low"
+        },
+        {
+          "line": 1663,
+          "missing": "六次環",
+          "missing_len": 3,
+          "context": "第六次環境基本計画において環境政策の最上位の目的とされた「",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R07",
+      "kind": "secondary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R07/R07_試験問題_記述式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r07-secondary/article.mdx",
+      "ocr_text_len": 2595,
+      "mdx_text_lines": 22,
+      "ocr_kanji_ngrams": 540,
+      "mismatch_total": 23,
+      "mismatch_by_confidence": {
+        "high": 6,
+        "medium": 9,
+        "low": 8
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 25,
+          "missing": "世代型社会",
+          "missing_len": 5,
+          "context": "会の実現に向けた「働き方改革実行計画」の推進，「全世代型社会保障構築会議」「こども未来戦略会議」の開催など，我",
+          "confidence": "high"
+        },
+        {
+          "line": 25,
+          "missing": "代型社会保",
+          "missing_len": 5,
+          "context": "の実現に向けた「働き方改革実行計画」の推進，「全世代型社会保障構築会議」「こども未来戦略会議」の開催など，我が",
+          "confidence": "high"
+        },
+        {
+          "line": 25,
+          "missing": "型社会保障",
+          "missing_len": 5,
+          "context": "実現に向けた「働き方改革実行計画」の推進，「全世代型社会保障構築会議」「こども未来戦略会議」の開催など，我が国",
+          "confidence": "high"
+        },
+        {
+          "line": 25,
+          "missing": "社会保障構",
+          "missing_len": 5,
+          "context": "現に向けた「働き方改革実行計画」の推進，「全世代型社会保障構築会議」「こども未来戦略会議」の開催など，我が国と",
+          "confidence": "high"
+        },
+        {
+          "line": 62,
+          "missing": "経済財政政",
+          "missing_len": 5,
+          "context": "し，想定する今後の世界情勢の変化，技術革新の進展，経済財政政策や厚生労働政策の動向，予算の制約等の背景を含めて",
+          "confidence": "high"
+        },
+        {
+          "line": 62,
+          "missing": "済財政政策",
+          "missing_len": 5,
+          "context": "，想定する今後の世界情勢の変化，技術革新の進展，経済財政政策や厚生労働政策の動向，予算の制約等の背景を含めて，",
+          "confidence": "high"
+        },
+        {
+          "line": 23,
+          "missing": "高齢化率",
+          "missing_len": 4,
+          "context": "6年10月現在65歳以上人口が総人口に占める割合（高齢化率）が29.3％に達し，今後も伸び続けると推測されて",
+          "confidence": "medium"
+        },
+        {
+          "line": 25,
+          "missing": "代型社会",
+          "missing_len": 4,
+          "context": "の実現に向けた「働き方改革実行計画」の推進，「全世代型社会保障構築会議」「こども未来戦略会議」の開催など，我",
+          "confidence": "medium"
+        },
+        {
+          "line": 25,
+          "missing": "型社会保",
+          "missing_len": 4,
+          "context": "実現に向けた「働き方改革実行計画」の推進，「全世代型社会保障構築会議」「こども未来戦略会議」の開催など，我が",
+          "confidence": "medium"
+        },
+        {
+          "line": 25,
+          "missing": "社会保障",
+          "missing_len": 4,
+          "context": "現に向けた「働き方改革実行計画」の推進，「全世代型社会保障構築会議」「こども未来戦略会議」の開催など，我が国",
+          "confidence": "medium"
+        },
+        {
+          "line": 27,
+          "missing": "製品製造",
+          "missing_len": 4,
+          "context": "に経験した，若しくはよく知っている事業（研究開発・製品製造・販売等の業務機能の集合体としての事業，個々のプロ",
+          "confidence": "medium"
+        },
+        {
+          "line": 27,
+          "missing": "成果物等",
+          "missing_len": 4,
+          "context": "もできる。）を1つ取り上げ，その目的や創出している成果物等を踏まえ，少子高齢化に伴う課題と施策について，総合",
+          "confidence": "medium"
+        },
+        {
+          "line": 29,
+          "missing": "業務全体",
+          "missing_len": 4,
+          "context": "技術監理の視点とは，トレードオフに留意しながら，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報",
+          "confidence": "medium"
+        },
+        {
+          "line": 62,
+          "missing": "経済財政",
+          "missing_len": 4,
+          "context": "し，想定する今後の世界情勢の変化，技術革新の進展，経済財政政策や厚生労働政策の動向，予算の制約等の背景を含め",
+          "confidence": "medium"
+        },
+        {
+          "line": 62,
+          "missing": "済財政政",
+          "missing_len": 4,
+          "context": "，想定する今後の世界情勢の変化，技術革新の進展，経済財政政策や厚生労働政策の動向，予算の制約等の背景を含めて",
+          "confidence": "medium"
+        },
+        {
+          "line": 23,
+          "missing": "齢化率",
+          "missing_len": 3,
+          "context": "年10月現在65歳以上人口が総人口に占める割合（高齢化率）が29.3％に達し，今後も伸び続けると推測されて",
+          "confidence": "low"
+        },
+        {
+          "line": 25,
+          "missing": "型社会",
+          "missing_len": 3,
+          "context": "実現に向けた「働き方改革実行計画」の推進，「全世代型社会保障構築会議」「こども未来戦略会議」の開催など，我",
+          "confidence": "low"
+        },
+        {
+          "line": 25,
+          "missing": "社会保",
+          "missing_len": 3,
+          "context": "現に向けた「働き方改革実行計画」の推進，「全世代型社会保障構築会議」「こども未来戦略会議」の開催など，我が",
+          "confidence": "low"
+        },
+        {
+          "line": 27,
+          "missing": "品製造",
+          "missing_len": 3,
+          "context": "経験した，若しくはよく知っている事業（研究開発・製品製造・販売等の業務機能の集合体としての事業，個々のプロ",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "業務全",
+          "missing_len": 3,
+          "context": "技術監理の視点とは，トレードオフに留意しながら，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "論理的",
+          "missing_len": 3,
+          "context": "評価する際，考察における視点の広さ，記述の明確さと論理的なつながり，そして論文全体のまとまりを特に重視する",
+          "confidence": "low"
+        },
+        {
+          "line": 62,
+          "missing": "経済財",
+          "missing_len": 3,
+          "context": "し，想定する今後の世界情勢の変化，技術革新の進展，経済財政政策や厚生労働政策の動向，予算の制約等の背景を含",
+          "confidence": "low"
+        },
+        {
+          "line": 62,
+          "missing": "済財政",
+          "missing_len": 3,
+          "context": "，想定する今後の世界情勢の変化，技術革新の進展，経済財政政策や厚生労働政策の動向，予算の制約等の背景を含め",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R06",
+      "kind": "primary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R06/R06_試験問題_択一式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r06-primary/article.mdx",
+      "ocr_text_len": 19285,
+      "mdx_text_lines": 319,
+      "ocr_kanji_ngrams": 3998,
+      "mismatch_total": 273,
+      "mismatch_by_confidence": {
+        "high": 64,
+        "medium": 95,
+        "low": 114
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 117,
+          "missing": "個別原価計",
+          "missing_len": 5,
+          "context": "0万円をこれらの3つのプロジェクトに配賦するとき、個別原価計算方法の違いにより、各プロジェクトの原価がどのよう",
+          "confidence": "high"
+        },
+        {
+          "line": 117,
+          "missing": "別原価計算",
+          "missing_len": 5,
+          "context": "万円をこれらの3つのプロジェクトに配賦するとき、個別原価計算方法の違いにより、各プロジェクトの原価がどのように",
+          "confidence": "high"
+        },
+        {
+          "line": 117,
+          "missing": "原価計算方",
+          "missing_len": 5,
+          "context": "円をこれらの3つのプロジェクトに配賦するとき、個別原価計算方法の違いにより、各プロジェクトの原価がどのようにな",
+          "confidence": "high"
+        },
+        {
+          "line": 363,
+          "missing": "多元的思考",
+          "missing_len": 5,
+          "context": "、要因と他の要因など、複数の要素間の関係を整理し、多元的思考によって問題点を明確にしていく手法である。",
+          "confidence": "high"
+        },
+        {
+          "line": 407,
+          "missing": "総労働時間",
+          "missing_len": 5,
+          "context": "する変形労働時間制においては、あらかじめ定められた総労働時間の範囲内で、対象期間における各日の始業及び終業の時",
+          "confidence": "high"
+        },
+        {
+          "line": 447,
+          "missing": "雇用労働者",
+          "missing_len": 5,
+          "context": "された事業主の下で、定年後引き続いて雇用される有期雇用労働者については、無期転換申込権が発生しない。",
+          "confidence": "high"
+        },
+        {
+          "line": 485,
+          "missing": "生時育児体",
+          "missing_len": 5,
+          "context": "のはどれか。なお、以下において、産後パパ育体は、出生時育児体業を指すものとする。",
+          "confidence": "high"
+        },
+        {
+          "line": 485,
+          "missing": "時育児体業",
+          "missing_len": 5,
+          "context": "はどれか。なお、以下において、産後パパ育体は、出生時育児体業を指すものとする。",
+          "confidence": "high"
+        },
+        {
+          "line": 489,
+          "missing": "育児休業制",
+          "missing_len": 5,
+          "context": "偶者の妊娠・出産等を申し出た労働者に対して、個別に育児休業制度等の周知、及び休業の取得意向の確認のための面談等",
+          "confidence": "high"
+        },
+        {
+          "line": 489,
+          "missing": "児休業制度",
+          "missing_len": 5,
+          "context": "者の妊娠・出産等を申し出た労働者に対して、個別に育児休業制度等の周知、及び休業の取得意向の確認のための面談等の",
+          "confidence": "high"
+        },
+        {
+          "line": 489,
+          "missing": "休業制度等",
+          "missing_len": 5,
+          "context": "の妊娠・出産等を申し出た労働者に対して、個別に育児休業制度等の周知、及び休業の取得意向の確認のための面談等の措",
+          "confidence": "high"
+        },
+        {
+          "line": 493,
+          "missing": "育体期間中",
+          "missing_len": 5,
+          "context": "4. 事業主は、労使協定に産後パパ育体期間中に就業させることができると定めた労働者から期間中の",
+          "confidence": "high"
+        },
+        {
+          "line": 530,
+          "missing": "社会復帰等",
+          "missing_len": 5,
+          "context": "等に対して必要な保険給付を行い、併せて被災労働者の社会復帰等の事業を行う制度である。",
+          "confidence": "high"
+        },
+        {
+          "line": 620,
+          "missing": "企業価値向",
+          "missing_len": 5,
+          "context": "シーは、ダイバーシティを通じて中長期的にどのような企業価値向上を目指すのかの方針であり、その明確にあたっては、",
+          "confidence": "high"
+        },
+        {
+          "line": 620,
+          "missing": "業価値向上",
+          "missing_len": 5,
+          "context": "ーは、ダイバーシティを通じて中長期的にどのような企業価値向上を目指すのかの方針であり、その明確にあたっては、業",
+          "confidence": "high"
+        },
+        {
+          "line": 622,
+          "missing": "会均等法等",
+          "missing_len": 5,
+          "context": "進に関する優遇措置を行うことは、いわゆる男女雇用機会均等法等により認められている。",
+          "confidence": "high"
+        },
+        {
+          "line": 666,
+          "missing": "役割明確化",
+          "missing_len": 5,
+          "context": "学び・学び直しが効果的に行われるためには、労働者の役割明確化と合わせ、職務に必要な能力・スキル等を可能な限り明",
+          "confidence": "high"
+        },
+        {
+          "line": 668,
+          "missing": "教育訓練機",
+          "missing_len": 5,
+          "context": "対する企業の支援策として、受講料などの金銭的援助、教育訓練機関に関する情報提供、就業時間の配慮などが行われる。",
+          "confidence": "high"
+        },
+        {
+          "line": 668,
+          "missing": "育訓練機関",
+          "missing_len": 5,
+          "context": "する企業の支援策として、受講料などの金銭的援助、教育訓練機関に関する情報提供、就業時間の配慮などが行われる。",
+          "confidence": "high"
+        },
+        {
+          "line": 708,
+          "missing": "労働時間協",
+          "missing_len": 5,
+          "context": "（B）従業員持株制度や労働時間協議制度などの経営参加制度により、従業員に自発的に行",
+          "confidence": "high"
+        },
+        {
+          "line": 708,
+          "missing": "働時間協議",
+          "missing_len": 5,
+          "context": "（B）従業員持株制度や労働時間協議制度などの経営参加制度により、従業員に自発的に行動",
+          "confidence": "high"
+        },
+        {
+          "line": 708,
+          "missing": "時間協議制",
+          "missing_len": 5,
+          "context": "（B）従業員持株制度や労働時間協議制度などの経営参加制度により、従業員に自発的に行動さ",
+          "confidence": "high"
+        },
+        {
+          "line": 814,
+          "missing": "多次元尺度",
+          "missing_len": 5,
+          "context": "3. 多次元尺度法は、個体間の親近性データを2次元あるいは3次元空",
+          "confidence": "high"
+        },
+        {
+          "line": 814,
+          "missing": "次元尺度法",
+          "missing_len": 5,
+          "context": "3. 多次元尺度法は、個体間の親近性データを2次元あるいは3次元空間",
+          "confidence": "high"
+        },
+        {
+          "line": 1126,
+          "missing": "隕石避難用",
+          "missing_len": 5,
+          "context": "限石飛来のニュースで被害の深刻さを見て、自宅地下に隕石避難用シェルターを建設することとし、準備していた資金をこ",
+          "confidence": "high"
+        },
+        {
+          "line": 1128,
+          "missing": "社内管理体",
+          "missing_len": 5,
+          "context": "行の可能性が高いにも関わらず、管理担当部長の資識は社内管理体制の向上に向かわず、内部犯行による情報漏洩が再発し",
+          "confidence": "high"
+        },
+        {
+          "line": 1128,
+          "missing": "内管理体制",
+          "missing_len": 5,
+          "context": "の可能性が高いにも関わらず、管理担当部長の資識は社内管理体制の向上に向かわず、内部犯行による情報漏洩が再発した",
+          "confidence": "high"
+        },
+        {
+          "line": 1291,
+          "missing": "大雨警報表",
+          "missing_len": 5,
+          "context": "5. 記録的短時間大雨情報は、大雨警報表の有無にかかわらず、その地域にとって災害の発生に繋",
+          "confidence": "high"
+        },
+        {
+          "line": 1368,
+          "missing": "和元年改正",
+          "missing_len": 5,
+          "context": "生マネジメントシステムに関する指針（厚生労働省、令和元年改正。以下「OSHMS指針」という。）及び労働安全衛生",
+          "confidence": "high"
+        },
+        {
+          "line": 1378,
+          "missing": "安全衛生生",
+          "missing_len": 5,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用する",
+          "confidence": "high"
+        },
+        {
+          "line": 1378,
+          "missing": "全衛生生活",
+          "missing_len": 5,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用するこ",
+          "confidence": "high"
+        },
+        {
+          "line": 1378,
+          "missing": "衛生生活活",
+          "missing_len": 5,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用すること",
+          "confidence": "high"
+        },
+        {
+          "line": 1378,
+          "missing": "生生活活動",
+          "missing_len": 5,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用することで",
+          "confidence": "high"
+        },
+        {
+          "line": 1457,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防",
+          "confidence": "high"
+        },
+        {
+          "line": 1457,
+          "missing": "土強靭化基",
+          "missing_len": 5,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災",
+          "confidence": "high"
+        },
+        {
+          "line": 1457,
+          "missing": "強靭化基本",
+          "missing_len": 5,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災・",
+          "confidence": "high"
+        },
+        {
+          "line": 1457,
+          "missing": "靭化基本法",
+          "missing_len": 5,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災・減",
+          "confidence": "high"
+        },
+        {
+          "line": 1459,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "1. 国土強靭化は、大規模自然災害が発生した場合においても、国家及",
+          "confidence": "high"
+        },
+        {
+          "line": 1461,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に係",
+          "confidence": "high"
+        },
+        {
+          "line": 1461,
+          "missing": "土強靭化基",
+          "missing_len": 5,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に係る",
+          "confidence": "high"
+        },
+        {
+          "line": 1461,
+          "missing": "強靭化基本",
+          "missing_len": 5,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に係る国",
+          "confidence": "high"
+        },
+        {
+          "line": 1461,
+          "missing": "靭化基本計",
+          "missing_len": 5,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に係る国の",
+          "confidence": "high"
+        },
+        {
+          "line": 1463,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め、",
+          "confidence": "high"
+        },
+        {
+          "line": 1463,
+          "missing": "土強靭化実",
+          "missing_len": 5,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め、脆",
+          "confidence": "high"
+        },
+        {
+          "line": 1463,
+          "missing": "強靭化実施",
+          "missing_len": 5,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め、脆弱",
+          "confidence": "high"
+        },
+        {
+          "line": 1463,
+          "missing": "靭化実施中",
+          "missing_len": 5,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め、脆弱性",
+          "confidence": "high"
+        },
+        {
+          "line": 1465,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に国",
+          "confidence": "high"
+        },
+        {
+          "line": 1465,
+          "missing": "土強靭化実",
+          "missing_len": 5,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に国土",
+          "confidence": "high"
+        },
+        {
+          "line": 1465,
+          "missing": "強靭化実施",
+          "missing_len": 5,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に国土強",
+          "confidence": "high"
+        },
+        {
+          "line": 1465,
+          "missing": "靭化実施中",
+          "missing_len": 5,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に国土強靭",
+          "confidence": "high"
+        },
+        {
+          "line": 1467,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "又は市町村は、当該都道府県又は市町村の区域における国土強靭化に関する施策の推進に関する基本的な計画を、定めるこ",
+          "confidence": "high"
+        },
+        {
+          "line": 1545,
+          "missing": "制度開始後",
+          "missing_len": 5,
+          "context": "陽光、風力、水力、地熱、バイオマスの合発電のうち、制度開始後に新たに導転を開始した設備導入量が最も大きいのは太",
+          "confidence": "high"
+        },
+        {
+          "line": 1547,
+          "missing": "発電促進課",
+          "missing_len": 5,
+          "context": "、電気の使用合から広く集められる再生可能エネルギー発電促進課金によってまかなわれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 1547,
+          "missing": "電促進課金",
+          "missing_len": 5,
+          "context": "電気の使用合から広く集められる再生可能エネルギー発電促進課金によってまかなわれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 1553,
+          "missing": "需要補助出",
+          "missing_len": 5,
+          "context": "ため、火力発電の抑制、揚水発電のくみ上げ運転による需要補助出等が行われ、それでもなお供給が需要を上回る場合には",
+          "confidence": "high"
+        },
+        {
+          "line": 1553,
+          "missing": "要補助出等",
+          "missing_len": 5,
+          "context": "め、火力発電の抑制、揚水発電のくみ上げ運転による需要補助出等が行われ、それでもなお供給が需要を上回る場合には再",
+          "confidence": "high"
+        },
+        {
+          "line": 1590,
+          "missing": "輸入入手続",
+          "missing_len": 5,
+          "context": "び持続可能な利用への悪影響を防止するためのLMOの輸入入手続き等に関する国際的な枠組みは、COP10における名",
+          "confidence": "high"
+        },
+        {
+          "line": 1637,
+          "missing": "不法投棄巡",
+          "missing_len": 5,
+          "context": "においては、海洋プラスチック対策として、ボイ拾い・不法投棄巡廃の徹底、洗い流しのスクラップ製品に含まれるマイク",
+          "confidence": "high"
+        },
+        {
+          "line": 1637,
+          "missing": "法投棄巡廃",
+          "missing_len": 5,
+          "context": "おいては、海洋プラスチック対策として、ボイ拾い・不法投棄巡廃の徹底、洗い流しのスクラップ製品に含まれるマイクロ",
+          "confidence": "high"
+        },
+        {
+          "line": 1679,
+          "missing": "液状化現象",
+          "missing_len": 5,
+          "context": "強い衝撃を受け、地盤が液体のような状態になる現象を液状化現象という、噴水、噴砂や堆積などを伴うとし、令和6年能",
+          "confidence": "high"
+        },
+        {
+          "line": 1679,
+          "missing": "年能登半島",
+          "missing_len": 5,
+          "context": "現象という、噴水、噴砂や堆積などを伴うとし、令和6年能登半島地震でも被害が確認されている。",
+          "confidence": "high"
+        },
+        {
+          "line": 1679,
+          "missing": "能登半島地",
+          "missing_len": 5,
+          "context": "象という、噴水、噴砂や堆積などを伴うとし、令和6年能登半島地震でも被害が確認されている。",
+          "confidence": "high"
+        },
+        {
+          "line": 1679,
+          "missing": "登半島地震",
+          "missing_len": 5,
+          "context": "という、噴水、噴砂や堆積などを伴うとし、令和6年能登半島地震でも被害が確認されている。",
+          "confidence": "high"
+        },
+        {
+          "line": 1720,
+          "missing": "月閣議決定",
+          "missing_len": 5,
+          "context": "第五次環境基本計画（平成30年4月閣議決定）に示されている環境政策の実施の手法に関する次の記",
+          "confidence": "high"
+        },
+        {
+          "line": 117,
+          "missing": "別原価計",
+          "missing_len": 4,
+          "context": "万円をこれらの3つのプロジェクトに配賦するとき、個別原価計算方法の違いにより、各プロジェクトの原価がどのよう",
+          "confidence": "medium"
+        },
+        {
+          "line": 117,
+          "missing": "原価計算",
+          "missing_len": 4,
+          "context": "円をこれらの3つのプロジェクトに配賦するとき、個別原価計算方法の違いにより、各プロジェクトの原価がどのように",
+          "confidence": "medium"
+        },
+        {
+          "line": 224,
+          "missing": "運搬指示",
+          "missing_len": 4,
+          "context": "んばんは、生産指示をするための生産指示かんばんと、運搬指示をするための引取かんばんの2種類に大別される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 363,
+          "missing": "元的思考",
+          "missing_len": 4,
+          "context": "要因と他の要因など、複数の要素間の関係を整理し、多元的思考によって問題点を明確にしていく手法である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 445,
+          "missing": "労働契約",
+          "missing_len": 4,
+          "context": "労働者の定年の定めをしている場合、期間の定めの無い労働契約を締結することを目的に、当該定年の年齢を下回ること",
+          "confidence": "medium"
+        },
+        {
+          "line": 447,
+          "missing": "用労働者",
+          "missing_len": 4,
+          "context": "れた事業主の下で、定年後引き続いて雇用される有期雇用労働者については、無期転換申込権が発生しない。",
+          "confidence": "medium"
+        },
+        {
+          "line": 485,
+          "missing": "時育児体",
+          "missing_len": 4,
+          "context": "はどれか。なお、以下において、産後パパ育体は、出生時育児体業を指すものとする。",
+          "confidence": "medium"
+        },
+        {
+          "line": 485,
+          "missing": "育児体業",
+          "missing_len": 4,
+          "context": "どれか。なお、以下において、産後パパ育体は、出生時育児体業を指すものとする。",
+          "confidence": "medium"
+        },
+        {
+          "line": 489,
+          "missing": "児休業制",
+          "missing_len": 4,
+          "context": "者の妊娠・出産等を申し出た労働者に対して、個別に育児休業制度等の周知、及び休業の取得意向の確認のための面談等",
+          "confidence": "medium"
+        },
+        {
+          "line": 489,
+          "missing": "休業制度",
+          "missing_len": 4,
+          "context": "の妊娠・出産等を申し出た労働者に対して、個別に育児休業制度等の周知、及び休業の取得意向の確認のための面談等の",
+          "confidence": "medium"
+        },
+        {
+          "line": 491,
+          "missing": "原則体業",
+          "missing_len": 4,
+          "context": "3. 産後パパ育体は、原則体業の2週間前までに申し出る必要があり、育児休業とは別",
+          "confidence": "medium"
+        },
+        {
+          "line": 493,
+          "missing": "育体期間",
+          "missing_len": 4,
+          "context": "4. 事業主は、労使協定に産後パパ育体期間中に就業させることができると定めた労働者から期間中",
+          "confidence": "medium"
+        },
+        {
+          "line": 493,
+          "missing": "体期間中",
+          "missing_len": 4,
+          "context": "4. 事業主は、労使協定に産後パパ育体期間中に就業させることができると定めた労働者から期間中の",
+          "confidence": "medium"
+        },
+        {
+          "line": 530,
+          "missing": "会復帰等",
+          "missing_len": 4,
+          "context": "に対して必要な保険給付を行い、併せて被災労働者の社会復帰等の事業を行う制度である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 571,
+          "missing": "従業員等",
+          "missing_len": 4,
+          "context": "従業員等の健康管理を経営の視点から考えて戦略的に実践する健",
+          "confidence": "medium"
+        },
+        {
+          "line": 581,
+          "missing": "経営理念",
+          "missing_len": 4,
+          "context": "は、法令遵守・リスクマネジメントの実践を基礎とし、経営理念・方針、組織体制、制度・施策実行及び評価改善の取組",
+          "confidence": "medium"
+        },
+        {
+          "line": 620,
+          "missing": "業価値向",
+          "missing_len": 4,
+          "context": "ーは、ダイバーシティを通じて中長期的にどのような企業価値向上を目指すのかの方針であり、その明確にあたっては、",
+          "confidence": "medium"
+        },
+        {
+          "line": 620,
+          "missing": "価値向上",
+          "missing_len": 4,
+          "context": "は、ダイバーシティを通じて中長期的にどのような企業価値向上を目指すのかの方針であり、その明確にあたっては、業",
+          "confidence": "medium"
+        },
+        {
+          "line": 622,
+          "missing": "不利益方",
+          "missing_len": 4,
+          "context": "支援となっている事情を改善するために、男女に関わり不利益方の性別の労働者に関して、採用や昇進に関する優遇措置",
+          "confidence": "medium"
+        },
+        {
+          "line": 622,
+          "missing": "優遇措置",
+          "missing_len": 4,
+          "context": "不利益方の性別の労働者に関して、採用や昇進に関する優遇措置を行うことは、いわゆる男女雇用機会均等法等により認",
+          "confidence": "medium"
+        },
+        {
+          "line": 622,
+          "missing": "均等法等",
+          "missing_len": 4,
+          "context": "に関する優遇措置を行うことは、いわゆる男女雇用機会均等法等により認められている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 666,
+          "missing": "役割明確",
+          "missing_len": 4,
+          "context": "学び・学び直しが効果的に行われるためには、労働者の役割明確化と合わせ、職務に必要な能力・スキル等を可能な限り",
+          "confidence": "medium"
+        },
+        {
+          "line": 668,
+          "missing": "育訓練機",
+          "missing_len": 4,
+          "context": "する企業の支援策として、受講料などの金銭的援助、教育訓練機関に関する情報提供、就業時間の配慮などが行われる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 668,
+          "missing": "訓練機関",
+          "missing_len": 4,
+          "context": "る企業の支援策として、受講料などの金銭的援助、教育訓練機関に関する情報提供、就業時間の配慮などが行われる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 708,
+          "missing": "働時間協",
+          "missing_len": 4,
+          "context": "（B）従業員持株制度や労働時間協議制度などの経営参加制度により、従業員に自発的に行",
+          "confidence": "medium"
+        },
+        {
+          "line": 708,
+          "missing": "時間協議",
+          "missing_len": 4,
+          "context": "（B）従業員持株制度や労働時間協議制度などの経営参加制度により、従業員に自発的に行動",
+          "confidence": "medium"
+        },
+        {
+          "line": 812,
+          "missing": "共通因子",
+          "missing_len": 4,
+          "context": "相関関係から共通の因子を求めることで、多くの変数を共通因子によってまとめて説明する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 814,
+          "missing": "多次元尺",
+          "missing_len": 4,
+          "context": "3. 多次元尺度法は、個体間の親近性データを2次元あるいは3次元",
+          "confidence": "medium"
+        },
+        {
+          "line": 814,
+          "missing": "次元尺度",
+          "missing_len": 4,
+          "context": "3. 多次元尺度法は、個体間の親近性データを2次元あるいは3次元空",
+          "confidence": "medium"
+        },
+        {
+          "line": 814,
+          "missing": "元尺度法",
+          "missing_len": 4,
+          "context": "3. 多次元尺度法は、個体間の親近性データを2次元あるいは3次元空間",
+          "confidence": "medium"
+        },
+        {
+          "line": 901,
+          "missing": "人的資源",
+          "missing_len": 4,
+          "context": "ングでは、クライアントは本来、創造的であり、資質や人的資源に富み、欠けることがない存在であると考える。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1031,
+          "missing": "暗号資産",
+          "missing_len": 4,
+          "context": "3. 暗号資産のビットコインには、参加者が自由にネットワークに加",
+          "confidence": "medium"
+        },
+        {
+          "line": 1076,
+          "missing": "感染痕跡",
+          "missing_len": 4,
+          "context": " ランサムウェアへの感染原因等の調査にあたっては、感染痕跡をはじめとした各種機器のログが必要となるので、適切",
+          "confidence": "medium"
+        },
+        {
+          "line": 1076,
+          "missing": "各種機器",
+          "missing_len": 4,
+          "context": "染原因等の調査にあたっては、感染痕跡をはじめとした各種機器のログが必要となるので、適切にログを保管することが",
+          "confidence": "medium"
+        },
+        {
+          "line": 1078,
+          "missing": "実行可能",
+          "missing_len": 4,
+          "context": "け防止するため、ユーザアカウントに割り当てる権限や実行可能とする範囲は必要最小限にすることが望ましい。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1126,
+          "missing": "耐震補強",
+          "missing_len": 4,
+          "context": "（ア）自宅の耐震補強のために資金を準備していたが、海外の限石飛来のニュ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1126,
+          "missing": "限石飛来",
+          "missing_len": 4,
+          "context": "自宅の耐震補強のために資金を準備していたが、海外の限石飛来のニュースで被害の深刻さを見て、自宅地下に隕石避難",
+          "confidence": "medium"
+        },
+        {
+          "line": 1126,
+          "missing": "隕石避難",
+          "missing_len": 4,
+          "context": "限石飛来のニュースで被害の深刻さを見て、自宅地下に隕石避難用シェルターを建設することとし、準備していた資金を",
+          "confidence": "medium"
+        },
+        {
+          "line": 1126,
+          "missing": "石避難用",
+          "missing_len": 4,
+          "context": "石飛来のニュースで被害の深刻さを見て、自宅地下に隕石避難用シェルターを建設することとし、準備していた資金をこ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1128,
+          "missing": "社内管理",
+          "missing_len": 4,
+          "context": "行の可能性が高いにも関わらず、管理担当部長の資識は社内管理体制の向上に向かわず、内部犯行による情報漏洩が再発",
+          "confidence": "medium"
+        },
+        {
+          "line": 1128,
+          "missing": "内管理体",
+          "missing_len": 4,
+          "context": "の可能性が高いにも関わらず、管理担当部長の資識は社内管理体制の向上に向かわず、内部犯行による情報漏洩が再発し",
+          "confidence": "medium"
+        },
+        {
+          "line": 1177,
+          "missing": "健康障害",
+          "missing_len": 4,
+          "context": "の健康に関する、持続的な健康の保持増進を仕事による健康障害の防止、健康不全の早期発見・早期対処、職場復帰支援",
+          "confidence": "medium"
+        },
+        {
+          "line": 1179,
+          "missing": "本然防止",
+          "missing_len": 4,
+          "context": "ヘルス対策のひとつに自殺の予防と対応があり、これは本然防止、危機介入、事後対応を含む。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1181,
+          "missing": "事業場内",
+          "missing_len": 4,
+          "context": "方法、評価制度など、労働者の心の健康に影響を与える事業場内の事項についての問題を点検し、その改善を図ることが",
+          "confidence": "medium"
+        },
+        {
+          "line": 1291,
+          "missing": "雨警報表",
+          "missing_len": 4,
+          "context": "5. 記録的短時間大雨情報は、大雨警報表の有無にかかわらず、その地域にとって災害の発生に繋",
+          "confidence": "medium"
+        },
+        {
+          "line": 1368,
+          "missing": "元年改正",
+          "missing_len": 4,
+          "context": "マネジメントシステムに関する指針（厚生労働省、令和元年改正。以下「OSHMS指針」という。）及び労働安全衛生",
+          "confidence": "medium"
+        },
+        {
+          "line": 1378,
+          "missing": "全衛生生",
+          "missing_len": 4,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用する",
+          "confidence": "medium"
+        },
+        {
+          "line": 1378,
+          "missing": "衛生生活",
+          "missing_len": 4,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用するこ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1378,
+          "missing": "生生活活",
+          "missing_len": 4,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用すること",
+          "confidence": "medium"
+        },
+        {
+          "line": 1378,
+          "missing": "生活活動",
+          "missing_len": 4,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用することで",
+          "confidence": "medium"
+        },
+        {
+          "line": 1412,
+          "missing": "故障発生",
+          "missing_len": 4,
+          "context": "の信頼度に最も近い値はどれか。ただし、各ユニットの故障発生は独立事象とする。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1416,
+          "missing": "並列接続",
+          "missing_len": 4,
+          "context": "頼度0.800）とユニット3（信頼度0.800）の並列接続 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1417,
+          "missing": "並列接続",
+          "missing_len": 4,
+          "context": "頼度0.700）とユニット4（信頼度0.700）の並列接続 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1457,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための",
+          "confidence": "medium"
+        },
+        {
+          "line": 1457,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防",
+          "confidence": "medium"
+        },
+        {
+          "line": 1457,
+          "missing": "強靭化基",
+          "missing_len": 4,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災",
+          "confidence": "medium"
+        },
+        {
+          "line": 1457,
+          "missing": "靭化基本",
+          "missing_len": 4,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災・",
+          "confidence": "medium"
+        },
+        {
+          "line": 1457,
+          "missing": "国民生活",
+          "missing_len": 4,
+          "context": "正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災・減災等に資する国土強靭化基",
+          "confidence": "medium"
+        },
+        {
+          "line": 1459,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "1. 国土強靭化は、大規模自然災害が発生した場合においても、国家",
+          "confidence": "medium"
+        },
+        {
+          "line": 1459,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "1. 国土強靭化は、大規模自然災害が発生した場合においても、国家及",
+          "confidence": "medium"
+        },
+        {
+          "line": 1461,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に",
+          "confidence": "medium"
+        },
+        {
+          "line": 1461,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に係",
+          "confidence": "medium"
+        },
+        {
+          "line": 1461,
+          "missing": "強靭化基",
+          "missing_len": 4,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に係る",
+          "confidence": "medium"
+        },
+        {
+          "line": 1461,
+          "missing": "靭化基本",
+          "missing_len": 4,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に係る国",
+          "confidence": "medium"
+        },
+        {
+          "line": 1463,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め",
+          "confidence": "medium"
+        },
+        {
+          "line": 1463,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め、",
+          "confidence": "medium"
+        },
+        {
+          "line": 1463,
+          "missing": "強靭化実",
+          "missing_len": 4,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め、脆",
+          "confidence": "medium"
+        },
+        {
+          "line": 1463,
+          "missing": "靭化実施",
+          "missing_len": 4,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め、脆弱",
+          "confidence": "medium"
+        },
+        {
+          "line": 1465,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に",
+          "confidence": "medium"
+        },
+        {
+          "line": 1465,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に国",
+          "confidence": "medium"
+        },
+        {
+          "line": 1465,
+          "missing": "強靭化実",
+          "missing_len": 4,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に国土",
+          "confidence": "medium"
+        },
+        {
+          "line": 1465,
+          "missing": "靭化実施",
+          "missing_len": 4,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に国土強",
+          "confidence": "medium"
+        },
+        {
+          "line": 1467,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "又は市町村は、当該都道府県又は市町村の区域における国土強靭化に関する施策の推進に関する基本的な計画を、定める",
+          "confidence": "medium"
+        },
+        {
+          "line": 1467,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "は市町村は、当該都道府県又は市町村の区域における国土強靭化に関する施策の推進に関する基本的な計画を、定めるこ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1545,
+          "missing": "制度開始",
+          "missing_len": 4,
+          "context": "陽光、風力、水力、地熱、バイオマスの合発電のうち、制度開始後に新たに導転を開始した設備導入量が最も大きいのは",
+          "confidence": "medium"
+        },
+        {
+          "line": 1545,
+          "missing": "度開始後",
+          "missing_len": 4,
+          "context": "光、風力、水力、地熱、バイオマスの合発電のうち、制度開始後に新たに導転を開始した設備導入量が最も大きいのは太",
+          "confidence": "medium"
+        },
+        {
+          "line": 1547,
+          "missing": "電促進課",
+          "missing_len": 4,
+          "context": "電気の使用合から広く集められる再生可能エネルギー発電促進課金によってまかなわれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1547,
+          "missing": "促進課金",
+          "missing_len": 4,
+          "context": "気の使用合から広く集められる再生可能エネルギー発電促進課金によってまかなわれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1553,
+          "missing": "需要補助",
+          "missing_len": 4,
+          "context": "ため、火力発電の抑制、揚水発電のくみ上げ運転による需要補助出等が行われ、それでもなお供給が需要を上回る場合に",
+          "confidence": "medium"
+        },
+        {
+          "line": 1553,
+          "missing": "要補助出",
+          "missing_len": 4,
+          "context": "め、火力発電の抑制、揚水発電のくみ上げ運転による需要補助出等が行われ、それでもなお供給が需要を上回る場合には",
+          "confidence": "medium"
+        },
+        {
+          "line": 1553,
+          "missing": "補助出等",
+          "missing_len": 4,
+          "context": "、火力発電の抑制、揚水発電のくみ上げ運転による需要補助出等が行われ、それでもなお供給が需要を上回る場合には再",
+          "confidence": "medium"
+        },
+        {
+          "line": 1586,
+          "missing": "国際取引",
+          "missing_len": 4,
+          "context": "ントン条約とは「絶滅のおそれのある野生動植物の種の国際取引に関する条約」、種の保存法とは「絶滅のおそれのある",
+          "confidence": "medium"
+        },
+        {
+          "line": 1590,
+          "missing": "輸入入手",
+          "missing_len": 4,
+          "context": "び持続可能な利用への悪影響を防止するためのLMOの輸入入手続き等に関する国際的な枠組みは、COP10における",
+          "confidence": "medium"
+        },
+        {
+          "line": 1590,
+          "missing": "入入手続",
+          "missing_len": 4,
+          "context": "持続可能な利用への悪影響を防止するためのLMOの輸入入手続き等に関する国際的な枠組みは、COP10における名",
+          "confidence": "medium"
+        },
+        {
+          "line": 1633,
+          "missing": "優先順位",
+          "missing_len": 4,
+          "context": "、基本原則として、循環資源の循環的な利用及び処分の優先順位を、第1に発生抑制、第2に再利用、第3に再生利用、",
+          "confidence": "medium"
+        },
+        {
+          "line": 1637,
+          "missing": "法投棄巡",
+          "missing_len": 4,
+          "context": "おいては、海洋プラスチック対策として、ボイ拾い・不法投棄巡廃の徹底、洗い流しのスクラップ製品に含まれるマイク",
+          "confidence": "medium"
+        },
+        {
+          "line": 1637,
+          "missing": "投棄巡廃",
+          "missing_len": 4,
+          "context": "いては、海洋プラスチック対策として、ボイ拾い・不法投棄巡廃の徹底、洗い流しのスクラップ製品に含まれるマイクロ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1679,
+          "missing": "液状化現",
+          "missing_len": 4,
+          "context": "強い衝撃を受け、地盤が液体のような状態になる現象を液状化現象という、噴水、噴砂や堆積などを伴うとし、令和6年",
+          "confidence": "medium"
+        },
+        {
+          "line": 1679,
+          "missing": "状化現象",
+          "missing_len": 4,
+          "context": "い衝撃を受け、地盤が液体のような状態になる現象を液状化現象という、噴水、噴砂や堆積などを伴うとし、令和6年能",
+          "confidence": "medium"
+        },
+        {
+          "line": 1679,
+          "missing": "年能登半",
+          "missing_len": 4,
+          "context": "現象という、噴水、噴砂や堆積などを伴うとし、令和6年能登半島地震でも被害が確認されている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1679,
+          "missing": "能登半島",
+          "missing_len": 4,
+          "context": "象という、噴水、噴砂や堆積などを伴うとし、令和6年能登半島地震でも被害が確認されている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1679,
+          "missing": "登半島地",
+          "missing_len": 4,
+          "context": "という、噴水、噴砂や堆積などを伴うとし、令和6年能登半島地震でも被害が確認されている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1720,
+          "missing": "月閣議決",
+          "missing_len": 4,
+          "context": "第五次環境基本計画（平成30年4月閣議決定）に示されている環境政策の実施の手法に関する次の",
+          "confidence": "medium"
+        },
+        {
+          "line": 1720,
+          "missing": "閣議決定",
+          "missing_len": 4,
+          "context": "第五次環境基本計画（平成30年4月閣議決定）に示されている環境政策の実施の手法に関する次の記",
+          "confidence": "medium"
+        },
+        {
+          "line": 1815,
+          "missing": "消費行動",
+          "missing_len": 4,
+          "context": "の活性化や雇用など、人・社会・地域・環境に配慮した消費行動のことであり、□アのわいた商品の選択的な購入や食品",
+          "confidence": "medium"
+        },
+        {
+          "line": 28,
+          "missing": "罰科金",
+          "missing_len": 3,
+          "context": "（B）税金、関税、罰科金の支払いに対する政府への支出",
+          "confidence": "low"
+        },
+        {
+          "line": 77,
+          "missing": "年以降",
+          "missing_len": 3,
+          "context": "る。追加投資費用が400万円で、追加投資によって3年以降の毎年末に得られる収益は（500+x）万円に増加す",
+          "confidence": "low"
+        },
+        {
+          "line": 117,
+          "missing": "原価計",
+          "missing_len": 3,
+          "context": "円をこれらの3つのプロジェクトに配賦するとき、個別原価計算方法の違いにより、各プロジェクトの原価がどのよう",
+          "confidence": "low"
+        },
+        {
+          "line": 224,
+          "missing": "運搬指",
+          "missing_len": 3,
+          "context": "んばんは、生産指示をするための生産指示かんばんと、運搬指示をするための引取かんばんの2種類に大別される。",
+          "confidence": "low"
+        },
+        {
+          "line": 260,
+          "missing": "作業名",
+          "missing_len": 3,
+          "context": "| 作業名 | 所要時間（時間） | 先行作業 |",
+          "confidence": "low"
+        },
+        {
+          "line": 355,
+          "missing": "解決策",
+          "missing_len": 3,
+          "context": "ーは、現状の分析に基づいて、現状からの情報をもとに解決策を導く手順である。",
+          "confidence": "low"
+        },
+        {
+          "line": 363,
+          "missing": "的思考",
+          "missing_len": 3,
+          "context": "因と他の要因など、複数の要素間の関係を整理し、多元的思考によって問題点を明確にしていく手法である。",
+          "confidence": "low"
+        },
+        {
+          "line": 441,
+          "missing": "安定等",
+          "missing_len": 3,
+          "context": "以下において、グループ会社とは、高年齢者等の雇用の安定等に関する法律施行規則第四条の三に規定する特殊関係事",
+          "confidence": "low"
+        },
+        {
+          "line": 445,
+          "missing": "労働契",
+          "missing_len": 3,
+          "context": "労働者の定年の定めをしている場合、期間の定めの無い労働契約を締結することを目的に、当該定年の年齢を下回るこ",
+          "confidence": "low"
+        },
+        {
+          "line": 445,
+          "missing": "働契約",
+          "missing_len": 3,
+          "context": "働者の定年の定めをしている場合、期間の定めの無い労働契約を締結することを目的に、当該定年の年齢を下回ること",
+          "confidence": "low"
+        },
+        {
+          "line": 445,
+          "missing": "募集及",
+          "missing_len": 3,
+          "context": "に、当該定年の年齢を下回ることを条件として労働者の募集及び採用をすることができる。",
+          "confidence": "low"
+        },
+        {
+          "line": 485,
+          "missing": "育児体",
+          "missing_len": 3,
+          "context": "どれか。なお、以下において、産後パパ育体は、出生時育児体業を指すものとする。",
+          "confidence": "low"
+        },
+        {
+          "line": 485,
+          "missing": "児体業",
+          "missing_len": 3,
+          "context": "れか。なお、以下において、産後パパ育体は、出生時育児体業を指すものとする。",
+          "confidence": "low"
+        },
+        {
+          "line": 489,
+          "missing": "休業制",
+          "missing_len": 3,
+          "context": "の妊娠・出産等を申し出た労働者に対して、個別に育児休業制度等の周知、及び休業の取得意向の確認のための面談等",
+          "confidence": "low"
+        },
+        {
+          "line": 491,
+          "missing": "原則体",
+          "missing_len": 3,
+          "context": "3. 産後パパ育体は、原則体業の2週間前までに申し出る必要があり、育児休業とは",
+          "confidence": "low"
+        },
+        {
+          "line": 491,
+          "missing": "則体業",
+          "missing_len": 3,
+          "context": "3. 産後パパ育体は、原則体業の2週間前までに申し出る必要があり、育児休業とは別",
+          "confidence": "low"
+        },
+        {
+          "line": 493,
+          "missing": "育体期",
+          "missing_len": 3,
+          "context": "4. 事業主は、労使協定に産後パパ育体期間中に就業させることができると定めた労働者から期間",
+          "confidence": "low"
+        },
+        {
+          "line": 493,
+          "missing": "体期間",
+          "missing_len": 3,
+          "context": "4. 事業主は、労使協定に産後パパ育体期間中に就業させることができると定めた労働者から期間中",
+          "confidence": "low"
+        },
+        {
+          "line": 530,
+          "missing": "復帰等",
+          "missing_len": 3,
+          "context": "対して必要な保険給付を行い、併せて被災労働者の社会復帰等の事業を行う制度である。",
+          "confidence": "low"
+        },
+        {
+          "line": 571,
+          "missing": "業員等",
+          "missing_len": 3,
+          "context": "従業員等の健康管理を経営の視点から考えて戦略的に実践する健",
+          "confidence": "low"
+        },
+        {
+          "line": 581,
+          "missing": "営理念",
+          "missing_len": 3,
+          "context": "、法令遵守・リスクマネジメントの実践を基礎とし、経営理念・方針、組織体制、制度・施策実行及び評価改善の取組",
+          "confidence": "low"
+        },
+        {
+          "line": 620,
+          "missing": "価値向",
+          "missing_len": 3,
+          "context": "は、ダイバーシティを通じて中長期的にどのような企業価値向上を目指すのかの方針であり、その明確にあたっては、",
+          "confidence": "low"
+        },
+        {
+          "line": 622,
+          "missing": "利益方",
+          "missing_len": 3,
+          "context": "援となっている事情を改善するために、男女に関わり不利益方の性別の労働者に関して、採用や昇進に関する優遇措置",
+          "confidence": "low"
+        },
+        {
+          "line": 622,
+          "missing": "優遇措",
+          "missing_len": 3,
+          "context": "不利益方の性別の労働者に関して、採用や昇進に関する優遇措置を行うことは、いわゆる男女雇用機会均等法等により",
+          "confidence": "low"
+        },
+        {
+          "line": 622,
+          "missing": "等法等",
+          "missing_len": 3,
+          "context": "関する優遇措置を行うことは、いわゆる男女雇用機会均等法等により認められている。",
+          "confidence": "low"
+        },
+        {
+          "line": 662,
+          "missing": "開発及",
+          "missing_len": 3,
+          "context": "は、労働者の職業の選択、職業生活設計又は職業能力の開発及び向上に関する相談に応じ、助言及び指導を行う。",
+          "confidence": "low"
+        },
+        {
+          "line": 666,
+          "missing": "役割明",
+          "missing_len": 3,
+          "context": "学び・学び直しが効果的に行われるためには、労働者の役割明確化と合わせ、職務に必要な能力・スキル等を可能な限",
+          "confidence": "low"
+        },
+        {
+          "line": 668,
+          "missing": "訓練機",
+          "missing_len": 3,
+          "context": "る企業の支援策として、受講料などの金銭的援助、教育訓練機関に関する情報提供、就業時間の配慮などが行われる。",
+          "confidence": "low"
+        },
+        {
+          "line": 668,
+          "missing": "練機関",
+          "missing_len": 3,
+          "context": "企業の支援策として、受講料などの金銭的援助、教育訓練機関に関する情報提供、就業時間の配慮などが行われる。",
+          "confidence": "low"
+        },
+        {
+          "line": 708,
+          "missing": "時間協",
+          "missing_len": 3,
+          "context": "（B）従業員持株制度や労働時間協議制度などの経営参加制度により、従業員に自発的に行",
+          "confidence": "low"
+        },
+        {
+          "line": 812,
+          "missing": "共通因",
+          "missing_len": 3,
+          "context": "相関関係から共通の因子を求めることで、多くの変数を共通因子によってまとめて説明する。",
+          "confidence": "low"
+        },
+        {
+          "line": 814,
+          "missing": "次元尺",
+          "missing_len": 3,
+          "context": "3. 多次元尺度法は、個体間の親近性データを2次元あるいは3次元",
+          "confidence": "low"
+        },
+        {
+          "line": 814,
+          "missing": "元尺度",
+          "missing_len": 3,
+          "context": "3. 多次元尺度法は、個体間の親近性データを2次元あるいは3次元空",
+          "confidence": "low"
+        },
+        {
+          "line": 814,
+          "missing": "尺度法",
+          "missing_len": 3,
+          "context": "3. 多次元尺度法は、個体間の親近性データを2次元あるいは3次元空間",
+          "confidence": "low"
+        },
+        {
+          "line": 856,
+          "missing": "優先先",
+          "missing_len": 3,
+          "context": "報セキュリティ方針は、情報セキュリティ目的の達成を優先先し、組織の目的には影響されてはならない。",
+          "confidence": "low"
+        },
+        {
+          "line": 901,
+          "missing": "人的資",
+          "missing_len": 3,
+          "context": "ングでは、クライアントは本来、創造的であり、資質や人的資源に富み、欠けることがない存在であると考える。",
+          "confidence": "low"
+        },
+        {
+          "line": 901,
+          "missing": "的資源",
+          "missing_len": 3,
+          "context": "グでは、クライアントは本来、創造的であり、資質や人的資源に富み、欠けることがない存在であると考える。",
+          "confidence": "low"
+        },
+        {
+          "line": 1031,
+          "missing": "暗号資",
+          "missing_len": 3,
+          "context": "3. 暗号資産のビットコインには、参加者が自由にネットワークに",
+          "confidence": "low"
+        },
+        {
+          "line": 1033,
+          "missing": "障害性",
+          "missing_len": 3,
+          "context": "ネットワークへの参加ノード数が増えるほど、改ざんや障害性が低下する。",
+          "confidence": "low"
+        },
+        {
+          "line": 1076,
+          "missing": "感染痕",
+          "missing_len": 3,
+          "context": " ランサムウェアへの感染原因等の調査にあたっては、感染痕跡をはじめとした各種機器のログが必要となるので、適",
+          "confidence": "low"
+        },
+        {
+          "line": 1076,
+          "missing": "染痕跡",
+          "missing_len": 3,
+          "context": "ランサムウェアへの感染原因等の調査にあたっては、感染痕跡をはじめとした各種機器のログが必要となるので、適切",
+          "confidence": "low"
+        },
+        {
+          "line": 1076,
+          "missing": "種機器",
+          "missing_len": 3,
+          "context": "原因等の調査にあたっては、感染痕跡をはじめとした各種機器のログが必要となるので、適切にログを保管することが",
+          "confidence": "low"
+        },
+        {
+          "line": 1078,
+          "missing": "実行可",
+          "missing_len": 3,
+          "context": "け防止するため、ユーザアカウントに割り当てる権限や実行可能とする範囲は必要最小限にすることが望ましい。",
+          "confidence": "low"
+        },
+        {
+          "line": 1078,
+          "missing": "行可能",
+          "missing_len": 3,
+          "context": "防止するため、ユーザアカウントに割り当てる権限や実行可能とする範囲は必要最小限にすることが望ましい。",
+          "confidence": "low"
+        },
+        {
+          "line": 1126,
+          "missing": "耐震補",
+          "missing_len": 3,
+          "context": "（ア）自宅の耐震補強のために資金を準備していたが、海外の限石飛来のニ",
+          "confidence": "low"
+        },
+        {
+          "line": 1126,
+          "missing": "限石飛",
+          "missing_len": 3,
+          "context": "自宅の耐震補強のために資金を準備していたが、海外の限石飛来のニュースで被害の深刻さを見て、自宅地下に隕石避",
+          "confidence": "low"
+        },
+        {
+          "line": 1126,
+          "missing": "隕石避",
+          "missing_len": 3,
+          "context": "限石飛来のニュースで被害の深刻さを見て、自宅地下に隕石避難用シェルターを建設することとし、準備していた資金",
+          "confidence": "low"
+        },
+        {
+          "line": 1126,
+          "missing": "石避難",
+          "missing_len": 3,
+          "context": "石飛来のニュースで被害の深刻さを見て、自宅地下に隕石避難用シェルターを建設することとし、準備していた資金を",
+          "confidence": "low"
+        },
+        {
+          "line": 1128,
+          "missing": "社内管",
+          "missing_len": 3,
+          "context": "行の可能性が高いにも関わらず、管理担当部長の資識は社内管理体制の向上に向かわず、内部犯行による情報漏洩が再",
+          "confidence": "low"
+        },
+        {
+          "line": 1128,
+          "missing": "内管理",
+          "missing_len": 3,
+          "context": "の可能性が高いにも関わらず、管理担当部長の資識は社内管理体制の向上に向かわず、内部犯行による情報漏洩が再発",
+          "confidence": "low"
+        },
+        {
+          "line": 1177,
+          "missing": "持続的",
+          "missing_len": 3,
+          "context": "1. メンタルヘルス対策は、心の健康に関する、持続的な健康の保持増進を仕事による健康障害の防止、健康不",
+          "confidence": "low"
+        },
+        {
+          "line": 1177,
+          "missing": "健康障",
+          "missing_len": 3,
+          "context": "の健康に関する、持続的な健康の保持増進を仕事による健康障害の防止、健康不全の早期発見・早期対処、職場復帰支",
+          "confidence": "low"
+        },
+        {
+          "line": 1179,
+          "missing": "本然防",
+          "missing_len": 3,
+          "context": "ヘルス対策のひとつに自殺の予防と対応があり、これは本然防止、危機介入、事後対応を含む。",
+          "confidence": "low"
+        },
+        {
+          "line": 1181,
+          "missing": "業場内",
+          "missing_len": 3,
+          "context": "法、評価制度など、労働者の心の健康に影響を与える事業場内の事項についての問題を点検し、その改善を図ることが",
+          "confidence": "low"
+        },
+        {
+          "line": 1237,
+          "missing": "手指等",
+          "missing_len": 3,
+          "context": "ることときに限って機械が運転を開始し、操作装置から手指等を離したときは直ちに機械を停止させる回路",
+          "confidence": "low"
+        },
+        {
+          "line": 1283,
+          "missing": "実層的",
+          "missing_len": 3,
+          "context": "直し、地域の特性に応じた対策をハード・ソフト一体で実層的に進める。",
+          "confidence": "low"
+        },
+        {
+          "line": 1285,
+          "missing": "河町村",
+          "missing_len": 3,
+          "context": "2. 洪水浸水想定区域をその区域に含む河町村の長は、洪水予報等の伝達方法、避難場所、避難経路等",
+          "confidence": "low"
+        },
+        {
+          "line": 1291,
+          "missing": "警報表",
+          "missing_len": 3,
+          "context": "5. 記録的短時間大雨情報は、大雨警報表の有無にかかわらず、その地域にとって災害の発生に繋",
+          "confidence": "low"
+        },
+        {
+          "line": 1327,
+          "missing": "禁止等",
+          "missing_len": 3,
+          "context": "由とする公益通報者の解雇の無効及び不利益を取扱いの禁止等、並びに公益通報に関し事業者及び行政機関がとるべき",
+          "confidence": "low"
+        },
+        {
+          "line": 1368,
+          "missing": "年改正",
+          "missing_len": 3,
+          "context": "ネジメントシステムに関する指針（厚生労働省、令和元年改正。以下「OSHMS指針」という。）及び労働安全衛生",
+          "confidence": "low"
+        },
+        {
+          "line": 1378,
+          "missing": "衛生生",
+          "missing_len": 3,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用する",
+          "confidence": "low"
+        },
+        {
+          "line": 1378,
+          "missing": "生生活",
+          "missing_len": 3,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用するこ",
+          "confidence": "low"
+        },
+        {
+          "line": 1378,
+          "missing": "生活活",
+          "missing_len": 3,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用すること",
+          "confidence": "low"
+        },
+        {
+          "line": 1378,
+          "missing": "活活動",
+          "missing_len": 3,
+          "context": "5. ISO45001に日本独自の安全衛生生活活動を取り入れたJIS Q 45100を運用することで",
+          "confidence": "low"
+        },
+        {
+          "line": 1412,
+          "missing": "故障発",
+          "missing_len": 3,
+          "context": "の信頼度に最も近い値はどれか。ただし、各ユニットの故障発生は独立事象とする。",
+          "confidence": "low"
+        },
+        {
+          "line": 1416,
+          "missing": "並列接",
+          "missing_len": 3,
+          "context": "頼度0.800）とユニット3（信頼度0.800）の並列接続 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1416,
+          "missing": "列接続",
+          "missing_len": 3,
+          "context": "度0.800）とユニット3（信頼度0.800）の並列接続 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1417,
+          "missing": "並列接",
+          "missing_len": 3,
+          "context": "頼度0.700）とユニット4（信頼度0.700）の並列接続 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1417,
+          "missing": "列接続",
+          "missing_len": 3,
+          "context": "度0.700）とユニット4（信頼度0.700）の並列接続 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1457,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための",
+          "confidence": "low"
+        },
+        {
+          "line": 1457,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防",
+          "confidence": "low"
+        },
+        {
+          "line": 1457,
+          "missing": "靭化基",
+          "missing_len": 3,
+          "context": "2023年6月に改正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災",
+          "confidence": "low"
+        },
+        {
+          "line": 1457,
+          "missing": "国民生",
+          "missing_len": 3,
+          "context": "正された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災・減災等に資する国土強靭化",
+          "confidence": "low"
+        },
+        {
+          "line": 1457,
+          "missing": "民生活",
+          "missing_len": 3,
+          "context": "された、いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災・減災等に資する国土強靭化基",
+          "confidence": "low"
+        },
+        {
+          "line": 1459,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "1. 国土強靭化は、大規模自然災害が発生した場合においても、国家",
+          "confidence": "low"
+        },
+        {
+          "line": 1459,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "1. 国土強靭化は、大規模自然災害が発生した場合においても、国家及",
+          "confidence": "low"
+        },
+        {
+          "line": 1461,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に",
+          "confidence": "low"
+        },
+        {
+          "line": 1461,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に係",
+          "confidence": "low"
+        },
+        {
+          "line": 1461,
+          "missing": "靭化基",
+          "missing_len": 3,
+          "context": "2. 国土強靭化基本計画は、国土強靭化基本計画以外の国土強靭化に係る",
+          "confidence": "low"
+        },
+        {
+          "line": 1463,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め",
+          "confidence": "low"
+        },
+        {
+          "line": 1463,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め、",
+          "confidence": "low"
+        },
+        {
+          "line": 1463,
+          "missing": "靭化実",
+          "missing_len": 3,
+          "context": "3. 政府は、国土強靭化実施中期計画案の作成時に、脆弱性評価の指針を定め、脆",
+          "confidence": "low"
+        },
+        {
+          "line": 1465,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に",
+          "confidence": "low"
+        },
+        {
+          "line": 1465,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に国",
+          "confidence": "low"
+        },
+        {
+          "line": 1465,
+          "missing": "靭化実",
+          "missing_len": 3,
+          "context": "4. 政府は、国土強靭化実施中期計画において、計画期間及び、計画期間内に国土",
+          "confidence": "low"
+        },
+        {
+          "line": 1467,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "は市町村は、当該都道府県又は市町村の区域における国土強靭化に関する施策の推進に関する基本的な計画を、定める",
+          "confidence": "low"
+        },
+        {
+          "line": 1467,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "市町村は、当該都道府県又は市町村の区域における国土強靭化に関する施策の推進に関する基本的な計画を、定めるこ",
+          "confidence": "low"
+        },
+        {
+          "line": 1545,
+          "missing": "合発電",
+          "missing_len": 3,
+          "context": "の対象である太陽光、風力、水力、地熱、バイオマスの合発電のうち、制度開始後に新たに導転を開始した設備導入量",
+          "confidence": "low"
+        },
+        {
+          "line": 1545,
+          "missing": "制度開",
+          "missing_len": 3,
+          "context": "陽光、風力、水力、地熱、バイオマスの合発電のうち、制度開始後に新たに導転を開始した設備導入量が最も大きいの",
+          "confidence": "low"
+        },
+        {
+          "line": 1545,
+          "missing": "度開始",
+          "missing_len": 3,
+          "context": "光、風力、水力、地熱、バイオマスの合発電のうち、制度開始後に新たに導転を開始した設備導入量が最も大きいのは",
+          "confidence": "low"
+        },
+        {
+          "line": 1547,
+          "missing": "使用合",
+          "missing_len": 3,
+          "context": "可能エネルギー電気の買い取りに要した費用は、電気の使用合から広く集められる再生可能エネルギー発電促進課金に",
+          "confidence": "low"
+        },
+        {
+          "line": 1547,
+          "missing": "促進課",
+          "missing_len": 3,
+          "context": "気の使用合から広く集められる再生可能エネルギー発電促進課金によってまかなわれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 1547,
+          "missing": "進課金",
+          "missing_len": 3,
+          "context": "の使用合から広く集められる再生可能エネルギー発電促進課金によってまかなわれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 1553,
+          "missing": "需要補",
+          "missing_len": 3,
+          "context": "ため、火力発電の抑制、揚水発電のくみ上げ運転による需要補助出等が行われ、それでもなお供給が需要を上回る場合",
+          "confidence": "low"
+        },
+        {
+          "line": 1553,
+          "missing": "要補助",
+          "missing_len": 3,
+          "context": "め、火力発電の抑制、揚水発電のくみ上げ運転による需要補助出等が行われ、それでもなお供給が需要を上回る場合に",
+          "confidence": "low"
+        },
+        {
+          "line": 1553,
+          "missing": "補助出",
+          "missing_len": 3,
+          "context": "、火力発電の抑制、揚水発電のくみ上げ運転による需要補助出等が行われ、それでもなお供給が需要を上回る場合には",
+          "confidence": "low"
+        },
+        {
+          "line": 1553,
+          "missing": "助出等",
+          "missing_len": 3,
+          "context": "火力発電の抑制、揚水発電のくみ上げ運転による需要補助出等が行われ、それでもなお供給が需要を上回る場合には再",
+          "confidence": "low"
+        },
+        {
+          "line": 1586,
+          "missing": "際取引",
+          "missing_len": 3,
+          "context": "トン条約とは「絶滅のおそれのある野生動植物の種の国際取引に関する条約」、種の保存法とは「絶滅のおそれのある",
+          "confidence": "low"
+        },
+        {
+          "line": 1590,
+          "missing": "輸入入",
+          "missing_len": 3,
+          "context": "び持続可能な利用への悪影響を防止するためのLMOの輸入入手続き等に関する国際的な枠組みは、COP10におけ",
+          "confidence": "low"
+        },
+        {
+          "line": 1590,
+          "missing": "入入手",
+          "missing_len": 3,
+          "context": "持続可能な利用への悪影響を防止するためのLMOの輸入入手続き等に関する国際的な枠組みは、COP10における",
+          "confidence": "low"
+        },
+        {
+          "line": 1590,
+          "missing": "入手続",
+          "missing_len": 3,
+          "context": "続可能な利用への悪影響を防止するためのLMOの輸入入手続き等に関する国際的な枠組みは、COP10における名",
+          "confidence": "low"
+        },
+        {
+          "line": 1633,
+          "missing": "優先順",
+          "missing_len": 3,
+          "context": "、基本原則として、循環資源の循環的な利用及び処分の優先順位を、第1に発生抑制、第2に再利用、第3に再生利用",
+          "confidence": "low"
+        },
+        {
+          "line": 1633,
+          "missing": "再利用",
+          "missing_len": 3,
+          "context": "な利用及び処分の優先順位を、第1に発生抑制、第2に再利用、第3に再生利用、第4に熱回収、最後に処分と定めて",
+          "confidence": "low"
+        },
+        {
+          "line": 1637,
+          "missing": "投棄巡",
+          "missing_len": 3,
+          "context": "いては、海洋プラスチック対策として、ボイ拾い・不法投棄巡廃の徹底、洗い流しのスクラップ製品に含まれるマイク",
+          "confidence": "low"
+        },
+        {
+          "line": 1637,
+          "missing": "棄巡廃",
+          "missing_len": 3,
+          "context": "ては、海洋プラスチック対策として、ボイ拾い・不法投棄巡廃の徹底、洗い流しのスクラップ製品に含まれるマイクロ",
+          "confidence": "low"
+        },
+        {
+          "line": 1641,
+          "missing": "由生産",
+          "missing_len": 3,
+          "context": "気中の二酸化炭素を固定したものであり、バイオマスを由生産する際においては、カーボンニュートラルである。",
+          "confidence": "low"
+        },
+        {
+          "line": 1679,
+          "missing": "状化現",
+          "missing_len": 3,
+          "context": "い衝撃を受け、地盤が液体のような状態になる現象を液状化現象という、噴水、噴砂や堆積などを伴うとし、令和6年",
+          "confidence": "low"
+        },
+        {
+          "line": 1679,
+          "missing": "化現象",
+          "missing_len": 3,
+          "context": "衝撃を受け、地盤が液体のような状態になる現象を液状化現象という、噴水、噴砂や堆積などを伴うとし、令和6年能",
+          "confidence": "low"
+        },
+        {
+          "line": 1679,
+          "missing": "年能登",
+          "missing_len": 3,
+          "context": "現象という、噴水、噴砂や堆積などを伴うとし、令和6年能登半島地震でも被害が確認されている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1679,
+          "missing": "能登半",
+          "missing_len": 3,
+          "context": "象という、噴水、噴砂や堆積などを伴うとし、令和6年能登半島地震でも被害が確認されている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1679,
+          "missing": "登半島",
+          "missing_len": 3,
+          "context": "という、噴水、噴砂や堆積などを伴うとし、令和6年能登半島地震でも被害が確認されている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1720,
+          "missing": "月閣議",
+          "missing_len": 3,
+          "context": "第五次環境基本計画（平成30年4月閣議決定）に示されている環境政策の実施の手法に関する次",
+          "confidence": "low"
+        },
+        {
+          "line": 1720,
+          "missing": "閣議決",
+          "missing_len": 3,
+          "context": "第五次環境基本計画（平成30年4月閣議決定）に示されている環境政策の実施の手法に関する次の",
+          "confidence": "low"
+        },
+        {
+          "line": 1815,
+          "missing": "消費行",
+          "missing_len": 3,
+          "context": "の活性化や雇用など、人・社会・地域・環境に配慮した消費行動のことであり、□アのわいた商品の選択的な購入や食",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R06",
+      "kind": "secondary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R06/R06_試験問題_記述式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r06-secondary/article.mdx",
+      "ocr_text_len": 3658,
+      "mdx_text_lines": 30,
+      "ocr_kanji_ngrams": 673,
+      "mismatch_total": 41,
+      "mismatch_by_confidence": {
+        "high": 5,
+        "medium": 14,
+        "low": 22
+      },
+      "ocr_figure_captions": [
+        "表 20"
+      ],
+      "ocr_figure_caption_count": 1,
+      "candidates": [
+        {
+          "line": 27,
+          "missing": "原材料調達",
+          "missing_len": 5,
+          "context": "投資」，事業者自らの温室効果ガスの排出のみならず，原材料調達・製造・物流・廃棄等，サプライチェーンを構成する一",
+          "confidence": "high"
+        },
+        {
+          "line": 29,
+          "missing": "月閣議決定",
+          "missing_len": 5,
+          "context": "協定に基づく成長戦略としての長期戦略。令和3年10月閣議決定）で謳われているとおり，カーボンニュートラルの実現",
+          "confidence": "high"
+        },
+        {
+          "line": 36,
+          "missing": "製造関連産",
+          "missing_len": 5,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，⑦船",
+          "confidence": "high"
+        },
+        {
+          "line": 36,
+          "missing": "造関連産業",
+          "missing_len": 5,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，⑦船舶",
+          "confidence": "high"
+        },
+        {
+          "line": 64,
+          "missing": "社会貢献等",
+          "missing_len": 5,
+          "context": "めることで，温室効果ガスの抑制により，脱炭素経営や社会貢献等の観点から事業や組織にとって期待できる効果を，理由",
+          "confidence": "high"
+        },
+        {
+          "line": 23,
+          "missing": "課題解決",
+          "missing_len": 4,
+          "context": "点から，それぞれに適した施策を検討し，地球規模での課題解決に繋げることは重要であろう。そこで本論文では，この",
+          "confidence": "medium"
+        },
+        {
+          "line": 27,
+          "missing": "原材料調",
+          "missing_len": 4,
+          "context": "投資」，事業者自らの温室効果ガスの排出のみならず，原材料調達・製造・物流・廃棄等，サプライチェーンを構成する",
+          "confidence": "medium"
+        },
+        {
+          "line": 27,
+          "missing": "材料調達",
+          "missing_len": 4,
+          "context": "資」，事業者自らの温室効果ガスの排出のみならず，原材料調達・製造・物流・廃棄等，サプライチェーンを構成する一",
+          "confidence": "medium"
+        },
+        {
+          "line": 29,
+          "missing": "月閣議決",
+          "missing_len": 4,
+          "context": "協定に基づく成長戦略としての長期戦略。令和3年10月閣議決定）で謳われているとおり，カーボンニュートラルの実",
+          "confidence": "medium"
+        },
+        {
+          "line": 29,
+          "missing": "閣議決定",
+          "missing_len": 4,
+          "context": "定に基づく成長戦略としての長期戦略。令和3年10月閣議決定）で謳われているとおり，カーボンニュートラルの実現",
+          "confidence": "medium"
+        },
+        {
+          "line": 29,
+          "missing": "経済成長",
+          "missing_len": 4,
+          "context": "とおり，カーボンニュートラルの実現に向けた取組を，経済成長の制約ではなく，産業構造の大転換と力強い成長を生み",
+          "confidence": "medium"
+        },
+        {
+          "line": 35,
+          "missing": "関連産業",
+          "missing_len": 4,
+          "context": "| エネルギー関連産業 | ①洋上風力・太陽光・地熱，②水素・燃料アンモ",
+          "confidence": "medium"
+        },
+        {
+          "line": 36,
+          "missing": "製造関連",
+          "missing_len": 4,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，⑦",
+          "confidence": "medium"
+        },
+        {
+          "line": 36,
+          "missing": "造関連産",
+          "missing_len": 4,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，⑦船",
+          "confidence": "medium"
+        },
+        {
+          "line": 36,
+          "missing": "関連産業",
+          "missing_len": 4,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，⑦船舶",
+          "confidence": "medium"
+        },
+        {
+          "line": 37,
+          "missing": "関連産業",
+          "missing_len": 4,
+          "context": "| 家庭・オフィス関連産業 | ⑫住宅・建築物・次世代電力マネジメント，⑬資",
+          "confidence": "medium"
+        },
+        {
+          "line": 41,
+          "missing": "安全管理",
+          "missing_len": 4,
+          "context": "術監理の視点とは，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に関する総合",
+          "confidence": "medium"
+        },
+        {
+          "line": 64,
+          "missing": "社会貢献",
+          "missing_len": 4,
+          "context": "めることで，温室効果ガスの抑制により，脱炭素経営や社会貢献等の観点から事業や組織にとって期待できる効果を，理",
+          "confidence": "medium"
+        },
+        {
+          "line": 64,
+          "missing": "会貢献等",
+          "missing_len": 4,
+          "context": "ることで，温室効果ガスの抑制により，脱炭素経営や社会貢献等の観点から事業や組織にとって期待できる効果を，理由",
+          "confidence": "medium"
+        },
+        {
+          "line": 23,
+          "missing": "俯瞰的",
+          "missing_len": 3,
+          "context": "より異なると考えられるが，総合技術監理に求められる俯瞰的な視点から，それぞれに適した施策を検討し，地球規模",
+          "confidence": "low"
+        },
+        {
+          "line": 23,
+          "missing": "題解決",
+          "missing_len": 3,
+          "context": "から，それぞれに適した施策を検討し，地球規模での課題解決に繋げることは重要であろう。そこで本論文では，この",
+          "confidence": "low"
+        },
+        {
+          "line": 27,
+          "missing": "原材料",
+          "missing_len": 3,
+          "context": "投資」，事業者自らの温室効果ガスの排出のみならず，原材料調達・製造・物流・廃棄等，サプライチェーンを構成す",
+          "confidence": "low"
+        },
+        {
+          "line": 27,
+          "missing": "材料調",
+          "missing_len": 3,
+          "context": "資」，事業者自らの温室効果ガスの排出のみならず，原材料調達・製造・物流・廃棄等，サプライチェーンを構成する",
+          "confidence": "low"
+        },
+        {
+          "line": 27,
+          "missing": "自動化",
+          "missing_len": 3,
+          "context": "や活用，再生可能エネルギーの活用，生産現場における自動化の推進，森林保護への投資等の幅広い観点で工夫した施",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "月閣議",
+          "missing_len": 3,
+          "context": "協定に基づく成長戦略としての長期戦略。令和3年10月閣議決定）で謳われているとおり，カーボンニュートラルの",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "閣議決",
+          "missing_len": 3,
+          "context": "定に基づく成長戦略としての長期戦略。令和3年10月閣議決定）で謳われているとおり，カーボンニュートラルの実",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "経済成",
+          "missing_len": 3,
+          "context": "とおり，カーボンニュートラルの実現に向けた取組を，経済成長の制約ではなく，産業構造の大転換と力強い成長を生",
+          "confidence": "low"
+        },
+        {
+          "line": 35,
+          "missing": "関連産",
+          "missing_len": 3,
+          "context": "| エネルギー関連産業 | ①洋上風力・太陽光・地熱，②水素・燃料アン",
+          "confidence": "low"
+        },
+        {
+          "line": 35,
+          "missing": "連産業",
+          "missing_len": 3,
+          "context": "| エネルギー関連産業 | ①洋上風力・太陽光・地熱，②水素・燃料アンモ",
+          "confidence": "low"
+        },
+        {
+          "line": 35,
+          "missing": "原子力",
+          "missing_len": 3,
+          "context": "，②水素・燃料アンモニア，③次世代熱エネルギー，④原子力 |",
+          "confidence": "low"
+        },
+        {
+          "line": 36,
+          "missing": "製造関",
+          "missing_len": 3,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，",
+          "confidence": "low"
+        },
+        {
+          "line": 36,
+          "missing": "造関連",
+          "missing_len": 3,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，⑦",
+          "confidence": "low"
+        },
+        {
+          "line": 36,
+          "missing": "関連産",
+          "missing_len": 3,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，⑦船",
+          "confidence": "low"
+        },
+        {
+          "line": 36,
+          "missing": "連産業",
+          "missing_len": 3,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，⑦船舶",
+          "confidence": "low"
+        },
+        {
+          "line": 36,
+          "missing": "蓄電池",
+          "missing_len": 3,
+          "context": "| 輸送・製造関連産業 | ⑤自動車・蓄電池，⑥半導体・情報通信，⑦船舶，⑧物流・人流・土木イ",
+          "confidence": "low"
+        },
+        {
+          "line": 37,
+          "missing": "関連産",
+          "missing_len": 3,
+          "context": "| 家庭・オフィス関連産業 | ⑫住宅・建築物・次世代電力マネジメント，⑬",
+          "confidence": "low"
+        },
+        {
+          "line": 37,
+          "missing": "連産業",
+          "missing_len": 3,
+          "context": "| 家庭・オフィス関連産業 | ⑫住宅・建築物・次世代電力マネジメント，⑬資",
+          "confidence": "low"
+        },
+        {
+          "line": 41,
+          "missing": "安全管",
+          "missing_len": 3,
+          "context": "術監理の視点とは，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に関する総",
+          "confidence": "low"
+        },
+        {
+          "line": 41,
+          "missing": "全管理",
+          "missing_len": 3,
+          "context": "監理の視点とは，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に関する総合",
+          "confidence": "low"
+        },
+        {
+          "line": 64,
+          "missing": "会貢献",
+          "missing_len": 3,
+          "context": "ることで，温室効果ガスの抑制により，脱炭素経営や社会貢献等の観点から事業や組織にとって期待できる効果を，理",
+          "confidence": "low"
+        },
+        {
+          "line": 64,
+          "missing": "貢献等",
+          "missing_len": 3,
+          "context": "ことで，温室効果ガスの抑制により，脱炭素経営や社会貢献等の観点から事業や組織にとって期待できる効果を，理由",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R05",
+      "kind": "primary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R05/R05_試験問題_択一式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r05-primary/article.mdx",
+      "ocr_text_len": 19092,
+      "mdx_text_lines": 323,
+      "ocr_kanji_ngrams": 3431,
+      "mismatch_total": 218,
+      "mismatch_by_confidence": {
+        "high": 44,
+        "medium": 75,
+        "low": 99
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 379,
+          "missing": "指間外労働",
+          "missing_len": 5,
+          "context": "1. 使用者は、労働者に指間外労働、休日労働を行わせる場合には、時間外労働、休日労働",
+          "confidence": "high"
+        },
+        {
+          "line": 382,
+          "missing": "裁員労働関",
+          "missing_len": 5,
+          "context": "4. 事業者は、健康管理の観点から、裁員労働関の適用者及び管理監督者を除き、労働者の労働時間の状",
+          "confidence": "high"
+        },
+        {
+          "line": 459,
+          "missing": "業務上必要",
+          "missing_len": 5,
+          "context": "メントとは、優越的な関係を背景とした言動であって、業務上必要かつ相当な範囲を超えたものをいい、労働者の就業環境",
+          "confidence": "high"
+        },
+        {
+          "line": 499,
+          "missing": "争調整委員",
+          "missing_len": 5,
+          "context": "合、紛争の解決のために必要があると認めるときは、紛争調整委員会にあっせんを行わせる。",
+          "confidence": "high"
+        },
+        {
+          "line": 499,
+          "missing": "調整委員会",
+          "missing_len": 5,
+          "context": "、紛争の解決のために必要があると認めるときは、紛争調整委員会にあっせんを行わせる。",
+          "confidence": "high"
+        },
+        {
+          "line": 895,
+          "missing": "最尤推定量",
+          "missing_len": 5,
+          "context": "2. x̄はμの最尤推定量である。",
+          "confidence": "high"
+        },
+        {
+          "line": 1035,
+          "missing": "通信最大遅",
+          "missing_len": 5,
+          "context": "付近にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷などを抑える手法である",
+          "confidence": "high"
+        },
+        {
+          "line": 1035,
+          "missing": "信最大遅延",
+          "missing_len": 5,
+          "context": "近にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷などを抑える手法である。",
+          "confidence": "high"
+        },
+        {
+          "line": 1074,
+          "missing": "記録作成及",
+          "missing_len": 5,
+          "context": "」があり、左右に「（エ）」が示されている。下部に「記録作成及び報告」がある。]",
+          "confidence": "high"
+        },
+        {
+          "line": 1117,
+          "missing": "製品安全表",
+          "missing_len": 5,
+          "context": "品安全法及び「長期使用製品安全点検制度及び長期使用製品安全表示制度のガイドライン」に関する次の記述のうち、最も",
+          "confidence": "high"
+        },
+        {
+          "line": 1117,
+          "missing": "品安全表示",
+          "missing_len": 5,
+          "context": "安全法及び「長期使用製品安全点検制度及び長期使用製品安全表示制度のガイドライン」に関する次の記述のうち、最も不",
+          "confidence": "high"
+        },
+        {
+          "line": 1117,
+          "missing": "安全表示制",
+          "missing_len": 5,
+          "context": "全法及び「長期使用製品安全点検制度及び長期使用製品安全表示制度のガイドライン」に関する次の記述のうち、最も不適",
+          "confidence": "high"
+        },
+        {
+          "line": 1120,
+          "missing": "使用期間及",
+          "missing_len": 5,
+          "context": "特定保守製品の製造又は輸入を行う事業者は、設計標準使用期間及び点検期間を設定するとともに、販売終了には設計標準",
+          "confidence": "high"
+        },
+        {
+          "line": 1161,
+          "missing": "安定化処置",
+          "missing_len": 5,
+          "context": "る医療チームを全国から迅速に参集させ、被災地内での安定化処置などの最低限の対応が可能な体制の確保を図るとともに",
+          "confidence": "high"
+        },
+        {
+          "line": 1200,
+          "missing": "絶括安全衛",
+          "missing_len": 5,
+          "context": "4. 事業者は、絶括安全衛生管理者等、事業の実施を統括管理する者に調査等の実",
+          "confidence": "high"
+        },
+        {
+          "line": 1234,
+          "missing": "連携委員会",
+          "missing_len": 5,
+          "context": "文部科学省に設置された「安全・安心科学技術及び社会連携委員会」は、平常時におけるリスクコミュニケーションの在り",
+          "confidence": "high"
+        },
+        {
+          "line": 1276,
+          "missing": "高齢労働災",
+          "missing_len": 5,
+          "context": "危険源の洗い出しを行い、当該リスクの高さを考慮して高齢労働災害防止対策の優先順位を検討した。",
+          "confidence": "high"
+        },
+        {
+          "line": 1276,
+          "missing": "齢労働災害",
+          "missing_len": 5,
+          "context": "険源の洗い出しを行い、当該リスクの高さを考慮して高齢労働災害防止対策の優先順位を検討した。",
+          "confidence": "high"
+        },
+        {
+          "line": 1316,
+          "missing": "戦略的活動",
+          "missing_len": 5,
+          "context": "他平常時からのマネジメント活動であり、経営レベルの戦略的活動として位置付けられる。",
+          "confidence": "high"
+        },
+        {
+          "line": 1395,
+          "missing": "一酸化二窒",
+          "missing_len": 5,
+          "context": "れか。なお、温室効果ガスにはCO2のほか、メタン、一酸化二窒素、ハイドロフルオロカーボン類等があり、以下におい",
+          "confidence": "high"
+        },
+        {
+          "line": 1395,
+          "missing": "酸化二窒素",
+          "missing_len": 5,
+          "context": "か。なお、温室効果ガスにはCO2のほか、メタン、一酸化二窒素、ハイドロフルオロカーボン類等があり、以下において",
+          "confidence": "high"
+        },
+        {
+          "line": 1439,
+          "missing": "脱炭素素化",
+          "missing_len": 5,
+          "context": "石エネルギーについては、合成燃料・合成メタンなどの脱炭素素化の融を措ずる技術を確立し、コストを低減することを目",
+          "confidence": "high"
+        },
+        {
+          "line": 1440,
+          "missing": "一資給構造",
+          "missing_len": 5,
+          "context": "5. 原子力発電は、長期的なエネルギー一資給構造の安定性に寄与する重要なベースロード電源と位置付け",
+          "confidence": "high"
+        },
+        {
+          "line": 1477,
+          "missing": "国家的利益",
+          "missing_len": 5,
+          "context": "れの締約国も、既に登録されている湿地の区域を緊急な国家的利益のために廃止し若しくは縮小する権利を有している。",
+          "confidence": "high"
+        },
+        {
+          "line": 1514,
+          "missing": "棄物輸入規",
+          "missing_len": 5,
+          "context": "た背景として、海洋プラスチックごみ問題や諸外国の廃棄物輸入規制強化等への対応を契機として、国におけるプラスチッ",
+          "confidence": "high"
+        },
+        {
+          "line": 1514,
+          "missing": "物輸入規制",
+          "missing_len": 5,
+          "context": "背景として、海洋プラスチックごみ問題や諸外国の廃棄物輸入規制強化等への対応を契機として、国におけるプラスチック",
+          "confidence": "high"
+        },
+        {
+          "line": 1514,
+          "missing": "輸入規制強",
+          "missing_len": 5,
+          "context": "景として、海洋プラスチックごみ問題や諸外国の廃棄物輸入規制強化等への対応を契機として、国におけるプラスチックの",
+          "confidence": "high"
+        },
+        {
+          "line": 1514,
+          "missing": "入規制強化",
+          "missing_len": 5,
+          "context": "として、海洋プラスチックごみ問題や諸外国の廃棄物輸入規制強化等への対応を契機として、国におけるプラスチックの資",
+          "confidence": "high"
+        },
+        {
+          "line": 1518,
+          "missing": "品廃棄物発",
+          "missing_len": 5,
+          "context": "の責務として、その区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置",
+          "confidence": "high"
+        },
+        {
+          "line": 1518,
+          "missing": "廃棄物発業",
+          "missing_len": 5,
+          "context": "責務として、その区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置を",
+          "confidence": "high"
+        },
+        {
+          "line": 1518,
+          "missing": "分別収集集",
+          "missing_len": 5,
+          "context": "その区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置を講ずるよう努",
+          "confidence": "high"
+        },
+        {
+          "line": 1518,
+          "missing": "別収集集及",
+          "missing_len": 5,
+          "context": "の区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置を講ずるよう努め",
+          "confidence": "high"
+        },
+        {
+          "line": 1551,
+          "missing": "環境政策手",
+          "missing_len": 5,
+          "context": "環境政策手段に関する次の記述の、□□□□□に入る用語の組合せ",
+          "confidence": "high"
+        },
+        {
+          "line": 1567,
+          "missing": "環境報告書",
+          "missing_len": 5,
+          "context": "パフォーマンス規制 | 低利融資 | 補助金 | 環境報告書 | 再生可能エネルギーの固定価格買取制度 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1640,
+          "missing": "影響評価準",
+          "missing_len": 5,
+          "context": "お、以下では、環境影響評価方法書を「方法書」、環境影響評価準備書を「準備書」、環境影響評価書を「評価書」とそれ",
+          "confidence": "high"
+        },
+        {
+          "line": 1640,
+          "missing": "響評価準備",
+          "missing_len": 5,
+          "context": "、以下では、環境影響評価方法書を「方法書」、環境影響評価準備書を「準備書」、環境影響評価書を「評価書」とそれぞ",
+          "confidence": "high"
+        },
+        {
+          "line": 1640,
+          "missing": "評価準備書",
+          "missing_len": 5,
+          "context": "以下では、環境影響評価方法書を「方法書」、環境影響評価準備書を「準備書」、環境影響評価書を「評価書」とそれぞれ",
+          "confidence": "high"
+        },
+        {
+          "line": 1644,
+          "missing": "都道府県知",
+          "missing_len": 5,
+          "context": "影響を受ける範囲である と認められる地域を管轄する都道府県知事及び市町村長に対し、方法書及びこれを要約した書類",
+          "confidence": "high"
+        },
+        {
+          "line": 1645,
+          "missing": "都道府県知",
+          "missing_len": 5,
+          "context": "境影響を受ける範囲であると認められる地域を管轄する都道府県知事は、必要に応じ、事業者に対し、準備書についての環",
+          "confidence": "high"
+        },
+        {
+          "line": 1678,
+          "missing": "気候関連務",
+          "missing_len": 5,
+          "context": "気候関連務情報開示タスクフォース（TCFD）提言と踏まえて、",
+          "confidence": "high"
+        },
+        {
+          "line": 1678,
+          "missing": "候関連務情",
+          "missing_len": 5,
+          "context": "気候関連務情報開示タスクフォース（TCFD）提言と踏まえて、環",
+          "confidence": "high"
+        },
+        {
+          "line": 1678,
+          "missing": "関連務情報",
+          "missing_len": 5,
+          "context": "気候関連務情報開示タスクフォース（TCFD）提言と踏まえて、環境",
+          "confidence": "high"
+        },
+        {
+          "line": 1678,
+          "missing": "連務情報開",
+          "missing_len": 5,
+          "context": "気候関連務情報開示タスクフォース（TCFD）提言と踏まえて、環境省",
+          "confidence": "high"
+        },
+        {
+          "line": 1682,
+          "missing": "低炭素経済",
+          "missing_len": 5,
+          "context": "3. TCFD提言では気候関連リスクを、低炭素経済への「移行」に関するリスクと、気候変動による「物理",
+          "confidence": "high"
+        },
+        {
+          "line": 73,
+          "missing": "売上高及",
+          "missing_len": 4,
+          "context": "を行うため、下図のような横軸に販売量、縦軸に金額（売上高及び費用）をとったグラフを用いる。このグラフを用いた",
+          "confidence": "medium"
+        },
+        {
+          "line": 122,
+          "missing": "故障箇所",
+          "missing_len": 4,
+          "context": "（ア）故障が発生した場合、その故障箇所がすぐに検知でき、容易に修復できるように考慮した設",
+          "confidence": "medium"
+        },
+        {
+          "line": 176,
+          "missing": "中心傾向",
+          "missing_len": 4,
+          "context": "計的に解析して棒グラフで示し、平均値や中央値などの中心傾向、分布の形状を知る。",
+          "confidence": "medium"
+        },
+        {
+          "line": 215,
+          "missing": "製造価値",
+          "missing_len": 4,
+          "context": " 設備の段取作業の省人化によって、段取作業における製造価値を減らした。",
+          "confidence": "medium"
+        },
+        {
+          "line": 218,
+          "missing": "設備故障",
+          "missing_len": 4,
+          "context": "5. 設備の事後保全の活動を見直すことによって、設備故障から復旧までの時間を減らした。",
+          "confidence": "medium"
+        },
+        {
+          "line": 254,
+          "missing": "所要時間",
+          "missing_len": 4,
+          "context": "| 作業名 | 所要時間 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 379,
+          "missing": "指間外労",
+          "missing_len": 4,
+          "context": "1. 使用者は、労働者に指間外労働、休日労働を行わせる場合には、時間外労働、休日労",
+          "confidence": "medium"
+        },
+        {
+          "line": 382,
+          "missing": "裁員労働",
+          "missing_len": 4,
+          "context": "4. 事業者は、健康管理の観点から、裁員労働関の適用者及び管理監督者を除き、労働者の労働時間の",
+          "confidence": "medium"
+        },
+        {
+          "line": 382,
+          "missing": "員労働関",
+          "missing_len": 4,
+          "context": "4. 事業者は、健康管理の観点から、裁員労働関の適用者及び管理監督者を除き、労働者の労働時間の状",
+          "confidence": "medium"
+        },
+        {
+          "line": 459,
+          "missing": "業務上必",
+          "missing_len": 4,
+          "context": "メントとは、優越的な関係を背景とした言動であって、業務上必要かつ相当な範囲を超えたものをいい、労働者の就業環",
+          "confidence": "medium"
+        },
+        {
+          "line": 499,
+          "missing": "調整委員",
+          "missing_len": 4,
+          "context": "、紛争の解決のために必要があると認めるときは、紛争調整委員会にあっせんを行わせる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 499,
+          "missing": "整委員会",
+          "missing_len": 4,
+          "context": "紛争の解決のために必要があると認めるときは、紛争調整委員会にあっせんを行わせる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 536,
+          "missing": "組織全体",
+          "missing_len": 4,
+          "context": "きかけであることに対し、組織開発は「グループ」や「組織全体」に働きかける取組であり、「個人」への働きかけは含",
+          "confidence": "medium"
+        },
+        {
+          "line": 538,
+          "missing": "個価値観",
+          "missing_len": 4,
+          "context": "3. 組織開発で大切にされる個価値観の1つとして人間尊重の価値観があり、マクレガーが提",
+          "confidence": "medium"
+        },
+        {
+          "line": 576,
+          "missing": "絶人件費",
+          "missing_len": 4,
+          "context": "どの理由により、職務等級制度や役割等級制度に比べ、絶人件費が高くなりがちである。",
+          "confidence": "medium"
+        },
+        {
+          "line": 895,
+          "missing": "最尤推定",
+          "missing_len": 4,
+          "context": "2. x̄はμの最尤推定量である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 895,
+          "missing": "尤推定量",
+          "missing_len": 4,
+          "context": "2. x̄はμの最尤推定量である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 937,
+          "missing": "電話番号",
+          "missing_len": 4,
+          "context": "報の情報伝達には、幅広により警報に近い場合がある、電話番号が分かる相手にしか連絡が取れない、といった課題があ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1034,
+          "missing": "付与可能",
+          "missing_len": 4,
+          "context": "計されたインターネットプロトコルであり、IPv6の付与可能なIPアドレスの数は約43億個である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "分散配置",
+          "missing_len": 4,
+          "context": "グは、エンドユーザー付近にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "通信最大",
+          "missing_len": 4,
+          "context": "付近にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷などを抑える手法であ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "信最大遅",
+          "missing_len": 4,
+          "context": "近にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷などを抑える手法である",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "最大遅延",
+          "missing_len": 4,
+          "context": "にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷などを抑える手法である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1074,
+          "missing": "適用範囲",
+          "missing_len": 4,
+          "context": "スクマネジメントのプロセスを示す円形の図。中央に「適用範囲、状況、基準」があり、その下に「リスクアセスメント",
+          "confidence": "medium"
+        },
+        {
+          "line": 1074,
+          "missing": "記録作成",
+          "missing_len": 4,
+          "context": "」があり、左右に「（エ）」が示されている。下部に「記録作成及び報告」がある。]",
+          "confidence": "medium"
+        },
+        {
+          "line": 1074,
+          "missing": "録作成及",
+          "missing_len": 4,
+          "context": "があり、左右に「（エ）」が示されている。下部に「記録作成及び報告」がある。]",
+          "confidence": "medium"
+        },
+        {
+          "line": 1117,
+          "missing": "品安全表",
+          "missing_len": 4,
+          "context": "安全法及び「長期使用製品安全点検制度及び長期使用製品安全表示制度のガイドライン」に関する次の記述のうち、最も",
+          "confidence": "medium"
+        },
+        {
+          "line": 1117,
+          "missing": "安全表示",
+          "missing_len": 4,
+          "context": "全法及び「長期使用製品安全点検制度及び長期使用製品安全表示制度のガイドライン」に関する次の記述のうち、最も不",
+          "confidence": "medium"
+        },
+        {
+          "line": 1120,
+          "missing": "用期間及",
+          "missing_len": 4,
+          "context": "定保守製品の製造又は輸入を行う事業者は、設計標準使用期間及び点検期間を設定するとともに、販売終了には設計標準",
+          "confidence": "medium"
+        },
+        {
+          "line": 1120,
+          "missing": "販売終了",
+          "missing_len": 4,
+          "context": "、設計標準使用期間及び点検期間を設定するとともに、販売終了には設計標準使用期間の算定の根拠等の害面を添付する",
+          "confidence": "medium"
+        },
+        {
+          "line": 1121,
+          "missing": "個人売却",
+          "missing_len": 4,
+          "context": "保守製品取引事業者に該当しない個人売主が、不動産の個人売却に伴い特定保守製品を引き渡す際、個人売主には、取得",
+          "confidence": "medium"
+        },
+        {
+          "line": 1161,
+          "missing": "安定化処",
+          "missing_len": 4,
+          "context": "る医療チームを全国から迅速に参集させ、被災地内での安定化処置などの最低限の対応が可能な体制の確保を図るととも",
+          "confidence": "medium"
+        },
+        {
+          "line": 1161,
+          "missing": "定化処置",
+          "missing_len": 4,
+          "context": "医療チームを全国から迅速に参集させ、被災地内での安定化処置などの最低限の対応が可能な体制の確保を図るとともに",
+          "confidence": "medium"
+        },
+        {
+          "line": 1197,
+          "missing": "業業行動",
+          "missing_len": 4,
+          "context": "物、設備、原材料、ガス、蒸気、粉じん等により、又は業業行動その他業務に起因する危険性又は有害性であって、労働",
+          "confidence": "medium"
+        },
+        {
+          "line": 1200,
+          "missing": "絶括安全",
+          "missing_len": 4,
+          "context": "4. 事業者は、絶括安全衛生管理者等、事業の実施を統括管理する者に調査等の",
+          "confidence": "medium"
+        },
+        {
+          "line": 1234,
+          "missing": "携委員会",
+          "missing_len": 4,
+          "context": "部科学省に設置された「安全・安心科学技術及び社会連携委員会」は、平常時におけるリスクコミュニケーションの在り",
+          "confidence": "medium"
+        },
+        {
+          "line": 1276,
+          "missing": "高齢労働",
+          "missing_len": 4,
+          "context": "危険源の洗い出しを行い、当該リスクの高さを考慮して高齢労働災害防止対策の優先順位を検討した。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1276,
+          "missing": "齢労働災",
+          "missing_len": 4,
+          "context": "険源の洗い出しを行い、当該リスクの高さを考慮して高齢労働災害防止対策の優先順位を検討した。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1316,
+          "missing": "戦略的活",
+          "missing_len": 4,
+          "context": "他平常時からのマネジメント活動であり、経営レベルの戦略的活動として位置付けられる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1316,
+          "missing": "略的活動",
+          "missing_len": 4,
+          "context": "平常時からのマネジメント活動であり、経営レベルの戦略的活動として位置付けられる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1319,
+          "missing": "結果事象",
+          "missing_len": 4,
+          "context": "、自社に生じた事態を、「ある拠点が使用不能」などの結果事象により考えるのではなく、「直下型地震」などの原因事",
+          "confidence": "medium"
+        },
+        {
+          "line": 1395,
+          "missing": "酸化二窒",
+          "missing_len": 4,
+          "context": "か。なお、温室効果ガスにはCO2のほか、メタン、一酸化二窒素、ハイドロフルオロカーボン類等があり、以下におい",
+          "confidence": "medium"
+        },
+        {
+          "line": 1395,
+          "missing": "化二窒素",
+          "missing_len": 4,
+          "context": "。なお、温室効果ガスにはCO2のほか、メタン、一酸化二窒素、ハイドロフルオロカーボン類等があり、以下において",
+          "confidence": "medium"
+        },
+        {
+          "line": 1399,
+          "missing": "産業部門",
+          "missing_len": 4,
+          "context": "値を見ると、2020年度でも家庭部門からの排出量が産業部門からの排出量を上回っている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1434,
+          "missing": "閣議決定",
+          "missing_len": 4,
+          "context": "令和3年10月に閣議決定された第6次エネルギー基本計画に関する次の記述のう",
+          "confidence": "medium"
+        },
+        {
+          "line": 1439,
+          "missing": "脱炭素素",
+          "missing_len": 4,
+          "context": "石エネルギーについては、合成燃料・合成メタンなどの脱炭素素化の融を措ずる技術を確立し、コストを低減することを",
+          "confidence": "medium"
+        },
+        {
+          "line": 1439,
+          "missing": "炭素素化",
+          "missing_len": 4,
+          "context": "エネルギーについては、合成燃料・合成メタンなどの脱炭素素化の融を措ずる技術を確立し、コストを低減することを目",
+          "confidence": "medium"
+        },
+        {
+          "line": 1440,
+          "missing": "一資給構",
+          "missing_len": 4,
+          "context": "5. 原子力発電は、長期的なエネルギー一資給構造の安定性に寄与する重要なベースロード電源と位置付",
+          "confidence": "medium"
+        },
+        {
+          "line": 1440,
+          "missing": "資給構造",
+          "missing_len": 4,
+          "context": "5. 原子力発電は、長期的なエネルギー一資給構造の安定性に寄与する重要なベースロード電源と位置付け",
+          "confidence": "medium"
+        },
+        {
+          "line": 1477,
+          "missing": "国家的利",
+          "missing_len": 4,
+          "context": "れの締約国も、既に登録されている湿地の区域を緊急な国家的利益のために廃止し若しくは縮小する権利を有している。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1514,
+          "missing": "物輸入規",
+          "missing_len": 4,
+          "context": "背景として、海洋プラスチックごみ問題や諸外国の廃棄物輸入規制強化等への対応を契機として、国におけるプラスチッ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1514,
+          "missing": "輸入規制",
+          "missing_len": 4,
+          "context": "景として、海洋プラスチックごみ問題や諸外国の廃棄物輸入規制強化等への対応を契機として、国におけるプラスチック",
+          "confidence": "medium"
+        },
+        {
+          "line": 1514,
+          "missing": "入規制強",
+          "missing_len": 4,
+          "context": "として、海洋プラスチックごみ問題や諸外国の廃棄物輸入規制強化等への対応を契機として、国におけるプラスチックの",
+          "confidence": "medium"
+        },
+        {
+          "line": 1518,
+          "missing": "廃棄物発",
+          "missing_len": 4,
+          "context": "責務として、その区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置",
+          "confidence": "medium"
+        },
+        {
+          "line": 1518,
+          "missing": "棄物発業",
+          "missing_len": 4,
+          "context": "務として、その区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置を",
+          "confidence": "medium"
+        },
+        {
+          "line": 1518,
+          "missing": "別収集集",
+          "missing_len": 4,
+          "context": "の区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置を講ずるよう努",
+          "confidence": "medium"
+        },
+        {
+          "line": 1518,
+          "missing": "収集集及",
+          "missing_len": 4,
+          "context": "区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置を講ずるよう努め",
+          "confidence": "medium"
+        },
+        {
+          "line": 1551,
+          "missing": "環境政策",
+          "missing_len": 4,
+          "context": "環境政策手段に関する次の記述の、□□□□□に入る用語の組合",
+          "confidence": "medium"
+        },
+        {
+          "line": 1567,
+          "missing": "低利融資",
+          "missing_len": 4,
+          "context": "| ⑤ | パフォーマンス規制 | 低利融資 | 補助金 | 環境報告書 | 再生可能エネルギ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1567,
+          "missing": "環境報告",
+          "missing_len": 4,
+          "context": "パフォーマンス規制 | 低利融資 | 補助金 | 環境報告書 | 再生可能エネルギーの固定価格買取制度 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1567,
+          "missing": "境報告書",
+          "missing_len": 4,
+          "context": "フォーマンス規制 | 低利融資 | 補助金 | 環境報告書 | 再生可能エネルギーの固定価格買取制度 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1601,
+          "missing": "環境政策",
+          "missing_len": 4,
+          "context": "環境政策で使われる用語と、その説明の組合せとして、次のうち",
+          "confidence": "medium"
+        },
+        {
+          "line": 1605,
+          "missing": "環境目標",
+          "missing_len": 4,
+          "context": "グ：現状の社会構造や外部環境要因を前提とし、将来の環境目標は同示さず、環境対策ができるところから行う手法",
+          "confidence": "medium"
+        },
+        {
+          "line": 1640,
+          "missing": "響評価準",
+          "missing_len": 4,
+          "context": "、以下では、環境影響評価方法書を「方法書」、環境影響評価準備書を「準備書」、環境影響評価書を「評価書」とそれ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1640,
+          "missing": "評価準備",
+          "missing_len": 4,
+          "context": "以下では、環境影響評価方法書を「方法書」、環境影響評価準備書を「準備書」、環境影響評価書を「評価書」とそれぞ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1640,
+          "missing": "価準備書",
+          "missing_len": 4,
+          "context": "下では、環境影響評価方法書を「方法書」、環境影響評価準備書を「準備書」、環境影響評価書を「評価書」とそれぞれ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1642,
+          "missing": "設置工事",
+          "missing_len": 4,
+          "context": "1. 風力発電所の設置工事の事業は、出力の規模により、第一種事業の場合と第二",
+          "confidence": "medium"
+        },
+        {
+          "line": 1644,
+          "missing": "市町村長",
+          "missing_len": 4,
+          "context": "である と認められる地域を管轄する都道府県知事及び市町村長に対し、方法書及びこれを要約した書類を送付しなけれ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1678,
+          "missing": "候関連務",
+          "missing_len": 4,
+          "context": "気候関連務情報開示タスクフォース（TCFD）提言と踏まえて、",
+          "confidence": "medium"
+        },
+        {
+          "line": 1678,
+          "missing": "関連務情",
+          "missing_len": 4,
+          "context": "気候関連務情報開示タスクフォース（TCFD）提言と踏まえて、環",
+          "confidence": "medium"
+        },
+        {
+          "line": 1678,
+          "missing": "連務情報",
+          "missing_len": 4,
+          "context": "気候関連務情報開示タスクフォース（TCFD）提言と踏まえて、環境",
+          "confidence": "medium"
+        },
+        {
+          "line": 1678,
+          "missing": "最新報告",
+          "missing_len": 4,
+          "context": "CFD提言とは、TCFDが2017年6月に公表した最新報告の提言をいう。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1682,
+          "missing": "低炭素経",
+          "missing_len": 4,
+          "context": "3. TCFD提言では気候関連リスクを、低炭素経済への「移行」に関するリスクと、気候変動による「物",
+          "confidence": "medium"
+        },
+        {
+          "line": 1682,
+          "missing": "炭素経済",
+          "missing_len": 4,
+          "context": "3. TCFD提言では気候関連リスクを、低炭素経済への「移行」に関するリスクと、気候変動による「物理",
+          "confidence": "medium"
+        },
+        {
+          "line": 1682,
+          "missing": "気候変動",
+          "missing_len": 4,
+          "context": "リスクを、低炭素経済への「移行」に関するリスクと、気候変動による「物理的」変化に関するリスクに大別している。",
+          "confidence": "medium"
+        },
+        {
+          "line": 73,
+          "missing": "上高及",
+          "missing_len": 3,
+          "context": "行うため、下図のような横軸に販売量、縦軸に金額（売上高及び費用）をとったグラフを用いる。このグラフを用いた",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "故障箇",
+          "missing_len": 3,
+          "context": "（ア）故障が発生した場合、その故障箇所がすぐに検知でき、容易に修復できるように考慮した",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "障箇所",
+          "missing_len": 3,
+          "context": "（ア）故障が発生した場合、その故障箇所がすぐに検知でき、容易に修復できるように考慮した設",
+          "confidence": "low"
+        },
+        {
+          "line": 126,
+          "missing": "決断力",
+          "missing_len": 3,
+          "context": "書類を処理させることにより、読取りの能力、判断力、決断力などを高める。",
+          "confidence": "low"
+        },
+        {
+          "line": 176,
+          "missing": "中心傾",
+          "missing_len": 3,
+          "context": "計的に解析して棒グラフで示し、平均値や中央値などの中心傾向、分布の形状を知る。",
+          "confidence": "low"
+        },
+        {
+          "line": 215,
+          "missing": "製造価",
+          "missing_len": 3,
+          "context": " 設備の段取作業の省人化によって、段取作業における製造価値を減らした。",
+          "confidence": "low"
+        },
+        {
+          "line": 215,
+          "missing": "造価値",
+          "missing_len": 3,
+          "context": "設備の段取作業の省人化によって、段取作業における製造価値を減らした。",
+          "confidence": "low"
+        },
+        {
+          "line": 218,
+          "missing": "設備故",
+          "missing_len": 3,
+          "context": "5. 設備の事後保全の活動を見直すことによって、設備故障から復旧までの時間を減らした。",
+          "confidence": "low"
+        },
+        {
+          "line": 218,
+          "missing": "備故障",
+          "missing_len": 3,
+          "context": "5. 設備の事後保全の活動を見直すことによって、設備故障から復旧までの時間を減らした。",
+          "confidence": "low"
+        },
+        {
+          "line": 254,
+          "missing": "作業名",
+          "missing_len": 3,
+          "context": "| 作業名 | 所要時間 |",
+          "confidence": "low"
+        },
+        {
+          "line": 254,
+          "missing": "所要時",
+          "missing_len": 3,
+          "context": "| 作業名 | 所要時間 |",
+          "confidence": "low"
+        },
+        {
+          "line": 254,
+          "missing": "要時間",
+          "missing_len": 3,
+          "context": "| 作業名 | 所要時間 |",
+          "confidence": "low"
+        },
+        {
+          "line": 379,
+          "missing": "指間外",
+          "missing_len": 3,
+          "context": "1. 使用者は、労働者に指間外労働、休日労働を行わせる場合には、時間外労働、休日",
+          "confidence": "low"
+        },
+        {
+          "line": 382,
+          "missing": "裁員労",
+          "missing_len": 3,
+          "context": "4. 事業者は、健康管理の観点から、裁員労働関の適用者及び管理監督者を除き、労働者の労働時間",
+          "confidence": "low"
+        },
+        {
+          "line": 382,
+          "missing": "員労働",
+          "missing_len": 3,
+          "context": "4. 事業者は、健康管理の観点から、裁員労働関の適用者及び管理監督者を除き、労働者の労働時間の",
+          "confidence": "low"
+        },
+        {
+          "line": 457,
+          "missing": "措置等",
+          "missing_len": 3,
+          "context": "とした言動に起因する問題に関して雇用管理上講ずべき措置等についての指針）に関する次の記述のうち、最も不適切",
+          "confidence": "low"
+        },
+        {
+          "line": 459,
+          "missing": "業務上",
+          "missing_len": 3,
+          "context": "メントとは、優越的な関係を背景とした言動であって、業務上必要かつ相当な範囲を超えたものをいい、労働者の就業",
+          "confidence": "low"
+        },
+        {
+          "line": 499,
+          "missing": "整委員",
+          "missing_len": 3,
+          "context": "紛争の解決のために必要があると認めるときは、紛争調整委員会にあっせんを行わせる。",
+          "confidence": "low"
+        },
+        {
+          "line": 536,
+          "missing": "組織全",
+          "missing_len": 3,
+          "context": "きかけであることに対し、組織開発は「グループ」や「組織全体」に働きかける取組であり、「個人」への働きかけは",
+          "confidence": "low"
+        },
+        {
+          "line": 538,
+          "missing": "個価値",
+          "missing_len": 3,
+          "context": "3. 組織開発で大切にされる個価値観の1つとして人間尊重の価値観があり、マクレガーが",
+          "confidence": "low"
+        },
+        {
+          "line": 538,
+          "missing": "又理論",
+          "missing_len": 3,
+          "context": "として人間尊重の価値観があり、マクレガーが提唱した又理論もその表れである。",
+          "confidence": "low"
+        },
+        {
+          "line": 540,
+          "missing": "潜在力",
+          "missing_len": 3,
+          "context": "ーズによって部署や職場の強みに光を当て、その強みや潜在力を引き出すことを目指す。",
+          "confidence": "low"
+        },
+        {
+          "line": 576,
+          "missing": "絶人件",
+          "missing_len": 3,
+          "context": "どの理由により、職務等級制度や役割等級制度に比べ、絶人件費が高くなりがちである。",
+          "confidence": "low"
+        },
+        {
+          "line": 630,
+          "missing": "決断力",
+          "missing_len": 3,
+          "context": "書類を処理させることにより、読取りの能力、判断力、決断力などを高める。",
+          "confidence": "low"
+        },
+        {
+          "line": 682,
+          "missing": "実績感",
+          "missing_len": 3,
+          "context": "々は、お互いに意見したり、協力したりするが、仕事の実績感は余り感じられない。",
+          "confidence": "low"
+        },
+        {
+          "line": 895,
+          "missing": "最尤推",
+          "missing_len": 3,
+          "context": "2. x̄はμの最尤推定量である。",
+          "confidence": "low"
+        },
+        {
+          "line": 895,
+          "missing": "尤推定",
+          "missing_len": 3,
+          "context": "2. x̄はμの最尤推定量である。",
+          "confidence": "low"
+        },
+        {
+          "line": 937,
+          "missing": "電話番",
+          "missing_len": 3,
+          "context": "報の情報伝達には、幅広により警報に近い場合がある、電話番号が分かる相手にしか連絡が取れない、といった課題が",
+          "confidence": "low"
+        },
+        {
+          "line": 937,
+          "missing": "話番号",
+          "missing_len": 3,
+          "context": "の情報伝達には、幅広により警報に近い場合がある、電話番号が分かる相手にしか連絡が取れない、といった課題があ",
+          "confidence": "low"
+        },
+        {
+          "line": 984,
+          "missing": "真正性",
+          "missing_len": 3,
+          "context": "チェーン上で、デジタルデータに唯一の性質を付与して真正性を保保する機能や、取引履歴を追跡できる機能を持つト",
+          "confidence": "low"
+        },
+        {
+          "line": 988,
+          "missing": "自動化",
+          "missing_len": 3,
+          "context": "的なパソコン操作をソフトウェアのロボットが代替して自動化するもの。",
+          "confidence": "low"
+        },
+        {
+          "line": 1034,
+          "missing": "付与可",
+          "missing_len": 3,
+          "context": "計されたインターネットプロトコルであり、IPv6の付与可能なIPアドレスの数は約43億個である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "散配置",
+          "missing_len": 3,
+          "context": "は、エンドユーザー付近にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "通信最",
+          "missing_len": 3,
+          "context": "付近にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷などを抑える手法で",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "信最大",
+          "missing_len": 3,
+          "context": "近にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷などを抑える手法であ",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "最大遅",
+          "missing_len": 3,
+          "context": "にデータ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷などを抑える手法である",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "大遅延",
+          "missing_len": 3,
+          "context": "データ処理や保管の機能を分散配置することで、通信最大遅延、より上位ノードの演算負荷などを抑える手法である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1074,
+          "missing": "適用範",
+          "missing_len": 3,
+          "context": "スクマネジメントのプロセスを示す円形の図。中央に「適用範囲、状況、基準」があり、その下に「リスクアセスメン",
+          "confidence": "low"
+        },
+        {
+          "line": 1074,
+          "missing": "用範囲",
+          "missing_len": 3,
+          "context": "クマネジメントのプロセスを示す円形の図。中央に「適用範囲、状況、基準」があり、その下に「リスクアセスメント",
+          "confidence": "low"
+        },
+        {
+          "line": 1074,
+          "missing": "記録作",
+          "missing_len": 3,
+          "context": "」があり、左右に「（エ）」が示されている。下部に「記録作成及び報告」がある。]",
+          "confidence": "low"
+        },
+        {
+          "line": 1074,
+          "missing": "録作成",
+          "missing_len": 3,
+          "context": "があり、左右に「（エ）」が示されている。下部に「記録作成及び報告」がある。]",
+          "confidence": "low"
+        },
+        {
+          "line": 1074,
+          "missing": "作成及",
+          "missing_len": 3,
+          "context": "あり、左右に「（エ）」が示されている。下部に「記録作成及び報告」がある。]",
+          "confidence": "low"
+        },
+        {
+          "line": 1117,
+          "missing": "安全表",
+          "missing_len": 3,
+          "context": "全法及び「長期使用製品安全点検制度及び長期使用製品安全表示制度のガイドライン」に関する次の記述のうち、最も",
+          "confidence": "low"
+        },
+        {
+          "line": 1120,
+          "missing": "輸入用",
+          "missing_len": 3,
+          "context": "2. 輸入用のもの を除く特定保守製品の製造又は輸入を行う事業",
+          "confidence": "low"
+        },
+        {
+          "line": 1120,
+          "missing": "期間及",
+          "missing_len": 3,
+          "context": "保守製品の製造又は輸入を行う事業者は、設計標準使用期間及び点検期間を設定するとともに、販売終了には設計標準",
+          "confidence": "low"
+        },
+        {
+          "line": 1120,
+          "missing": "販売終",
+          "missing_len": 3,
+          "context": "、設計標準使用期間及び点検期間を設定するとともに、販売終了には設計標準使用期間の算定の根拠等の害面を添付す",
+          "confidence": "low"
+        },
+        {
+          "line": 1120,
+          "missing": "売終了",
+          "missing_len": 3,
+          "context": "設計標準使用期間及び点検期間を設定するとともに、販売終了には設計標準使用期間の算定の根拠等の害面を添付する",
+          "confidence": "low"
+        },
+        {
+          "line": 1121,
+          "missing": "人売却",
+          "missing_len": 3,
+          "context": "守製品取引事業者に該当しない個人売主が、不動産の個人売却に伴い特定保守製品を引き渡す際、個人売主には、取得",
+          "confidence": "low"
+        },
+        {
+          "line": 1159,
+          "missing": "重点的",
+          "missing_len": 3,
+          "context": "る地域に対しては、我が国が保有する人的・物的資源を重点的かつ迅速に投入することが必要である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1161,
+          "missing": "定化処",
+          "missing_len": 3,
+          "context": "医療チームを全国から迅速に参集させ、被災地内での安定化処置などの最低限の対応が可能な体制の確保を図るととも",
+          "confidence": "low"
+        },
+        {
+          "line": 1161,
+          "missing": "化処置",
+          "missing_len": 3,
+          "context": "療チームを全国から迅速に参集させ、被災地内での安定化処置などの最低限の対応が可能な体制の確保を図るとともに",
+          "confidence": "low"
+        },
+        {
+          "line": 1197,
+          "missing": "業業行",
+          "missing_len": 3,
+          "context": "物、設備、原材料、ガス、蒸気、粉じん等により、又は業業行動その他業務に起因する危険性又は有害性であって、労",
+          "confidence": "low"
+        },
+        {
+          "line": 1197,
+          "missing": "他業務",
+          "missing_len": 3,
+          "context": "材料、ガス、蒸気、粉じん等により、又は業業行動その他業務に起因する危険性又は有害性であって、労働者の就業に",
+          "confidence": "low"
+        },
+        {
+          "line": 1200,
+          "missing": "絶括安",
+          "missing_len": 3,
+          "context": "4. 事業者は、絶括安全衛生管理者等、事業の実施を統括管理する者に調査等",
+          "confidence": "low"
+        },
+        {
+          "line": 1201,
+          "missing": "整備等",
+          "missing_len": 3,
+          "context": "置に関し、ア）個人用保護具の使用、イ）マニュアルの整備等の管理的対策、ウ）設計や計画の段階から労働者の就業",
+          "confidence": "low"
+        },
+        {
+          "line": 1276,
+          "missing": "高齢労",
+          "missing_len": 3,
+          "context": "危険源の洗い出しを行い、当該リスクの高さを考慮して高齢労働災害防止対策の優先順位を検討した。",
+          "confidence": "low"
+        },
+        {
+          "line": 1278,
+          "missing": "敏捷性",
+          "missing_len": 3,
+          "context": "3. 敏捷性や持久性、筋力といった体力の低下等の高年齢労働者の",
+          "confidence": "low"
+        },
+        {
+          "line": 1316,
+          "missing": "戦略的",
+          "missing_len": 3,
+          "context": "他平常時からのマネジメント活動であり、経営レベルの戦略的活動として位置付けられる。",
+          "confidence": "low"
+        },
+        {
+          "line": 1316,
+          "missing": "略的活",
+          "missing_len": 3,
+          "context": "平常時からのマネジメント活動であり、経営レベルの戦略的活動として位置付けられる。",
+          "confidence": "low"
+        },
+        {
+          "line": 1319,
+          "missing": "結果事",
+          "missing_len": 3,
+          "context": "、自社に生じた事態を、「ある拠点が使用不能」などの結果事象により考えるのではなく、「直下型地震」などの原因",
+          "confidence": "low"
+        },
+        {
+          "line": 1353,
+          "missing": "故障率",
+          "missing_len": 3,
+          "context": "これら自家用発電機の起動要求時の故障確率（デマンド故障率）は、どちらも0.05であるとする。",
+          "confidence": "low"
+        },
+        {
+          "line": 1395,
+          "missing": "化二窒",
+          "missing_len": 3,
+          "context": "。なお、温室効果ガスにはCO2のほか、メタン、一酸化二窒素、ハイドロフルオロカーボン類等があり、以下におい",
+          "confidence": "low"
+        },
+        {
+          "line": 1395,
+          "missing": "二窒素",
+          "missing_len": 3,
+          "context": "なお、温室効果ガスにはCO2のほか、メタン、一酸化二窒素、ハイドロフルオロカーボン類等があり、以下において",
+          "confidence": "low"
+        },
+        {
+          "line": 1399,
+          "missing": "消費量",
+          "missing_len": 3,
+          "context": "及び熱発生に伴うエネルギー起源CO2排出量を、その消費量に応じて各部門に配分した値を見ると、2020年度で",
+          "confidence": "low"
+        },
+        {
+          "line": 1399,
+          "missing": "業部門",
+          "missing_len": 3,
+          "context": "を見ると、2020年度でも家庭部門からの排出量が産業部門からの排出量を上回っている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1434,
+          "missing": "閣議決",
+          "missing_len": 3,
+          "context": "令和3年10月に閣議決定された第6次エネルギー基本計画に関する次の記述の",
+          "confidence": "low"
+        },
+        {
+          "line": 1439,
+          "missing": "炭素素",
+          "missing_len": 3,
+          "context": "エネルギーについては、合成燃料・合成メタンなどの脱炭素素化の融を措ずる技術を確立し、コストを低減することを",
+          "confidence": "low"
+        },
+        {
+          "line": 1439,
+          "missing": "素素化",
+          "missing_len": 3,
+          "context": "ネルギーについては、合成燃料・合成メタンなどの脱炭素素化の融を措ずる技術を確立し、コストを低減することを目",
+          "confidence": "low"
+        },
+        {
+          "line": 1440,
+          "missing": "一資給",
+          "missing_len": 3,
+          "context": "5. 原子力発電は、長期的なエネルギー一資給構造の安定性に寄与する重要なベースロード電源と位置",
+          "confidence": "low"
+        },
+        {
+          "line": 1440,
+          "missing": "資給構",
+          "missing_len": 3,
+          "context": "5. 原子力発電は、長期的なエネルギー一資給構造の安定性に寄与する重要なベースロード電源と位置付",
+          "confidence": "low"
+        },
+        {
+          "line": 1473,
+          "missing": "登録簿",
+          "missing_len": 3,
+          "context": "。なお、以下においては、条約湿地はラムサール条約の登録簿に掲げられている湿地を指す。",
+          "confidence": "low"
+        },
+        {
+          "line": 1477,
+          "missing": "国家的",
+          "missing_len": 3,
+          "context": "れの締約国も、既に登録されている湿地の区域を緊急な国家的利益のために廃止し若しくは縮小する権利を有している",
+          "confidence": "low"
+        },
+        {
+          "line": 1514,
+          "missing": "輸入規",
+          "missing_len": 3,
+          "context": "景として、海洋プラスチックごみ問題や諸外国の廃棄物輸入規制強化等への対応を契機として、国におけるプラスチッ",
+          "confidence": "low"
+        },
+        {
+          "line": 1514,
+          "missing": "入規制",
+          "missing_len": 3,
+          "context": "として、海洋プラスチックごみ問題や諸外国の廃棄物輸入規制強化等への対応を契機として、国におけるプラスチック",
+          "confidence": "low"
+        },
+        {
+          "line": 1518,
+          "missing": "棄物発",
+          "missing_len": 3,
+          "context": "務として、その区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置",
+          "confidence": "low"
+        },
+        {
+          "line": 1518,
+          "missing": "物発業",
+          "missing_len": 3,
+          "context": "として、その区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置を",
+          "confidence": "low"
+        },
+        {
+          "line": 1518,
+          "missing": "収集集",
+          "missing_len": 3,
+          "context": "区域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置を講ずるよう努",
+          "confidence": "low"
+        },
+        {
+          "line": 1518,
+          "missing": "集集及",
+          "missing_len": 3,
+          "context": "域内におけるプラスチック使用製品廃棄物発業の分別収集集及び分別収集物の再商品化に必要な措置を講ずるよう努め",
+          "confidence": "low"
+        },
+        {
+          "line": 1551,
+          "missing": "環境政",
+          "missing_len": 3,
+          "context": "環境政策手段に関する次の記述の、□□□□□に入る用語の組",
+          "confidence": "low"
+        },
+        {
+          "line": 1567,
+          "missing": "低利融",
+          "missing_len": 3,
+          "context": "| ⑤ | パフォーマンス規制 | 低利融資 | 補助金 | 環境報告書 | 再生可能エネル",
+          "confidence": "low"
+        },
+        {
+          "line": 1567,
+          "missing": "利融資",
+          "missing_len": 3,
+          "context": "| ⑤ | パフォーマンス規制 | 低利融資 | 補助金 | 環境報告書 | 再生可能エネルギ",
+          "confidence": "low"
+        },
+        {
+          "line": 1567,
+          "missing": "環境報",
+          "missing_len": 3,
+          "context": "パフォーマンス規制 | 低利融資 | 補助金 | 環境報告書 | 再生可能エネルギーの固定価格買取制度 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1567,
+          "missing": "境報告",
+          "missing_len": 3,
+          "context": "フォーマンス規制 | 低利融資 | 補助金 | 環境報告書 | 再生可能エネルギーの固定価格買取制度 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1601,
+          "missing": "環境政",
+          "missing_len": 3,
+          "context": "環境政策で使われる用語と、その説明の組合せとして、次のう",
+          "confidence": "low"
+        },
+        {
+          "line": 1605,
+          "missing": "環境目",
+          "missing_len": 3,
+          "context": "グ：現状の社会構造や外部環境要因を前提とし、将来の環境目標は同示さず、環境対策ができるところから行う手法",
+          "confidence": "low"
+        },
+        {
+          "line": 1605,
+          "missing": "境目標",
+          "missing_len": 3,
+          "context": "：現状の社会構造や外部環境要因を前提とし、将来の環境目標は同示さず、環境対策ができるところから行う手法",
+          "confidence": "low"
+        },
+        {
+          "line": 1640,
+          "missing": "評価準",
+          "missing_len": 3,
+          "context": "以下では、環境影響評価方法書を「方法書」、環境影響評価準備書を「準備書」、環境影響評価書を「評価書」とそれ",
+          "confidence": "low"
+        },
+        {
+          "line": 1640,
+          "missing": "価準備",
+          "missing_len": 3,
+          "context": "下では、環境影響評価方法書を「方法書」、環境影響評価準備書を「準備書」、環境影響評価書を「評価書」とそれぞ",
+          "confidence": "low"
+        },
+        {
+          "line": 1642,
+          "missing": "設置工",
+          "missing_len": 3,
+          "context": "1. 風力発電所の設置工事の事業は、出力の規模により、第一種事業の場合と第",
+          "confidence": "low"
+        },
+        {
+          "line": 1642,
+          "missing": "置工事",
+          "missing_len": 3,
+          "context": "1. 風力発電所の設置工事の事業は、出力の規模により、第一種事業の場合と第二",
+          "confidence": "low"
+        },
+        {
+          "line": 1644,
+          "missing": "町村長",
+          "missing_len": 3,
+          "context": "ある と認められる地域を管轄する都道府県知事及び市町村長に対し、方法書及びこれを要約した書類を送付しなけれ",
+          "confidence": "low"
+        },
+        {
+          "line": 1678,
+          "missing": "関連務",
+          "missing_len": 3,
+          "context": "気候関連務情報開示タスクフォース（TCFD）提言と踏まえて、",
+          "confidence": "low"
+        },
+        {
+          "line": 1678,
+          "missing": "連務情",
+          "missing_len": 3,
+          "context": "気候関連務情報開示タスクフォース（TCFD）提言と踏まえて、環",
+          "confidence": "low"
+        },
+        {
+          "line": 1678,
+          "missing": "最新報",
+          "missing_len": 3,
+          "context": "CFD提言とは、TCFDが2017年6月に公表した最新報告の提言をいう。",
+          "confidence": "low"
+        },
+        {
+          "line": 1678,
+          "missing": "新報告",
+          "missing_len": 3,
+          "context": "FD提言とは、TCFDが2017年6月に公表した最新報告の提言をいう。",
+          "confidence": "low"
+        },
+        {
+          "line": 1682,
+          "missing": "低炭素",
+          "missing_len": 3,
+          "context": "3. TCFD提言では気候関連リスクを、低炭素経済への「移行」に関するリスクと、気候変動による「",
+          "confidence": "low"
+        },
+        {
+          "line": 1682,
+          "missing": "炭素経",
+          "missing_len": 3,
+          "context": "3. TCFD提言では気候関連リスクを、低炭素経済への「移行」に関するリスクと、気候変動による「物",
+          "confidence": "low"
+        },
+        {
+          "line": 1682,
+          "missing": "気候変",
+          "missing_len": 3,
+          "context": "リスクを、低炭素経済への「移行」に関するリスクと、気候変動による「物理的」変化に関するリスクに大別している",
+          "confidence": "low"
+        },
+        {
+          "line": 1682,
+          "missing": "候変動",
+          "missing_len": 3,
+          "context": "スクを、低炭素経済への「移行」に関するリスクと、気候変動による「物理的」変化に関するリスクに大別している。",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R05",
+      "kind": "secondary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R05/R05_試験問題_記述式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r05-secondary/article.mdx",
+      "ocr_text_len": 3857,
+      "mdx_text_lines": 50,
+      "ocr_kanji_ngrams": 601,
+      "mismatch_total": 17,
+      "mismatch_by_confidence": {
+        "high": 3,
+        "medium": 5,
+        "low": 9
+      },
+      "ocr_figure_captions": [
+        "図1",
+        "図 2"
+      ],
+      "ocr_figure_caption_count": 2,
+      "candidates": [
+        {
+          "line": 23,
+          "missing": "少子高齢化",
+          "missing_len": 5,
+          "context": "Tの急速な進展の成果等が利用可能となる反面，深刻な少子高齢化や労働力不足の加速化等，我が国の経済社会は大きく変",
+          "confidence": "high"
+        },
+        {
+          "line": 27,
+          "missing": "行政機関等",
+          "missing_len": 5,
+          "context": "例えば民間企業では「利益の最大化」などが考えられ，行政機関等では「公益の最大化」などが考えられる。その目的達成",
+          "confidence": "high"
+        },
+        {
+          "line": 66,
+          "missing": "的資源管理",
+          "missing_len": 5,
+          "context": "とは，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に関する総合的な分析，評価",
+          "confidence": "high"
+        },
+        {
+          "line": 23,
+          "missing": "子高齢化",
+          "missing_len": 4,
+          "context": "の急速な進展の成果等が利用可能となる反面，深刻な少子高齢化や労働力不足の加速化等，我が国の経済社会は大きく変",
+          "confidence": "medium"
+        },
+        {
+          "line": 27,
+          "missing": "政機関等",
+          "missing_len": 4,
+          "context": "えば民間企業では「利益の最大化」などが考えられ，行政機関等では「公益の最大化」などが考えられる。その目的達成",
+          "confidence": "medium"
+        },
+        {
+          "line": 29,
+          "missing": "人口動態",
+          "missing_len": 4,
+          "context": "向等の経済的要因，法令・規制の変更等の政治的要因，人口動態やライフスタイルの変化等の社会的要因，顧客や市場の",
+          "confidence": "medium"
+        },
+        {
+          "line": 47,
+          "missing": "撤退戦略",
+          "missing_len": 4,
+          "context": "威）差別化戦略など | パターンD：（弱み×脅威）撤退戦略，縮小戦略など |",
+          "confidence": "medium"
+        },
+        {
+          "line": 66,
+          "missing": "資源管理",
+          "missing_len": 4,
+          "context": "は，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に関する総合的な分析，評価",
+          "confidence": "medium"
+        },
+        {
+          "line": 23,
+          "missing": "高齢化",
+          "missing_len": 3,
+          "context": "急速な進展の成果等が利用可能となる反面，深刻な少子高齢化や労働力不足の加速化等，我が国の経済社会は大きく変",
+          "confidence": "low"
+        },
+        {
+          "line": 27,
+          "missing": "機関等",
+          "missing_len": 3,
+          "context": "ば民間企業では「利益の最大化」などが考えられ，行政機関等では「公益の最大化」などが考えられる。その目的達成",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "人口動",
+          "missing_len": 3,
+          "context": "向等の経済的要因，法令・規制の変更等の政治的要因，人口動態やライフスタイルの変化等の社会的要因，顧客や市場",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "口動態",
+          "missing_len": 3,
+          "context": "等の経済的要因，法令・規制の変更等の政治的要因，人口動態やライフスタイルの変化等の社会的要因，顧客や市場の",
+          "confidence": "low"
+        },
+        {
+          "line": 35,
+          "missing": "段階的",
+          "missing_len": 3,
+          "context": "，例えば外部からの補強や他組織との提携，経営資源の段階的な改善等の戦略が考えられる。",
+          "confidence": "low"
+        },
+        {
+          "line": 47,
+          "missing": "撤退戦",
+          "missing_len": 3,
+          "context": "威）差別化戦略など | パターンD：（弱み×脅威）撤退戦略，縮小戦略など |",
+          "confidence": "low"
+        },
+        {
+          "line": 66,
+          "missing": "源管理",
+          "missing_len": 3,
+          "context": "，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に関する総合的な分析，評価",
+          "confidence": "low"
+        },
+        {
+          "line": 72,
+          "missing": "事業部",
+          "missing_len": 3,
+          "context": "しては，組織体全体でもよいし，その一部を構成する「事業部」，「地方組織」などの単位で自由に設定してもよい。",
+          "confidence": "low"
+        },
+        {
+          "line": 78,
+          "missing": "代表例",
+          "missing_len": 3,
+          "context": "ロセス（経営資源によりアウトプットを創出する過程の代表例）を記せ。",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R04",
+      "kind": "primary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R04/R04_試験問題_択一式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r04-primary/article.mdx",
+      "ocr_text_len": 19644,
+      "mdx_text_lines": 325,
+      "ocr_kanji_ngrams": 3592,
+      "mismatch_total": 291,
+      "mismatch_by_confidence": {
+        "high": 69,
+        "medium": 101,
+        "low": 121
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 316,
+          "missing": "全系統時間",
+          "missing_len": 5,
+          "context": "日程計画における作業Eの作業時間は3時間、作業Eの全系統時間は4時間、作業Eの最早開始時刻は午前10時である。",
+          "confidence": "high"
+        },
+        {
+          "line": 323,
+          "missing": "全系統時間",
+          "missing_len": 5,
+          "context": "Eの作業時間だけが5時間に変更された場合、作業Eの全系統時間は2時間になる。",
+          "confidence": "high"
+        },
+        {
+          "line": 360,
+          "missing": "総労働時間",
+          "missing_len": 5,
+          "context": "変形労働時間制を導入した場合、あらかじめ定められた総労働時間の範囲内で、対象期間における各日の始業及び終業の時",
+          "confidence": "high"
+        },
+        {
+          "line": 476,
+          "missing": "検査結果報",
+          "missing_len": 5,
+          "context": "ックを実施した事業者は、労働者を検査した医師等から検査結果報告書を入手し、ストレスの程度を記録後、遅滞なく、労",
+          "confidence": "high"
+        },
+        {
+          "line": 476,
+          "missing": "査結果報告",
+          "missing_len": 5,
+          "context": "クを実施した事業者は、労働者を検査した医師等から検査結果報告書を入手し、ストレスの程度を記録後、遅滞なく、労働",
+          "confidence": "high"
+        },
+        {
+          "line": 518,
+          "missing": "企業内蓄積",
+          "missing_len": 5,
+          "context": "2つの指揮命令系統を設定することにより、市場競争と企業内蓄積のバランスのとれた事業運営を行う。",
+          "confidence": "high"
+        },
+        {
+          "line": 565,
+          "missing": "入社後一旦",
+          "missing_len": 5,
+          "context": "4. 組織コミットメントの3つの要素のうち、一般に入社後一旦低下したのち上昇していく傾向にあるのは功利的コミッ",
+          "confidence": "high"
+        },
+        {
+          "line": 565,
+          "missing": "社後一旦低",
+          "missing_len": 5,
+          "context": ". 組織コミットメントの3つの要素のうち、一般に入社後一旦低下したのち上昇していく傾向にあるのは功利的コミット",
+          "confidence": "high"
+        },
+        {
+          "line": 565,
+          "missing": "後一旦低下",
+          "missing_len": 5,
+          "context": " 組織コミットメントの3つの要素のうち、一般に入社後一旦低下したのち上昇していく傾向にあるのは功利的コミットメ",
+          "confidence": "high"
+        },
+        {
+          "line": 599,
+          "missing": "外部労働市",
+          "missing_len": 5,
+          "context": "における職型雇用では、人の出入りがあるために会社が外部労働市場にさらされ、一般的にメンバーシップ型より報酬が高",
+          "confidence": "high"
+        },
+        {
+          "line": 599,
+          "missing": "部労働市場",
+          "missing_len": 5,
+          "context": "おける職型雇用では、人の出入りがあるために会社が外部労働市場にさらされ、一般的にメンバーシップ型より報酬が高く",
+          "confidence": "high"
+        },
+        {
+          "line": 761,
+          "missing": "平均故障間",
+          "missing_len": 5,
+          "context": "使用しており、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用して",
+          "confidence": "high"
+        },
+        {
+          "line": 761,
+          "missing": "均故障間動",
+          "missing_len": 5,
+          "context": "用しており、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用してい",
+          "confidence": "high"
+        },
+        {
+          "line": 761,
+          "missing": "故障間動時",
+          "missing_len": 5,
+          "context": "しており、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用している",
+          "confidence": "high"
+        },
+        {
+          "line": 761,
+          "missing": "障間動時間",
+          "missing_len": 5,
+          "context": "ており、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用しているす",
+          "confidence": "high"
+        },
+        {
+          "line": 761,
+          "missing": "総稼働時間",
+          "missing_len": 5,
+          "context": "用しているすべてのサーバの運用開始から現時点までの総稼働時間（実績稼働時間と総修理時間の和）、稼働率、故障件数",
+          "confidence": "high"
+        },
+        {
+          "line": 761,
+          "missing": "実績稼働時",
+          "missing_len": 5,
+          "context": "べてのサーバの運用開始から現時点までの総稼働時間（実績稼働時間と総修理時間の和）、稼働率、故障件数を調べ、機種",
+          "confidence": "high"
+        },
+        {
+          "line": 761,
+          "missing": "績稼働時間",
+          "missing_len": 5,
+          "context": "てのサーバの運用開始から現時点までの総稼働時間（実績稼働時間と総修理時間の和）、稼働率、故障件数を調べ、機種ご",
+          "confidence": "high"
+        },
+        {
+          "line": 765,
+          "missing": "総稼働時間",
+          "missing_len": 5,
+          "context": "| | 総稼働時間（時間） | 稼働率 | 故障件数（件） |",
+          "confidence": "high"
+        },
+        {
+          "line": 1035,
+          "missing": "実労働時間",
+          "missing_len": 5,
+          "context": "| 事業所 | 労働災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数",
+          "confidence": "high"
+        },
+        {
+          "line": 1035,
+          "missing": "労働時間数",
+          "missing_len": 5,
+          "context": "| 事業所 | 労働災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 ",
+          "confidence": "high"
+        },
+        {
+          "line": 1035,
+          "missing": "労働損失日",
+          "missing_len": 5,
+          "context": "災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1035,
+          "missing": "働損失日数",
+          "missing_len": 5,
+          "context": "害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1035,
+          "missing": "平均労働者",
+          "missing_len": 5,
+          "context": "べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1035,
+          "missing": "均労働者数",
+          "missing_len": 5,
+          "context": "実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "土強靭化基",
+          "missing_len": 5,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "強靭化基本",
+          "missing_len": 5,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災・",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "靭化基本法",
+          "missing_len": 5,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災・減",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "土強靭化地",
+          "missing_len": 5,
+          "context": "ための防災・減災等に資する国土強靭化基本法）及び国土強靭化地域計画策定ガイドラインに関する次の記述のうち、最も",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "強靭化地域",
+          "missing_len": 5,
+          "context": "めの防災・減災等に資する国土強靭化基本法）及び国土強靭化地域計画策定ガイドラインに関する次の記述のうち、最も不",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "靭化地域計",
+          "missing_len": 5,
+          "context": "の防災・減災等に資する国土強靭化基本法）及び国土強靭化地域計画策定ガイドラインに関する次の記述のうち、最も不適",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "規模自然災",
+          "missing_len": 5,
+          "context": "不適切なものはどれか。ここでいう国土強靭化とは、大規模自然災害等に備えるため、事前防災・減災と迅速な復興に資す",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "模自然災害",
+          "missing_len": 5,
+          "context": "適切なものはどれか。ここでいう国土強靭化とは、大規模自然災害等に備えるため、事前防災・減災と迅速な復興に資する",
+          "confidence": "high"
+        },
+        {
+          "line": 1118,
+          "missing": "自然災害等",
+          "missing_len": 5,
+          "context": "切なものはどれか。ここでいう国土強靭化とは、大規模自然災害等に備えるため、事前防災・減災と迅速な復興に資する施",
+          "confidence": "high"
+        },
+        {
+          "line": 1120,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリス",
+          "confidence": "high"
+        },
+        {
+          "line": 1120,
+          "missing": "土強靭化基",
+          "missing_len": 5,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリスク",
+          "confidence": "high"
+        },
+        {
+          "line": 1120,
+          "missing": "強靭化基本",
+          "missing_len": 5,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリスクと",
+          "confidence": "high"
+        },
+        {
+          "line": 1120,
+          "missing": "靭化基本計",
+          "missing_len": 5,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリスクとし",
+          "confidence": "high"
+        },
+        {
+          "line": 1121,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する施",
+          "confidence": "high"
+        },
+        {
+          "line": 1121,
+          "missing": "土強靭化基",
+          "missing_len": 5,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する施策",
+          "confidence": "high"
+        },
+        {
+          "line": 1121,
+          "missing": "強靭化基本",
+          "missing_len": 5,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する施策の",
+          "confidence": "high"
+        },
+        {
+          "line": 1121,
+          "missing": "靭化基本計",
+          "missing_len": 5,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する施策の分",
+          "confidence": "high"
+        },
+        {
+          "line": 1122,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "3. 国土強靭化においては、自助、共助、公助を適切に組み合わせるこ",
+          "confidence": "high"
+        },
+        {
+          "line": 1123,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "4. 国土強靭化においては、非常時に効果を発揮するのはもちろん、平",
+          "confidence": "high"
+        },
+        {
+          "line": 1124,
+          "missing": "国土強靭化",
+          "missing_len": 5,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画で",
+          "confidence": "high"
+        },
+        {
+          "line": 1124,
+          "missing": "土強靭化地",
+          "missing_len": 5,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であ",
+          "confidence": "high"
+        },
+        {
+          "line": 1124,
+          "missing": "強靭化地域",
+          "missing_len": 5,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であり",
+          "confidence": "high"
+        },
+        {
+          "line": 1124,
+          "missing": "靭化地域計",
+          "missing_len": 5,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であり、",
+          "confidence": "high"
+        },
+        {
+          "line": 1124,
+          "missing": "土強靭化計",
+          "missing_len": 5,
+          "context": ". 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であり、地方公共団体が策定する国土強靭化に係る他",
+          "confidence": "high"
+        },
+        {
+          "line": 1124,
+          "missing": "強靭化計画",
+          "missing_len": 5,
+          "context": " 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であり、地方公共団体が策定する国土強靭化に係る他の",
+          "confidence": "high"
+        },
+        {
+          "line": 1328,
+          "missing": "目的達成及",
+          "missing_len": 5,
+          "context": "ジメントは、反復して行うものであり、■■■の決定、目的達成及び十分な情報に基づいた決定に当たって組織を支援する",
+          "confidence": "high"
+        },
+        {
+          "line": 1378,
+          "missing": "内航海運等",
+          "missing_len": 5,
+          "context": "ラック単体の低燃費化や輸送効率の向上と並せ、鉄道、内航海運等のエネルギー消費率の良い輸送機関の活用を図ることが",
+          "confidence": "high"
+        },
+        {
+          "line": 1379,
+          "missing": "分譲戸建住",
+          "missing_len": 5,
+          "context": " 住宅の省エネルギー一性能の一層の向上を図るため、分譲戸建住宅のほか、注文戸建住宅や賃貸アパートにも省エネルギ",
+          "confidence": "high"
+        },
+        {
+          "line": 1379,
+          "missing": "譲戸建住宅",
+          "missing_len": 5,
+          "context": "住宅の省エネルギー一性能の一層の向上を図るため、分譲戸建住宅のほか、注文戸建住宅や賃貸アパートにも省エネルギー",
+          "confidence": "high"
+        },
+        {
+          "line": 1379,
+          "missing": "文戸建住宅",
+          "missing_len": 5,
+          "context": "性能の一層の向上を図るため、分譲戸建住宅のほか、注文戸建住宅や賃貸アパートにも省エネルギー一性能の向上の目標が",
+          "confidence": "high"
+        },
+        {
+          "line": 1461,
+          "missing": "来生物被防",
+          "missing_len": 5,
+          "context": "5. 特定外来生物被防止基本方針では、特別な機器を使用しくともき種類の判",
+          "confidence": "high"
+        },
+        {
+          "line": 1461,
+          "missing": "生物被防止",
+          "missing_len": 5,
+          "context": "5. 特定外来生物被防止基本方針では、特別な機器を使用しくともき種類の判別",
+          "confidence": "high"
+        },
+        {
+          "line": 1461,
+          "missing": "物被防止基",
+          "missing_len": 5,
+          "context": "5. 特定外来生物被防止基本方針では、特別な機器を使用しくともき種類の判別が",
+          "confidence": "high"
+        },
+        {
+          "line": 1461,
+          "missing": "被防止基本",
+          "missing_len": 5,
+          "context": "5. 特定外来生物被防止基本方針では、特別な機器を使用しくともき種類の判別が可",
+          "confidence": "high"
+        },
+        {
+          "line": 1498,
+          "missing": "移動禁止特",
+          "missing_len": 5,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とする",
+          "confidence": "high"
+        },
+        {
+          "line": 1498,
+          "missing": "動禁止特定",
+          "missing_len": 5,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とするも",
+          "confidence": "high"
+        },
+        {
+          "line": 1498,
+          "missing": "禁止特定有",
+          "missing_len": 5,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とするもの",
+          "confidence": "high"
+        },
+        {
+          "line": 1498,
+          "missing": "止特定有害",
+          "missing_len": 5,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とするものが",
+          "confidence": "high"
+        },
+        {
+          "line": 1533,
+          "missing": "年間発生数",
+          "missing_len": 5,
+          "context": " 全国のフェーダスによる1時間降水量50mm以上の年間発生数は、増加傾向にある。",
+          "confidence": "high"
+        },
+        {
+          "line": 1613,
+          "missing": "影響評価項",
+          "missing_len": 5,
+          "context": "2. 事業者は、環境影響評価方法書とともに、環境影響評価項の項目並びに調査、予測及び評価の手法などを確定させ",
+          "confidence": "high"
+        },
+        {
+          "line": 1614,
+          "missing": "価準備書及",
+          "missing_len": 5,
+          "context": "管轄する都道府県知事及び市町村長に対し、環境影響評価準備書及びこれを要約した書類を送付しなければならない。",
+          "confidence": "high"
+        },
+        {
+          "line": 1649,
+          "missing": "投資対象企",
+          "missing_len": 5,
+          "context": "責任投資原則は、投資にESGの視点を組み込むことや投資対象企業に対してESGに関する情報開示を求めることなどか",
+          "confidence": "high"
+        },
+        {
+          "line": 1649,
+          "missing": "資対象企業",
+          "missing_len": 5,
+          "context": "任投資原則は、投資にESGの視点を組み込むことや投資対象企業に対してESGに関する情報開示を求めることなどから",
+          "confidence": "high"
+        },
+        {
+          "line": 98,
+          "missing": "計算方法",
+          "missing_len": 4,
+          "context": "。なお、移動平均法及び単純指数平滑法による予測値の計算方法はそれぞれ以下のとおりである。",
+          "confidence": "medium"
+        },
+        {
+          "line": 316,
+          "missing": "全系統時",
+          "missing_len": 4,
+          "context": "日程計画における作業Eの作業時間は3時間、作業Eの全系統時間は4時間、作業Eの最早開始時刻は午前10時である",
+          "confidence": "medium"
+        },
+        {
+          "line": 316,
+          "missing": "系統時間",
+          "missing_len": 4,
+          "context": "程計画における作業Eの作業時間は3時間、作業Eの全系統時間は4時間、作業Eの最早開始時刻は午前10時である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 323,
+          "missing": "全系統時",
+          "missing_len": 4,
+          "context": "Eの作業時間だけが5時間に変更された場合、作業Eの全系統時間は2時間になる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 323,
+          "missing": "系統時間",
+          "missing_len": 4,
+          "context": "の作業時間だけが5時間に変更された場合、作業Eの全系統時間は2時間になる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 360,
+          "missing": "総労働時",
+          "missing_len": 4,
+          "context": "変形労働時間制を導入した場合、あらかじめ定められた総労働時間の範囲内で、対象期間における各日の始業及び終業の",
+          "confidence": "medium"
+        },
+        {
+          "line": 397,
+          "missing": "退職手当",
+          "missing_len": 4,
+          "context": "用労働者を雇い入れたときは、速やかに、昇給の有無、退職手当の有無、賃与の有無、相談窓口を文書の交付などにより",
+          "confidence": "medium"
+        },
+        {
+          "line": 476,
+          "missing": "査結果報",
+          "missing_len": 4,
+          "context": "クを実施した事業者は、労働者を検査した医師等から検査結果報告書を入手し、ストレスの程度を記録後、遅滞なく、労",
+          "confidence": "medium"
+        },
+        {
+          "line": 512,
+          "missing": "構造変革",
+          "missing_len": 4,
+          "context": "働を行うことによって、環境の変化に対して自ら柔軟な構造変革を行う。",
+          "confidence": "medium"
+        },
+        {
+          "line": 518,
+          "missing": "企業内蓄",
+          "missing_len": 4,
+          "context": "2つの指揮命令系統を設定することにより、市場競争と企業内蓄積のバランスのとれた事業運営を行う。",
+          "confidence": "medium"
+        },
+        {
+          "line": 518,
+          "missing": "業内蓄積",
+          "missing_len": 4,
+          "context": "つの指揮命令系統を設定することにより、市場競争と企業内蓄積のバランスのとれた事業運営を行う。",
+          "confidence": "medium"
+        },
+        {
+          "line": 565,
+          "missing": "社後一旦",
+          "missing_len": 4,
+          "context": ". 組織コミットメントの3つの要素のうち、一般に入社後一旦低下したのち上昇していく傾向にあるのは功利的コミッ",
+          "confidence": "medium"
+        },
+        {
+          "line": 565,
+          "missing": "後一旦低",
+          "missing_len": 4,
+          "context": " 組織コミットメントの3つの要素のうち、一般に入社後一旦低下したのち上昇していく傾向にあるのは功利的コミット",
+          "confidence": "medium"
+        },
+        {
+          "line": 565,
+          "missing": "一旦低下",
+          "missing_len": 4,
+          "context": "組織コミットメントの3つの要素のうち、一般に入社後一旦低下したのち上昇していく傾向にあるのは功利的コミットメ",
+          "confidence": "medium"
+        },
+        {
+          "line": 599,
+          "missing": "職型雇用",
+          "missing_len": 4,
+          "context": "1. 専門性の高い業務における職型雇用では、人の出入りがあるために会社が外部労働市場にさ",
+          "confidence": "medium"
+        },
+        {
+          "line": 599,
+          "missing": "外部労働",
+          "missing_len": 4,
+          "context": "における職型雇用では、人の出入りがあるために会社が外部労働市場にさらされ、一般的にメンバーシップ型より報酬が",
+          "confidence": "medium"
+        },
+        {
+          "line": 599,
+          "missing": "部労働市",
+          "missing_len": 4,
+          "context": "おける職型雇用では、人の出入りがあるために会社が外部労働市場にさらされ、一般的にメンバーシップ型より報酬が高",
+          "confidence": "medium"
+        },
+        {
+          "line": 599,
+          "missing": "労働市場",
+          "missing_len": 4,
+          "context": "ける職型雇用では、人の出入りがあるために会社が外部労働市場にさらされ、一般的にメンバーシップ型より報酬が高く",
+          "confidence": "medium"
+        },
+        {
+          "line": 603,
+          "missing": "活用促進",
+          "missing_len": 4,
+          "context": "では、適材適所による生産性向上、ローバフォーマーの活用促進、セクショナリズムの軽減などが期待できる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 635,
+          "missing": "性績考課",
+          "missing_len": 4,
+          "context": "最も不適切なものはどれか。なお、成績考課については性績考課と呼ぶこともある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 680,
+          "missing": "情報漏洩",
+          "missing_len": 4,
+          "context": "（イ）複数の企業を対象にして、一定期間内の情報漏洩などの事件発生の有無に対して従業員数や情報セキュリ",
+          "confidence": "medium"
+        },
+        {
+          "line": 725,
+          "missing": "製造会社",
+          "missing_len": 4,
+          "context": "ソフトウェアを購入した個人が、メディア媒捺に備え、製造会社の許諾を得ずに個人的にDVD-Rにバックアップ・コ",
+          "confidence": "medium"
+        },
+        {
+          "line": 761,
+          "missing": "均故障間",
+          "missing_len": 4,
+          "context": "用しており、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用して",
+          "confidence": "medium"
+        },
+        {
+          "line": 761,
+          "missing": "故障間動",
+          "missing_len": 4,
+          "context": "しており、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用してい",
+          "confidence": "medium"
+        },
+        {
+          "line": 761,
+          "missing": "障間動時",
+          "missing_len": 4,
+          "context": "ており、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用している",
+          "confidence": "medium"
+        },
+        {
+          "line": 761,
+          "missing": "間動時間",
+          "missing_len": 4,
+          "context": "おり、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用しているす",
+          "confidence": "medium"
+        },
+        {
+          "line": 761,
+          "missing": "総稼働時",
+          "missing_len": 4,
+          "context": "用しているすべてのサーバの運用開始から現時点までの総稼働時間（実績稼働時間と総修理時間の和）、稼働率、故障件",
+          "confidence": "medium"
+        },
+        {
+          "line": 761,
+          "missing": "実績稼働",
+          "missing_len": 4,
+          "context": "べてのサーバの運用開始から現時点までの総稼働時間（実績稼働時間と総修理時間の和）、稼働率、故障件数を調べ、機",
+          "confidence": "medium"
+        },
+        {
+          "line": 761,
+          "missing": "績稼働時",
+          "missing_len": 4,
+          "context": "てのサーバの運用開始から現時点までの総稼働時間（実績稼働時間と総修理時間の和）、稼働率、故障件数を調べ、機種",
+          "confidence": "medium"
+        },
+        {
+          "line": 765,
+          "missing": "総稼働時",
+          "missing_len": 4,
+          "context": "| | 総稼働時間（時間） | 稼働率 | 故障件数（件） |",
+          "confidence": "medium"
+        },
+        {
+          "line": 850,
+          "missing": "名義尺度",
+          "missing_len": 4,
+          "context": "| 名義尺度 | （イ） | × | × | × | （エ） ",
+          "confidence": "medium"
+        },
+        {
+          "line": 851,
+          "missing": "段階評価",
+          "missing_len": 4,
+          "context": "| （ア）尺度 | 5段階評価による満足度 | ○ | × | × | 中央値 ",
+          "confidence": "medium"
+        },
+        {
+          "line": 852,
+          "missing": "間隔尺度",
+          "missing_len": 4,
+          "context": "| 間隔尺度 | 温度（℃） | ○ | ○ | × | 最頻",
+          "confidence": "medium"
+        },
+        {
+          "line": 952,
+          "missing": "既存企業",
+          "missing_len": 4,
+          "context": "従来型のビジネスモデルや商習慣に風穴が開くことで、既存企業の存続が困難になること。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1000,
+          "missing": "発信情報",
+          "missing_len": 4,
+          "context": "5. 電子メールによる発信情報が途中で書き換えられて受信者に届くなごまんを防ぐた",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "死傷者数",
+          "missing_len": 4,
+          "context": "| 事業所 | 労働災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "実労働時",
+          "missing_len": 4,
+          "context": "| 事業所 | 労働災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "働時間数",
+          "missing_len": 4,
+          "context": " 事業所 | 労働災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "労働損失",
+          "missing_len": 4,
+          "context": "災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "働損失日",
+          "missing_len": 4,
+          "context": "害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "損失日数",
+          "missing_len": 4,
+          "context": "による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "平均労働",
+          "missing_len": 4,
+          "context": "べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1035,
+          "missing": "均労働者",
+          "missing_len": 4,
+          "context": "実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1085,
+          "missing": "作業行動",
+          "missing_len": 4,
+          "context": "就業に係る建設物、設備、原材料、ガス等により、又は作業行動その他業務に起因して、労働者が負傷し、疾病にかかり",
+          "confidence": "medium"
+        },
+        {
+          "line": 1118,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための",
+          "confidence": "medium"
+        },
+        {
+          "line": 1118,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防",
+          "confidence": "medium"
+        },
+        {
+          "line": 1118,
+          "missing": "強靭化基",
+          "missing_len": 4,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災",
+          "confidence": "medium"
+        },
+        {
+          "line": 1118,
+          "missing": "靭化基本",
+          "missing_len": 4,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災・",
+          "confidence": "medium"
+        },
+        {
+          "line": 1118,
+          "missing": "強靭化地",
+          "missing_len": 4,
+          "context": "めの防災・減災等に資する国土強靭化基本法）及び国土強靭化地域計画策定ガイドラインに関する次の記述のうち、最も",
+          "confidence": "medium"
+        },
+        {
+          "line": 1118,
+          "missing": "靭化地域",
+          "missing_len": 4,
+          "context": "の防災・減災等に資する国土強靭化基本法）及び国土強靭化地域計画策定ガイドラインに関する次の記述のうち、最も不",
+          "confidence": "medium"
+        },
+        {
+          "line": 1118,
+          "missing": "模自然災",
+          "missing_len": 4,
+          "context": "適切なものはどれか。ここでいう国土強靭化とは、大規模自然災害等に備えるため、事前防災・減災と迅速な復興に資す",
+          "confidence": "medium"
+        },
+        {
+          "line": 1118,
+          "missing": "自然災害",
+          "missing_len": 4,
+          "context": "切なものはどれか。ここでいう国土強靭化とは、大規模自然災害等に備えるため、事前防災・減災と迅速な復興に資する",
+          "confidence": "medium"
+        },
+        {
+          "line": 1118,
+          "missing": "然災害等",
+          "missing_len": 4,
+          "context": "なものはどれか。ここでいう国土強靭化とは、大規模自然災害等に備えるため、事前防災・減災と迅速な復興に資する施",
+          "confidence": "medium"
+        },
+        {
+          "line": 1120,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1120,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリス",
+          "confidence": "medium"
+        },
+        {
+          "line": 1120,
+          "missing": "強靭化基",
+          "missing_len": 4,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリスク",
+          "confidence": "medium"
+        },
+        {
+          "line": 1120,
+          "missing": "靭化基本",
+          "missing_len": 4,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリスクと",
+          "confidence": "medium"
+        },
+        {
+          "line": 1120,
+          "missing": "自然災害",
+          "missing_len": 4,
+          "context": "は、国民生活・国民経済に影響を及ぼすリスクとして、自然災害のほか、原子力災害などの大規模事故等も含めたあらゆ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1121,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する",
+          "confidence": "medium"
+        },
+        {
+          "line": 1121,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する施",
+          "confidence": "medium"
+        },
+        {
+          "line": 1121,
+          "missing": "強靭化基",
+          "missing_len": 4,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する施策",
+          "confidence": "medium"
+        },
+        {
+          "line": 1121,
+          "missing": "靭化基本",
+          "missing_len": 4,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する施策の",
+          "confidence": "medium"
+        },
+        {
+          "line": 1122,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "3. 国土強靭化においては、自助、共助、公助を適切に組み合わせる",
+          "confidence": "medium"
+        },
+        {
+          "line": 1122,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "3. 国土強靭化においては、自助、共助、公助を適切に組み合わせるこ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1123,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "4. 国土強靭化においては、非常時に効果を発揮するのはもちろん、",
+          "confidence": "medium"
+        },
+        {
+          "line": 1123,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "4. 国土強靭化においては、非常時に効果を発揮するのはもちろん、平",
+          "confidence": "medium"
+        },
+        {
+          "line": 1123,
+          "missing": "土地利用",
+          "missing_len": 4,
+          "context": "常時に効果を発揮するのはもちろん、平時からの国土・土地利用や経済活動にも資する取組を推進する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1124,
+          "missing": "国土強靭",
+          "missing_len": 4,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画",
+          "confidence": "medium"
+        },
+        {
+          "line": 1124,
+          "missing": "土強靭化",
+          "missing_len": 4,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画で",
+          "confidence": "medium"
+        },
+        {
+          "line": 1124,
+          "missing": "強靭化地",
+          "missing_len": 4,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1124,
+          "missing": "靭化地域",
+          "missing_len": 4,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であり",
+          "confidence": "medium"
+        },
+        {
+          "line": 1124,
+          "missing": "強靭化計",
+          "missing_len": 4,
+          "context": " 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であり、地方公共団体が策定する国土強靭化に係る他",
+          "confidence": "medium"
+        },
+        {
+          "line": 1124,
+          "missing": "靭化計画",
+          "missing_len": 4,
+          "context": "国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であり、地方公共団体が策定する国土強靭化に係る他の",
+          "confidence": "medium"
+        },
+        {
+          "line": 1202,
+          "missing": "制御不全",
+          "missing_len": 4,
+          "context": "ット等を通じて他のAI等と接続・連携することにより制御不全となる等、AIがネットワーク化することによってリス",
+          "confidence": "medium"
+        },
+        {
+          "line": 1240,
+          "missing": "救済方法",
+          "missing_len": 4,
+          "context": "| 買主の救済方法 | 買主に帰責事由あり | 双方とも帰責事由なし",
+          "confidence": "medium"
+        },
+        {
+          "line": 1244,
+          "missing": "追完請求",
+          "missing_len": 4,
+          "context": "| 追完請求 | できない | （ウ） | できる |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1245,
+          "missing": "代金減額",
+          "missing_len": 4,
+          "context": "| 代金減額 | できない | できる | できる |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1328,
+          "missing": "的達成及",
+          "missing_len": 4,
+          "context": "メントは、反復して行うものであり、■■■の決定、目的達成及び十分な情報に基づいた決定に当たって組織を支援する",
+          "confidence": "medium"
+        },
+        {
+          "line": 1330,
+          "missing": "組織治及",
+          "missing_len": 4,
+          "context": "リスクマネジメントは、組織治及び■■■の一部であり、あらゆるレベルで組織のマネジ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1378,
+          "missing": "排出削合",
+          "missing_len": 4,
+          "context": "2. 物流部門におけるCO₂排出削合はトラック が大部分を占めていることから、CO₂の",
+          "confidence": "medium"
+        },
+        {
+          "line": 1378,
+          "missing": "内航海運",
+          "missing_len": 4,
+          "context": "ラック単体の低燃費化や輸送効率の向上と並せ、鉄道、内航海運等のエネルギー消費率の良い輸送機関の活用を図ること",
+          "confidence": "medium"
+        },
+        {
+          "line": 1378,
+          "missing": "航海運等",
+          "missing_len": 4,
+          "context": "ック単体の低燃費化や輸送効率の向上と並せ、鉄道、内航海運等のエネルギー消費率の良い輸送機関の活用を図ることが",
+          "confidence": "medium"
+        },
+        {
+          "line": 1379,
+          "missing": "分譲戸建",
+          "missing_len": 4,
+          "context": " 住宅の省エネルギー一性能の一層の向上を図るため、分譲戸建住宅のほか、注文戸建住宅や賃貸アパートにも省エネル",
+          "confidence": "medium"
+        },
+        {
+          "line": 1379,
+          "missing": "譲戸建住",
+          "missing_len": 4,
+          "context": "住宅の省エネルギー一性能の一層の向上を図るため、分譲戸建住宅のほか、注文戸建住宅や賃貸アパートにも省エネルギ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1461,
+          "missing": "生物被防",
+          "missing_len": 4,
+          "context": "5. 特定外来生物被防止基本方針では、特別な機器を使用しくともき種類の判",
+          "confidence": "medium"
+        },
+        {
+          "line": 1461,
+          "missing": "物被防止",
+          "missing_len": 4,
+          "context": "5. 特定外来生物被防止基本方針では、特別な機器を使用しくともき種類の判別",
+          "confidence": "medium"
+        },
+        {
+          "line": 1461,
+          "missing": "被防止基",
+          "missing_len": 4,
+          "context": "5. 特定外来生物被防止基本方針では、特別な機器を使用しくともき種類の判別が",
+          "confidence": "medium"
+        },
+        {
+          "line": 1461,
+          "missing": "生物種群",
+          "missing_len": 4,
+          "context": "では、特別な機器を使用しくともき種類の判別が可能な生物種群を特定外来生物の選定の対象とし、菌類、細菌類、ウイ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1497,
+          "missing": "二国間又",
+          "missing_len": 4,
+          "context": "締約国との間でも、廃棄物の国境を越える移動に関する二国間又は多数国間の取決めを結ぶことができる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1498,
+          "missing": "移動禁止",
+          "missing_len": 4,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とす",
+          "confidence": "medium"
+        },
+        {
+          "line": 1498,
+          "missing": "動禁止特",
+          "missing_len": 4,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とする",
+          "confidence": "medium"
+        },
+        {
+          "line": 1498,
+          "missing": "禁止特定",
+          "missing_len": 4,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とするも",
+          "confidence": "medium"
+        },
+        {
+          "line": 1498,
+          "missing": "止特定有",
+          "missing_len": 4,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とするもの",
+          "confidence": "medium"
+        },
+        {
+          "line": 1498,
+          "missing": "金属回収",
+          "missing_len": 4,
+          "context": "て、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とするものが多く、近年は輸入量が",
+          "confidence": "medium"
+        },
+        {
+          "line": 1533,
+          "missing": "間発生数",
+          "missing_len": 4,
+          "context": "全国のフェーダスによる1時間降水量50mm以上の年間発生数は、増加傾向にある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1537,
+          "missing": "避難継示",
+          "missing_len": 4,
+          "context": "険な警戒レベル5では「危険な場所から全員避難」と「避難継示」である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1576,
+          "missing": "音都圏等",
+          "missing_len": 4,
+          "context": "4. 音都圏等の対策地域内に使用の本拠の位置を有する乗用車につい",
+          "confidence": "medium"
+        },
+        {
+          "line": 1613,
+          "missing": "響評価項",
+          "missing_len": 4,
+          "context": "2. 事業者は、環境影響評価方法書とともに、環境影響評価項の項目並びに調査、予測及び評価の手法などを確定させ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1614,
+          "missing": "準備書及",
+          "missing_len": 4,
+          "context": "轄する都道府県知事及び市町村長に対し、環境影響評価準備書及びこれを要約した書類を送付しなければならない。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1649,
+          "missing": "資対象企",
+          "missing_len": 4,
+          "context": "任投資原則は、投資にESGの視点を組み込むことや投資対象企業に対してESGに関する情報開示を求めることなどか",
+          "confidence": "medium"
+        },
+        {
+          "line": 1649,
+          "missing": "対象企業",
+          "missing_len": 4,
+          "context": "投資原則は、投資にESGの視点を組み込むことや投資対象企業に対してESGに関する情報開示を求めることなどから",
+          "confidence": "medium"
+        },
+        {
+          "line": 98,
+          "missing": "子測値",
+          "missing_len": 3,
+          "context": "動平均法又は単純指数平滑法を用いて、各期の需要量の子測値を順次計算することを考える。第1期～第4期の需要量",
+          "confidence": "low"
+        },
+        {
+          "line": 98,
+          "missing": "計算方",
+          "missing_len": 3,
+          "context": "。なお、移動平均法及び単純指数平滑法による予測値の計算方法はそれぞれ以下のとおりである。",
+          "confidence": "low"
+        },
+        {
+          "line": 280,
+          "missing": "操作性",
+          "missing_len": 3,
+          "context": "要求分析に基づき、まず試作システムを製造し、機能や操作性を確認した後、本番の開発を進める方法である。",
+          "confidence": "low"
+        },
+        {
+          "line": 316,
+          "missing": "全系統",
+          "missing_len": 3,
+          "context": "日程計画における作業Eの作業時間は3時間、作業Eの全系統時間は4時間、作業Eの最早開始時刻は午前10時であ",
+          "confidence": "low"
+        },
+        {
+          "line": 316,
+          "missing": "系統時",
+          "missing_len": 3,
+          "context": "程計画における作業Eの作業時間は3時間、作業Eの全系統時間は4時間、作業Eの最早開始時刻は午前10時である",
+          "confidence": "low"
+        },
+        {
+          "line": 316,
+          "missing": "統時間",
+          "missing_len": 3,
+          "context": "計画における作業Eの作業時間は3時間、作業Eの全系統時間は4時間、作業Eの最早開始時刻は午前10時である。",
+          "confidence": "low"
+        },
+        {
+          "line": 323,
+          "missing": "全系統",
+          "missing_len": 3,
+          "context": "Eの作業時間だけが5時間に変更された場合、作業Eの全系統時間は2時間になる。",
+          "confidence": "low"
+        },
+        {
+          "line": 323,
+          "missing": "系統時",
+          "missing_len": 3,
+          "context": "の作業時間だけが5時間に変更された場合、作業Eの全系統時間は2時間になる。",
+          "confidence": "low"
+        },
+        {
+          "line": 323,
+          "missing": "統時間",
+          "missing_len": 3,
+          "context": "作業時間だけが5時間に変更された場合、作業Eの全系統時間は2時間になる。",
+          "confidence": "low"
+        },
+        {
+          "line": 360,
+          "missing": "総労働",
+          "missing_len": 3,
+          "context": "変形労働時間制を導入した場合、あらかじめ定められた総労働時間の範囲内で、対象期間における各日の始業及び終業",
+          "confidence": "low"
+        },
+        {
+          "line": 397,
+          "missing": "退職手",
+          "missing_len": 3,
+          "context": "用労働者を雇い入れたときは、速やかに、昇給の有無、退職手当の有無、賃与の有無、相談窓口を文書の交付などによ",
+          "confidence": "low"
+        },
+        {
+          "line": 512,
+          "missing": "構造変",
+          "missing_len": 3,
+          "context": "働を行うことによって、環境の変化に対して自ら柔軟な構造変革を行う。",
+          "confidence": "low"
+        },
+        {
+          "line": 518,
+          "missing": "業内蓄",
+          "missing_len": 3,
+          "context": "つの指揮命令系統を設定することにより、市場競争と企業内蓄積のバランスのとれた事業運営を行う。",
+          "confidence": "low"
+        },
+        {
+          "line": 518,
+          "missing": "内蓄積",
+          "missing_len": 3,
+          "context": "の指揮命令系統を設定することにより、市場競争と企業内蓄積のバランスのとれた事業運営を行う。",
+          "confidence": "low"
+        },
+        {
+          "line": 565,
+          "missing": "後一旦",
+          "missing_len": 3,
+          "context": " 組織コミットメントの3つの要素のうち、一般に入社後一旦低下したのち上昇していく傾向にあるのは功利的コミッ",
+          "confidence": "low"
+        },
+        {
+          "line": 565,
+          "missing": "一旦低",
+          "missing_len": 3,
+          "context": "組織コミットメントの3つの要素のうち、一般に入社後一旦低下したのち上昇していく傾向にあるのは功利的コミット",
+          "confidence": "low"
+        },
+        {
+          "line": 565,
+          "missing": "旦低下",
+          "missing_len": 3,
+          "context": "織コミットメントの3つの要素のうち、一般に入社後一旦低下したのち上昇していく傾向にあるのは功利的コミットメ",
+          "confidence": "low"
+        },
+        {
+          "line": 599,
+          "missing": "職型雇",
+          "missing_len": 3,
+          "context": "1. 専門性の高い業務における職型雇用では、人の出入りがあるために会社が外部労働市場に",
+          "confidence": "low"
+        },
+        {
+          "line": 599,
+          "missing": "部労働",
+          "missing_len": 3,
+          "context": "おける職型雇用では、人の出入りがあるために会社が外部労働市場にさらされ、一般的にメンバーシップ型より報酬が",
+          "confidence": "low"
+        },
+        {
+          "line": 599,
+          "missing": "労働市",
+          "missing_len": 3,
+          "context": "ける職型雇用では、人の出入りがあるために会社が外部労働市場にさらされ、一般的にメンバーシップ型より報酬が高",
+          "confidence": "low"
+        },
+        {
+          "line": 603,
+          "missing": "用促進",
+          "missing_len": 3,
+          "context": "は、適材適所による生産性向上、ローバフォーマーの活用促進、セクショナリズムの軽減などが期待できる。",
+          "confidence": "low"
+        },
+        {
+          "line": 635,
+          "missing": "性績考",
+          "missing_len": 3,
+          "context": "最も不適切なものはどれか。なお、成績考課については性績考課と呼ぶこともある。",
+          "confidence": "low"
+        },
+        {
+          "line": 680,
+          "missing": "報漏洩",
+          "missing_len": 3,
+          "context": "（イ）複数の企業を対象にして、一定期間内の情報漏洩などの事件発生の有無に対して従業員数や情報セキュリ",
+          "confidence": "low"
+        },
+        {
+          "line": 725,
+          "missing": "製造会",
+          "missing_len": 3,
+          "context": "ソフトウェアを購入した個人が、メディア媒捺に備え、製造会社の許諾を得ずに個人的にDVD-Rにバックアップ・",
+          "confidence": "low"
+        },
+        {
+          "line": 761,
+          "missing": "故障間",
+          "missing_len": 3,
+          "context": "しており、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用して",
+          "confidence": "low"
+        },
+        {
+          "line": 761,
+          "missing": "障間動",
+          "missing_len": 3,
+          "context": "ており、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用してい",
+          "confidence": "low"
+        },
+        {
+          "line": 761,
+          "missing": "間動時",
+          "missing_len": 3,
+          "context": "おり、いずれの機種のカタログにもMTBF（平均故障間動時間）は1,000時間と記載されている。使用している",
+          "confidence": "low"
+        },
+        {
+          "line": 761,
+          "missing": "総稼働",
+          "missing_len": 3,
+          "context": "用しているすべてのサーバの運用開始から現時点までの総稼働時間（実績稼働時間と総修理時間の和）、稼働率、故障",
+          "confidence": "low"
+        },
+        {
+          "line": 761,
+          "missing": "実績稼",
+          "missing_len": 3,
+          "context": "べてのサーバの運用開始から現時点までの総稼働時間（実績稼働時間と総修理時間の和）、稼働率、故障件数を調べ、",
+          "confidence": "low"
+        },
+        {
+          "line": 761,
+          "missing": "績稼働",
+          "missing_len": 3,
+          "context": "てのサーバの運用開始から現時点までの総稼働時間（実績稼働時間と総修理時間の和）、稼働率、故障件数を調べ、機",
+          "confidence": "low"
+        },
+        {
+          "line": 765,
+          "missing": "総稼働",
+          "missing_len": 3,
+          "context": "| | 総稼働時間（時間） | 稼働率 | 故障件数（件） |",
+          "confidence": "low"
+        },
+        {
+          "line": 847,
+          "missing": "代表的",
+          "missing_len": 3,
+          "context": "| 尺度 | 事例 | 尺度の特徴 | | | 代表的な値として適切な統計量の例 |",
+          "confidence": "low"
+        },
+        {
+          "line": 850,
+          "missing": "名義尺",
+          "missing_len": 3,
+          "context": "| 名義尺度 | （イ） | × | × | × | （エ）",
+          "confidence": "low"
+        },
+        {
+          "line": 850,
+          "missing": "義尺度",
+          "missing_len": 3,
+          "context": "| 名義尺度 | （イ） | × | × | × | （エ） ",
+          "confidence": "low"
+        },
+        {
+          "line": 851,
+          "missing": "段階評",
+          "missing_len": 3,
+          "context": "| （ア）尺度 | 5段階評価による満足度 | ○ | × | × | 中央値",
+          "confidence": "low"
+        },
+        {
+          "line": 851,
+          "missing": "階評価",
+          "missing_len": 3,
+          "context": "| （ア）尺度 | 5段階評価による満足度 | ○ | × | × | 中央値 ",
+          "confidence": "low"
+        },
+        {
+          "line": 851,
+          "missing": "満足度",
+          "missing_len": 3,
+          "context": "| （ア）尺度 | 5段階評価による満足度 | ○ | × | × | 中央値 |",
+          "confidence": "low"
+        },
+        {
+          "line": 852,
+          "missing": "間隔尺",
+          "missing_len": 3,
+          "context": "| 間隔尺度 | 温度（℃） | ○ | ○ | × | 最",
+          "confidence": "low"
+        },
+        {
+          "line": 852,
+          "missing": "隔尺度",
+          "missing_len": 3,
+          "context": "| 間隔尺度 | 温度（℃） | ○ | ○ | × | 最頻",
+          "confidence": "low"
+        },
+        {
+          "line": 855,
+          "missing": "選択肢",
+          "missing_len": 3,
+          "context": "選択肢：",
+          "confidence": "low"
+        },
+        {
+          "line": 952,
+          "missing": "既存企",
+          "missing_len": 3,
+          "context": "従来型のビジネスモデルや商習慣に風穴が開くことで、既存企業の存続が困難になること。",
+          "confidence": "low"
+        },
+        {
+          "line": 996,
+          "missing": "発送者",
+          "missing_len": 3,
+          "context": "否認することを防ぐため、発注情報を含む電子データに発送者のデジタル署名を施すよう受注者が依頼した。",
+          "confidence": "low"
+        },
+        {
+          "line": 1000,
+          "missing": "発信情",
+          "missing_len": 3,
+          "context": "5. 電子メールによる発信情報が途中で書き換えられて受信者に届くなごまんを防ぐ",
+          "confidence": "low"
+        },
+        {
+          "line": 1000,
+          "missing": "信情報",
+          "missing_len": 3,
+          "context": "5. 電子メールによる発信情報が途中で書き換えられて受信者に届くなごまんを防ぐた",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "死傷者",
+          "missing_len": 3,
+          "context": "| 事業所 | 労働災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "傷者数",
+          "missing_len": 3,
+          "context": "| 事業所 | 労働災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | ",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "実労働",
+          "missing_len": 3,
+          "context": "| 事業所 | 労働災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "時間数",
+          "missing_len": 3,
+          "context": "事業所 | 労働災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 ",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "労働損",
+          "missing_len": 3,
+          "context": "災害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "働損失",
+          "missing_len": 3,
+          "context": "害による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "損失日",
+          "missing_len": 3,
+          "context": "による死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "失日数",
+          "missing_len": 3,
+          "context": "よる死傷者数 | 延べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "平均労",
+          "missing_len": 3,
+          "context": "べ実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1035,
+          "missing": "均労働",
+          "missing_len": 3,
+          "context": "実労働時間数 | 延べ労働損失日数 | 1年間の平均労働者数 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1081,
+          "missing": "手順等",
+          "missing_len": 3,
+          "context": "意図とは別に安全な作業ができなかったもの、意図的に手順等を守らず安全に作業をしなかったものとの2つに大別で",
+          "confidence": "low"
+        },
+        {
+          "line": 1085,
+          "missing": "業行動",
+          "missing_len": 3,
+          "context": "業に係る建設物、設備、原材料、ガス等により、又は作業行動その他業務に起因して、労働者が負傷し、疾病にかかり",
+          "confidence": "low"
+        },
+        {
+          "line": 1118,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための",
+          "confidence": "low"
+        },
+        {
+          "line": 1118,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防",
+          "confidence": "low"
+        },
+        {
+          "line": 1118,
+          "missing": "靭化基",
+          "missing_len": 3,
+          "context": "いわゆる国土強靭化基本法（強くしなやかな国民生活の実現を図るための防災",
+          "confidence": "low"
+        },
+        {
+          "line": 1118,
+          "missing": "靭化地",
+          "missing_len": 3,
+          "context": "の防災・減災等に資する国土強靭化基本法）及び国土強靭化地域計画策定ガイドラインに関する次の記述のうち、最も",
+          "confidence": "low"
+        },
+        {
+          "line": 1118,
+          "missing": "然災害",
+          "missing_len": 3,
+          "context": "なものはどれか。ここでいう国土強靭化とは、大規模自然災害等に備えるため、事前防災・減災と迅速な復興に資する",
+          "confidence": "low"
+        },
+        {
+          "line": 1120,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリ",
+          "confidence": "low"
+        },
+        {
+          "line": 1120,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリス",
+          "confidence": "low"
+        },
+        {
+          "line": 1120,
+          "missing": "靭化基",
+          "missing_len": 3,
+          "context": "1. 国土強靭化基本計画では、国民生活・国民経済に影響を及ぼすリスク",
+          "confidence": "low"
+        },
+        {
+          "line": 1120,
+          "missing": "然災害",
+          "missing_len": 3,
+          "context": "、国民生活・国民経済に影響を及ぼすリスクとして、自然災害のほか、原子力災害などの大規模事故等も含めたあらゆ",
+          "confidence": "low"
+        },
+        {
+          "line": 1121,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する",
+          "confidence": "low"
+        },
+        {
+          "line": 1121,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する施",
+          "confidence": "low"
+        },
+        {
+          "line": 1121,
+          "missing": "靭化基",
+          "missing_len": 3,
+          "context": "2. 国土強靭化基本計画では、計画の対象とする国土強靭化に関する施策",
+          "confidence": "low"
+        },
+        {
+          "line": 1122,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "3. 国土強靭化においては、自助、共助、公助を適切に組み合わせる",
+          "confidence": "low"
+        },
+        {
+          "line": 1122,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "3. 国土強靭化においては、自助、共助、公助を適切に組み合わせるこ",
+          "confidence": "low"
+        },
+        {
+          "line": 1123,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "4. 国土強靭化においては、非常時に効果を発揮するのはもちろん、",
+          "confidence": "low"
+        },
+        {
+          "line": 1123,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "4. 国土強靭化においては、非常時に効果を発揮するのはもちろん、平",
+          "confidence": "low"
+        },
+        {
+          "line": 1123,
+          "missing": "土地利",
+          "missing_len": 3,
+          "context": "常時に効果を発揮するのはもちろん、平時からの国土・土地利用や経済活動にも資する取組を推進する。",
+          "confidence": "low"
+        },
+        {
+          "line": 1124,
+          "missing": "土強靭",
+          "missing_len": 3,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画",
+          "confidence": "low"
+        },
+        {
+          "line": 1124,
+          "missing": "強靭化",
+          "missing_len": 3,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画で",
+          "confidence": "low"
+        },
+        {
+          "line": 1124,
+          "missing": "靭化地",
+          "missing_len": 3,
+          "context": "5. 国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であ",
+          "confidence": "low"
+        },
+        {
+          "line": 1124,
+          "missing": "靭化計",
+          "missing_len": 3,
+          "context": "国土強靭化地域計画は、地方公共団体の策定する国土強靭化計画であり、地方公共団体が策定する国土強靭化に係る他",
+          "confidence": "low"
+        },
+        {
+          "line": 1202,
+          "missing": "御不全",
+          "missing_len": 3,
+          "context": "ト等を通じて他のAI等と接続・連携することにより制御不全となる等、AIがネットワーク化することによってリス",
+          "confidence": "low"
+        },
+        {
+          "line": 1236,
+          "missing": "代替物",
+          "missing_len": 3,
+          "context": "売主に対し、損害賠償請求や契約の解除のほか、修補や代替物の引き渡しなど履行の追求を請求することや、代金の減",
+          "confidence": "low"
+        },
+        {
+          "line": 1240,
+          "missing": "救済方",
+          "missing_len": 3,
+          "context": "| 買主の救済方法 | 買主に帰責事由あり | 双方とも帰責事由な",
+          "confidence": "low"
+        },
+        {
+          "line": 1240,
+          "missing": "済方法",
+          "missing_len": 3,
+          "context": "| 買主の救済方法 | 買主に帰責事由あり | 双方とも帰責事由なし",
+          "confidence": "low"
+        },
+        {
+          "line": 1244,
+          "missing": "追完請",
+          "missing_len": 3,
+          "context": "| 追完請求 | できない | （ウ） | できる |",
+          "confidence": "low"
+        },
+        {
+          "line": 1244,
+          "missing": "完請求",
+          "missing_len": 3,
+          "context": "| 追完請求 | できない | （ウ） | できる |",
+          "confidence": "low"
+        },
+        {
+          "line": 1245,
+          "missing": "代金減",
+          "missing_len": 3,
+          "context": "| 代金減額 | できない | できる | できる |",
+          "confidence": "low"
+        },
+        {
+          "line": 1245,
+          "missing": "金減額",
+          "missing_len": 3,
+          "context": "| 代金減額 | できない | できる | できる |",
+          "confidence": "low"
+        },
+        {
+          "line": 1247,
+          "missing": "選択肢",
+          "missing_len": 3,
+          "context": "選択肢：",
+          "confidence": "low"
+        },
+        {
+          "line": 1289,
+          "missing": "定期的",
+          "missing_len": 3,
+          "context": "これらの物を使用するすべての事業所の労働者に対し、定期的に安全又は衛生のための教育を行わなければならない。",
+          "confidence": "low"
+        },
+        {
+          "line": 1326,
+          "missing": "不確保",
+          "missing_len": 3,
+          "context": "らゆる業態及び規模の組織は、自らの目的達成の成否を不確保にする外部及び内部の要素並びに影響力に直面している",
+          "confidence": "low"
+        },
+        {
+          "line": 1330,
+          "missing": "組織治",
+          "missing_len": 3,
+          "context": "リスクマネジメントは、組織治及び■■■の一部であり、あらゆるレベルで組織のマネ",
+          "confidence": "low"
+        },
+        {
+          "line": 1330,
+          "missing": "織治及",
+          "missing_len": 3,
+          "context": "リスクマネジメントは、組織治及び■■■の一部であり、あらゆるレベルで組織のマネジ",
+          "confidence": "low"
+        },
+        {
+          "line": 1378,
+          "missing": "排出削",
+          "missing_len": 3,
+          "context": "2. 物流部門におけるCO₂排出削合はトラック が大部分を占めていることから、CO₂",
+          "confidence": "low"
+        },
+        {
+          "line": 1378,
+          "missing": "出削合",
+          "missing_len": 3,
+          "context": "2. 物流部門におけるCO₂排出削合はトラック が大部分を占めていることから、CO₂の",
+          "confidence": "low"
+        },
+        {
+          "line": 1378,
+          "missing": "航海運",
+          "missing_len": 3,
+          "context": "ック単体の低燃費化や輸送効率の向上と並せ、鉄道、内航海運等のエネルギー消費率の良い輸送機関の活用を図ること",
+          "confidence": "low"
+        },
+        {
+          "line": 1378,
+          "missing": "海運等",
+          "missing_len": 3,
+          "context": "ク単体の低燃費化や輸送効率の向上と並せ、鉄道、内航海運等のエネルギー消費率の良い輸送機関の活用を図ることが",
+          "confidence": "low"
+        },
+        {
+          "line": 1378,
+          "missing": "消費率",
+          "missing_len": 3,
+          "context": "輸送効率の向上と並せ、鉄道、内航海運等のエネルギー消費率の良い輸送機関の活用を図ることが必要とされている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1379,
+          "missing": "一性能",
+          "missing_len": 3,
+          "context": "3. 住宅の省エネルギー一性能の一層の向上を図るため、分譲戸建住宅のほか、注文戸",
+          "confidence": "low"
+        },
+        {
+          "line": 1379,
+          "missing": "分譲戸",
+          "missing_len": 3,
+          "context": " 住宅の省エネルギー一性能の一層の向上を図るため、分譲戸建住宅のほか、注文戸建住宅や賃貸アパートにも省エネ",
+          "confidence": "low"
+        },
+        {
+          "line": 1379,
+          "missing": "譲戸建",
+          "missing_len": 3,
+          "context": "住宅の省エネルギー一性能の一層の向上を図るため、分譲戸建住宅のほか、注文戸建住宅や賃貸アパートにも省エネル",
+          "confidence": "low"
+        },
+        {
+          "line": 1413,
+          "missing": "構想法",
+          "missing_len": 3,
+          "context": "いわゆる再エネ構想法（電気事業者による再生可能エネルギー電気の調達に関",
+          "confidence": "low"
+        },
+        {
+          "line": 1419,
+          "missing": "賦課金",
+          "missing_len": 3,
+          "context": "| 1 | 一定価格 | 地熱 | 賦課金 | 地域毎に | 環境大臣 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1421,
+          "missing": "賦課金",
+          "missing_len": 3,
+          "context": "| 3 | 一定価格 | 地熱 | 賦課金 | 全国 | 経済産業大臣 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1422,
+          "missing": "賦課金",
+          "missing_len": 3,
+          "context": "| 4 | 一定価格 | 地熱 | 賦課金 | 全国 | 環境大臣 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1461,
+          "missing": "物被防",
+          "missing_len": 3,
+          "context": "5. 特定外来生物被防止基本方針では、特別な機器を使用しくともき種類の判",
+          "confidence": "low"
+        },
+        {
+          "line": 1461,
+          "missing": "被防止",
+          "missing_len": 3,
+          "context": "5. 特定外来生物被防止基本方針では、特別な機器を使用しくともき種類の判別",
+          "confidence": "low"
+        },
+        {
+          "line": 1461,
+          "missing": "生物種",
+          "missing_len": 3,
+          "context": "では、特別な機器を使用しくともき種類の判別が可能な生物種群を特定外来生物の選定の対象とし、菌類、細菌類、ウ",
+          "confidence": "low"
+        },
+        {
+          "line": 1461,
+          "missing": "物種群",
+          "missing_len": 3,
+          "context": "は、特別な機器を使用しくともき種類の判別が可能な生物種群を特定外来生物の選定の対象とし、菌類、細菌類、ウイ",
+          "confidence": "low"
+        },
+        {
+          "line": 1497,
+          "missing": "国間又",
+          "missing_len": 3,
+          "context": "約国との間でも、廃棄物の国境を越える移動に関する二国間又は多数国間の取決めを結ぶことができる。",
+          "confidence": "low"
+        },
+        {
+          "line": 1498,
+          "missing": "移動禁",
+          "missing_len": 3,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的と",
+          "confidence": "low"
+        },
+        {
+          "line": 1498,
+          "missing": "動禁止",
+          "missing_len": 3,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とす",
+          "confidence": "low"
+        },
+        {
+          "line": 1498,
+          "missing": "禁止特",
+          "missing_len": 3,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とする",
+          "confidence": "low"
+        },
+        {
+          "line": 1498,
+          "missing": "止特定",
+          "missing_len": 3,
+          "context": "4. 我が国において、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とするも",
+          "confidence": "low"
+        },
+        {
+          "line": 1498,
+          "missing": "金属回",
+          "missing_len": 3,
+          "context": "て、バーゼル法に基づく移動禁止特定有害廃棄物等は、金属回収など再生利用を目的とするものが多く、近年は輸入量",
+          "confidence": "low"
+        },
+        {
+          "line": 1533,
+          "missing": "発生数",
+          "missing_len": 3,
+          "context": "国のフェーダスによる1時間降水量50mm以上の年間発生数は、増加傾向にある。",
+          "confidence": "low"
+        },
+        {
+          "line": 1535,
+          "missing": "規定上",
+          "missing_len": 3,
+          "context": "した印刷物の配布そのほかの必要な措置を講ずるとし、規定上ないている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1537,
+          "missing": "避難継",
+          "missing_len": 3,
+          "context": "険な警戒レベル5では「危険な場所から全員避難」と「避難継示」である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1537,
+          "missing": "難継示",
+          "missing_len": 3,
+          "context": "な警戒レベル5では「危険な場所から全員避難」と「避難継示」である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1574,
+          "missing": "工作等",
+          "missing_len": 3,
+          "context": "2. 建築物や工作等の解体又は改修工事を開始する前に、石綿の有無を調査",
+          "confidence": "low"
+        },
+        {
+          "line": 1576,
+          "missing": "音都圏",
+          "missing_len": 3,
+          "context": "4. 音都圏等の対策地域内に使用の本拠の位置を有する乗用車につ",
+          "confidence": "low"
+        },
+        {
+          "line": 1613,
+          "missing": "評価項",
+          "missing_len": 3,
+          "context": ". 事業者は、環境影響評価方法書とともに、環境影響評価項の項目並びに調査、予測及び評価の手法などを確定させ",
+          "confidence": "low"
+        },
+        {
+          "line": 1649,
+          "missing": "対象企",
+          "missing_len": 3,
+          "context": "投資原則は、投資にESGの視点を組み込むことや投資対象企業に対してESGに関する情報開示を求めることなどか",
+          "confidence": "low"
+        },
+        {
+          "line": 1649,
+          "missing": "象企業",
+          "missing_len": 3,
+          "context": "資原則は、投資にESGの視点を組み込むことや投資対象企業に対してESGに関する情報開示を求めることなどから",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R04",
+      "kind": "secondary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R04/R04_試験問題_記述式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r04-secondary/article.mdx",
+      "ocr_text_len": 2483,
+      "mdx_text_lines": 55,
+      "ocr_kanji_ngrams": 404,
+      "mismatch_total": 182,
+      "mismatch_by_confidence": {
+        "high": 20,
+        "medium": 57,
+        "low": 105
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 29,
+          "missing": "経済性管理",
+          "missing_len": 5,
+          "context": "でいう総合技術監理の視点とは，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に",
+          "confidence": "high"
+        },
+        {
+          "line": 68,
+          "missing": "記述式試験",
+          "missing_len": 5,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4 ",
+          "confidence": "high"
+        },
+        {
+          "line": 68,
+          "missing": "総監技術者",
+          "missing_len": 5,
+          "context": "計画とタスクフォース」が工程設計に踏み込んでおり、総監技術者が **工程管理とリスク管理を同時に実行できるか*",
+          "confidence": "high"
+        },
+        {
+          "line": 89,
+          "missing": "計画策定工",
+          "missing_len": 5,
+          "context": " 変遷分析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "high"
+        },
+        {
+          "line": 89,
+          "missing": "画策定工程",
+          "missing_len": 5,
+          "context": "変遷分析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "high"
+        },
+        {
+          "line": 89,
+          "missing": "策定工程設",
+          "missing_len": 5,
+          "context": "遷分析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "high"
+        },
+        {
+          "line": 89,
+          "missing": "定工程設計",
+          "missing_len": 5,
+          "context": "分析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "high"
+        },
+        {
+          "line": 112,
+          "missing": "経済性管理",
+          "missing_len": 5,
+          "context": "*: 5 管理のうち 2 つ以上の視点から（例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "high"
+        },
+        {
+          "line": 112,
+          "missing": "生産性向上",
+          "missing_len": 5,
+          "context": "理のうち 2 つ以上の視点から（例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "high"
+        },
+        {
+          "line": 113,
+          "missing": "経済性管理",
+          "missing_len": 5,
+          "context": "問題点**: 同様に 2 つ以上の視点から（例: 経済性管理＝メンテコスト、情報管理＝情報漏洩リスク）",
+          "confidence": "high"
+        },
+        {
+          "line": 115,
+          "missing": "致命的減点",
+          "missing_len": 5,
+          "context": "利点だけを書いて終わると致命的減点。**必ず問題点をセット** で記述する。",
+          "confidence": "high"
+        },
+        {
+          "line": 122,
+          "missing": "関係機関打",
+          "missing_len": 5,
+          "context": "・課題把握」「実現目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・説明",
+          "confidence": "high"
+        },
+        {
+          "line": 122,
+          "missing": "係機関打合",
+          "missing_len": 5,
+          "context": "課題把握」「実現目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・説明で",
+          "confidence": "high"
+        },
+        {
+          "line": 123,
+          "missing": "最重要工程",
+          "missing_len": 5,
+          "context": "3. **最重要工程**: どの工程が計画の現実性を左右するかを選び、",
+          "confidence": "high"
+        },
+        {
+          "line": 124,
+          "missing": "関係者増加",
+          "missing_len": 5,
+          "context": "る過程で顕在化する構造的リスク」を特定する（例: 関係者増加によるコミュニケーション負荷、人材・能力不足）。克",
+          "confidence": "high"
+        },
+        {
+          "line": 124,
+          "missing": "体制再設計",
+          "missing_len": 5,
+          "context": "）。克服策は総合技術監理の行為（管理方法の見直し・体制再設計・ルール整備）で示す",
+          "confidence": "high"
+        },
+        {
+          "line": 129,
+          "missing": "技術士学園",
+          "missing_len": 5,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境",
+          "confidence": "high"
+        },
+        {
+          "line": 129,
+          "missing": "模範論文例",
+          "missing_len": 5,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は",
+          "confidence": "high"
+        },
+        {
+          "line": 129,
+          "missing": "答案使用枚",
+          "missing_len": 5,
+          "context": "よる模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」です。",
+          "confidence": "high"
+        },
+        {
+          "line": 129,
+          "missing": "案使用枚数",
+          "missing_len": 5,
+          "context": "る模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」です。",
+          "confidence": "high"
+        },
+        {
+          "line": 27,
+          "missing": "製品製造",
+          "missing_len": 4,
+          "context": "に経験した，若しくはよく知っている事業（研究開発・製品製造・販売・アフターサービス等の業務機能の集合体として",
+          "confidence": "medium"
+        },
+        {
+          "line": 29,
+          "missing": "済性管理",
+          "missing_len": 4,
+          "context": "いう総合技術監理の視点とは，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "記述式試",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "述式試験",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4 ",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "解答戦略",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4 年度の問題",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "三層構造",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4 年度の問題文に当てはめた例。本問題",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "工程設計",
+          "missing_len": 4,
+          "context": "は (3) の「DX 推進計画とタスクフォース」が工程設計に踏み込んでおり、総監技術者が **工程管理とリス",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "総監技術",
+          "missing_len": 4,
+          "context": "計画とタスクフォース」が工程設計に踏み込んでおり、総監技術者が **工程管理とリスク管理を同時に実行できるか",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "監技術者",
+          "missing_len": 4,
+          "context": "画とタスクフォース」が工程設計に踏み込んでおり、総監技術者が **工程管理とリスク管理を同時に実行できるか*",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "工程管理",
+          "missing_len": 4,
+          "context": "ス」が工程設計に踏み込んでおり、総監技術者が **工程管理とリスク管理を同時に実行できるか** が問われてい",
+          "confidence": "medium"
+        },
+        {
+          "line": 73,
+          "missing": "利用変遷",
+          "missing_len": 4,
+          "context": "組織のビジネス・プロセス変革。過去のデジタル技術の利用変遷を踏まえ、来年度から 5 か年の DX 推進計画を",
+          "confidence": "medium"
+        },
+        {
+          "line": 84,
+          "missing": "要求事項",
+          "missing_len": 4,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 89,
+          "missing": "変遷分析",
+          "missing_len": 4,
+          "context": "| 行為 | 変遷分析 → 現在の DX 取組 → 13 週の計画策定工",
+          "confidence": "medium"
+        },
+        {
+          "line": 89,
+          "missing": "画策定工",
+          "missing_len": 4,
+          "context": "変遷分析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 89,
+          "missing": "策定工程",
+          "missing_len": 4,
+          "context": "遷分析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 89,
+          "missing": "定工程設",
+          "missing_len": 4,
+          "context": "分析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 89,
+          "missing": "工程設計",
+          "missing_len": 4,
+          "context": "析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 89,
+          "missing": "最大障害",
+          "missing_len": 4,
+          "context": "在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 93,
+          "missing": "評価項目",
+          "missing_len": 4,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 98,
+          "missing": "事業特性",
+          "missing_len": 4,
+          "context": "| 論文全体のまとまり | タスクフォース設計が、事業特性と DX 取組と整合しているか |",
+          "confidence": "medium"
+        },
+        {
+          "line": 106,
+          "missing": "利用変遷",
+          "missing_len": 4,
+          "context": "ロセスを記述する。過去から現在までのデジタル技術の利用変遷を示し、**変遷の過程で得られた効用と副作用** ",
+          "confidence": "medium"
+        },
+        {
+          "line": 106,
+          "missing": "最大障害",
+          "missing_len": 4,
+          "context": "」が後段 (2) の DX 取組の課題、(3) の最大障害につながる伏線となる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 112,
+          "missing": "済性管理",
+          "missing_len": 4,
+          "context": ": 5 管理のうち 2 つ以上の視点から（例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "medium"
+        },
+        {
+          "line": 112,
+          "missing": "生産性向",
+          "missing_len": 4,
+          "context": "理のうち 2 つ以上の視点から（例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "medium"
+        },
+        {
+          "line": 112,
+          "missing": "産性向上",
+          "missing_len": 4,
+          "context": "のうち 2 つ以上の視点から（例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "medium"
+        },
+        {
+          "line": 113,
+          "missing": "済性管理",
+          "missing_len": 4,
+          "context": "題点**: 同様に 2 つ以上の視点から（例: 経済性管理＝メンテコスト、情報管理＝情報漏洩リスク）",
+          "confidence": "medium"
+        },
+        {
+          "line": 113,
+          "missing": "情報漏洩",
+          "missing_len": 4,
+          "context": "点から（例: 経済性管理＝メンテコスト、情報管理＝情報漏洩リスク）",
+          "confidence": "medium"
+        },
+        {
+          "line": 115,
+          "missing": "致命的減",
+          "missing_len": 4,
+          "context": "利点だけを書いて終わると致命的減点。**必ず問題点をセット** で記述する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 115,
+          "missing": "命的減点",
+          "missing_len": 4,
+          "context": "利点だけを書いて終わると致命的減点。**必ず問題点をセット** で記述する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 117,
+          "missing": "延長線上",
+          "missing_len": 4,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "medium"
+        },
+        {
+          "line": 117,
+          "missing": "将来展望",
+          "missing_len": 4,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "medium"
+        },
+        {
+          "line": 119,
+          "missing": "事業特性",
+          "missing_len": 4,
+          "context": "(1) の事業特性と (2) の DX 取組を踏まえ、**来年度から",
+          "confidence": "medium"
+        },
+        {
+          "line": 121,
+          "missing": "監督行政",
+          "missing_len": 4,
+          "context": "母体・スキル・経験を具体的に。社内だけでなく外部（監督行政・地元企業）を含めてもよい",
+          "confidence": "medium"
+        },
+        {
+          "line": 121,
+          "missing": "地元企業",
+          "missing_len": 4,
+          "context": "ル・経験を具体的に。社内だけでなく外部（監督行政・地元企業）を含めてもよい",
+          "confidence": "medium"
+        },
+        {
+          "line": 122,
+          "missing": "課題把握",
+          "missing_len": 4,
+          "context": "2. **13 週のスケジュール**: 「現状・課題把握」「実現目標の設定」「取組内容の検討」「関係機関打",
+          "confidence": "medium"
+        },
+        {
+          "line": 122,
+          "missing": "関係機関",
+          "missing_len": 4,
+          "context": "・課題把握」「実現目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・説",
+          "confidence": "medium"
+        },
+        {
+          "line": 122,
+          "missing": "係機関打",
+          "missing_len": 4,
+          "context": "課題把握」「実現目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・説明",
+          "confidence": "medium"
+        },
+        {
+          "line": 122,
+          "missing": "機関打合",
+          "missing_len": 4,
+          "context": "題把握」「実現目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・説明で",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "最重要工",
+          "missing_len": 4,
+          "context": "3. **最重要工程**: どの工程が計画の現実性を左右するかを選び",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "重要工程",
+          "missing_len": 4,
+          "context": "3. **最重要工程**: どの工程が計画の現実性を左右するかを選び、",
+          "confidence": "medium"
+        },
+        {
+          "line": 124,
+          "missing": "最大障害",
+          "missing_len": 4,
+          "context": "4. **実現目標・取組内容・最大障害・克服策**: 仮説として提示する。最大障害は「(",
+          "confidence": "medium"
+        },
+        {
+          "line": 124,
+          "missing": "関係者増",
+          "missing_len": 4,
+          "context": "る過程で顕在化する構造的リスク」を特定する（例: 関係者増加によるコミュニケーション負荷、人材・能力不足）。",
+          "confidence": "medium"
+        },
+        {
+          "line": 124,
+          "missing": "係者増加",
+          "missing_len": 4,
+          "context": "過程で顕在化する構造的リスク」を特定する（例: 関係者増加によるコミュニケーション負荷、人材・能力不足）。克",
+          "confidence": "medium"
+        },
+        {
+          "line": 124,
+          "missing": "能力不足",
+          "missing_len": 4,
+          "context": ": 関係者増加によるコミュニケーション負荷、人材・能力不足）。克服策は総合技術監理の行為（管理方法の見直し・",
+          "confidence": "medium"
+        },
+        {
+          "line": 124,
+          "missing": "管理方法",
+          "missing_len": 4,
+          "context": "荷、人材・能力不足）。克服策は総合技術監理の行為（管理方法の見直し・体制再設計・ルール整備）で示す",
+          "confidence": "medium"
+        },
+        {
+          "line": 124,
+          "missing": "体制再設",
+          "missing_len": 4,
+          "context": "）。克服策は総合技術監理の行為（管理方法の見直し・体制再設計・ルール整備）で示す",
+          "confidence": "medium"
+        },
+        {
+          "line": 124,
+          "missing": "制再設計",
+          "missing_len": 4,
+          "context": "。克服策は総合技術監理の行為（管理方法の見直し・体制再設計・ルール整備）で示す",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "技術士学",
+          "missing_len": 4,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "術士学園",
+          "missing_len": 4,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "模範論文",
+          "missing_len": 4,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "範論文例",
+          "missing_len": 4,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "選択科目",
+          "missing_len": 4,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "建設部門",
+          "missing_len": 4,
+          "context": "ガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによ",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "建設環境",
+          "missing_len": 4,
+          "context": "術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」で",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "答案使用",
+          "missing_len": 4,
+          "context": "よる模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」です。",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "案使用枚",
+          "missing_len": 4,
+          "context": "る模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」です。",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "使用枚数",
+          "missing_len": 4,
+          "context": "模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」です。",
+          "confidence": "medium"
+        },
+        {
+          "line": 27,
+          "missing": "品製造",
+          "missing_len": 3,
+          "context": "経験した，若しくはよく知っている事業（研究開発・製品製造・販売・アフターサービス等の業務機能の集合体として",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "性管理",
+          "missing_len": 3,
+          "context": "う総合技術監理の視点とは，「業務全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に",
+          "confidence": "low"
+        },
+        {
+          "line": 60,
+          "missing": "部署等",
+          "missing_len": 3,
+          "context": "中核となるメンバー数名について，その出身母体（又は部署等），スキル，経験等を記せ。なお，中核メンバーを組織",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 ",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "述式試",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "式試験",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4 ",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "解答戦",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4 年度の問",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "答戦略",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4 年度の問題",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "三層構",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4 年度の問題文に当てはめた例。本問",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "層構造",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 4 年度の問題文に当てはめた例。本問題",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "問題文",
+          "missing_len": 3,
+          "context": "戦略 で論じている「三層構造」を、令和 4 年度の問題文に当てはめた例。本問題は (3) の「DX 推進計",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "本問題",
+          "missing_len": 3,
+          "context": "層構造」を、令和 4 年度の問題文に当てはめた例。本問題は (3) の「DX 推進計画とタスクフォース」が",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "工程設",
+          "missing_len": 3,
+          "context": "は (3) の「DX 推進計画とタスクフォース」が工程設計に踏み込んでおり、総監技術者が **工程管理とリ",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "程設計",
+          "missing_len": 3,
+          "context": " (3) の「DX 推進計画とタスクフォース」が工程設計に踏み込んでおり、総監技術者が **工程管理とリス",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "総監技",
+          "missing_len": 3,
+          "context": "計画とタスクフォース」が工程設計に踏み込んでおり、総監技術者が **工程管理とリスク管理を同時に実行できる",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "監技術",
+          "missing_len": 3,
+          "context": "画とタスクフォース」が工程設計に踏み込んでおり、総監技術者が **工程管理とリスク管理を同時に実行できるか",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "技術者",
+          "missing_len": 3,
+          "context": "とタスクフォース」が工程設計に踏み込んでおり、総監技術者が **工程管理とリスク管理を同時に実行できるか*",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "工程管",
+          "missing_len": 3,
+          "context": "ス」が工程設計に踏み込んでおり、総監技術者が **工程管理とリスク管理を同時に実行できるか** が問われて",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "程管理",
+          "missing_len": 3,
+          "context": "」が工程設計に踏み込んでおり、総監技術者が **工程管理とリスク管理を同時に実行できるか** が問われてい",
+          "confidence": "low"
+        },
+        {
+          "line": 73,
+          "missing": "利用変",
+          "missing_len": 3,
+          "context": "組織のビジネス・プロセス変革。過去のデジタル技術の利用変遷を踏まえ、来年度から 5 か年の DX 推進計画",
+          "confidence": "low"
+        },
+        {
+          "line": 73,
+          "missing": "用変遷",
+          "missing_len": 3,
+          "context": "織のビジネス・プロセス変革。過去のデジタル技術の利用変遷を踏まえ、来年度から 5 か年の DX 推進計画を",
+          "confidence": "low"
+        },
+        {
+          "line": 84,
+          "missing": "要求事",
+          "missing_len": 3,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "low"
+        },
+        {
+          "line": 84,
+          "missing": "求事項",
+          "missing_len": 3,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "low"
+        },
+        {
+          "line": 86,
+          "missing": "技術者",
+          "missing_len": 3,
+          "context": "| 立場 | 総合技術監理の技術者として、かつ DX 推進計画タスクフォースの **",
+          "confidence": "low"
+        },
+        {
+          "line": 89,
+          "missing": "変遷分",
+          "missing_len": 3,
+          "context": "| 行為 | 変遷分析 → 現在の DX 取組 → 13 週の計画策定",
+          "confidence": "low"
+        },
+        {
+          "line": 89,
+          "missing": "遷分析",
+          "missing_len": 3,
+          "context": "| 行為 | 変遷分析 → 現在の DX 取組 → 13 週の計画策定工",
+          "confidence": "low"
+        },
+        {
+          "line": 89,
+          "missing": "策定工",
+          "missing_len": 3,
+          "context": "遷分析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "low"
+        },
+        {
+          "line": 89,
+          "missing": "定工程",
+          "missing_len": 3,
+          "context": "分析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "low"
+        },
+        {
+          "line": 89,
+          "missing": "工程設",
+          "missing_len": 3,
+          "context": "析 → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "low"
+        },
+        {
+          "line": 89,
+          "missing": "程設計",
+          "missing_len": 3,
+          "context": " → 現在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "low"
+        },
+        {
+          "line": 89,
+          "missing": "最大障",
+          "missing_len": 3,
+          "context": "在の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "low"
+        },
+        {
+          "line": 89,
+          "missing": "大障害",
+          "missing_len": 3,
+          "context": "の DX 取組 → 13 週の計画策定工程設計＋最大障害と克服策 |",
+          "confidence": "low"
+        },
+        {
+          "line": 93,
+          "missing": "評価項",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 93,
+          "missing": "価項目",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 93,
+          "missing": "着眼点",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 97,
+          "missing": "一本線",
+          "missing_len": 3,
+          "context": "組 → 13 週の工程 → 5 か年の実現目標、が一本線でつながるか |",
+          "confidence": "low"
+        },
+        {
+          "line": 98,
+          "missing": "事業特",
+          "missing_len": 3,
+          "context": "| 論文全体のまとまり | タスクフォース設計が、事業特性と DX 取組と整合しているか |",
+          "confidence": "low"
+        },
+        {
+          "line": 98,
+          "missing": "業特性",
+          "missing_len": 3,
+          "context": " 論文全体のまとまり | タスクフォース設計が、事業特性と DX 取組と整合しているか |",
+          "confidence": "low"
+        },
+        {
+          "line": 104,
+          "missing": "設計図",
+          "missing_len": 3,
+          "context": "**(1) 設計図として置くべき前提**（設問 (1) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 106,
+          "missing": "利用変",
+          "missing_len": 3,
+          "context": "ロセスを記述する。過去から現在までのデジタル技術の利用変遷を示し、**変遷の過程で得られた効用と副作用**",
+          "confidence": "low"
+        },
+        {
+          "line": 106,
+          "missing": "用変遷",
+          "missing_len": 3,
+          "context": "セスを記述する。過去から現在までのデジタル技術の利用変遷を示し、**変遷の過程で得られた効用と副作用** ",
+          "confidence": "low"
+        },
+        {
+          "line": 106,
+          "missing": "最大障",
+          "missing_len": 3,
+          "context": "」が後段 (2) の DX 取組の課題、(3) の最大障害につながる伏線となる。",
+          "confidence": "low"
+        },
+        {
+          "line": 106,
+          "missing": "大障害",
+          "missing_len": 3,
+          "context": "が後段 (2) の DX 取組の課題、(3) の最大障害につながる伏線となる。",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "性管理",
+          "missing_len": 3,
+          "context": " 5 管理のうち 2 つ以上の視点から（例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "生産性",
+          "missing_len": 3,
+          "context": "理のうち 2 つ以上の視点から（例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "産性向",
+          "missing_len": 3,
+          "context": "のうち 2 つ以上の視点から（例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "性向上",
+          "missing_len": 3,
+          "context": "うち 2 つ以上の視点から（例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "即時性",
+          "missing_len": 3,
+          "context": "例: 経済性管理＝生産性向上、人的資源管理＝教育の即時性）",
+          "confidence": "low"
+        },
+        {
+          "line": 113,
+          "missing": "性管理",
+          "missing_len": 3,
+          "context": "点**: 同様に 2 つ以上の視点から（例: 経済性管理＝メンテコスト、情報管理＝情報漏洩リスク）",
+          "confidence": "low"
+        },
+        {
+          "line": 113,
+          "missing": "情報漏",
+          "missing_len": 3,
+          "context": "点から（例: 経済性管理＝メンテコスト、情報管理＝情報漏洩リスク）",
+          "confidence": "low"
+        },
+        {
+          "line": 113,
+          "missing": "報漏洩",
+          "missing_len": 3,
+          "context": "から（例: 経済性管理＝メンテコスト、情報管理＝情報漏洩リスク）",
+          "confidence": "low"
+        },
+        {
+          "line": 115,
+          "missing": "致命的",
+          "missing_len": 3,
+          "context": "利点だけを書いて終わると致命的減点。**必ず問題点をセット** で記述する。",
+          "confidence": "low"
+        },
+        {
+          "line": 115,
+          "missing": "命的減",
+          "missing_len": 3,
+          "context": "利点だけを書いて終わると致命的減点。**必ず問題点をセット** で記述する。",
+          "confidence": "low"
+        },
+        {
+          "line": 115,
+          "missing": "的減点",
+          "missing_len": 3,
+          "context": "利点だけを書いて終わると致命的減点。**必ず問題点をセット** で記述する。",
+          "confidence": "low"
+        },
+        {
+          "line": 117,
+          "missing": "延長線",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応",
+          "confidence": "low"
+        },
+        {
+          "line": 117,
+          "missing": "長線上",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 117,
+          "missing": "将来展",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 117,
+          "missing": "来展望",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 119,
+          "missing": "事業特",
+          "missing_len": 3,
+          "context": "(1) の事業特性と (2) の DX 取組を踏まえ、**来年度か",
+          "confidence": "low"
+        },
+        {
+          "line": 119,
+          "missing": "業特性",
+          "missing_len": 3,
+          "context": "(1) の事業特性と (2) の DX 取組を踏まえ、**来年度から",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "具体的",
+          "missing_len": 3,
+          "context": " **中核メンバー**: 出身母体・スキル・経験を具体的に。社内だけでなく外部（監督行政・地元企業）を含め",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "監督行",
+          "missing_len": 3,
+          "context": "母体・スキル・経験を具体的に。社内だけでなく外部（監督行政・地元企業）を含めてもよい",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "督行政",
+          "missing_len": 3,
+          "context": "体・スキル・経験を具体的に。社内だけでなく外部（監督行政・地元企業）を含めてもよい",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "地元企",
+          "missing_len": 3,
+          "context": "ル・経験を具体的に。社内だけでなく外部（監督行政・地元企業）を含めてもよい",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "元企業",
+          "missing_len": 3,
+          "context": "・経験を具体的に。社内だけでなく外部（監督行政・地元企業）を含めてもよい",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "課題把",
+          "missing_len": 3,
+          "context": "2. **13 週のスケジュール**: 「現状・課題把握」「実現目標の設定」「取組内容の検討」「関係機関",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "題把握",
+          "missing_len": 3,
+          "context": "2. **13 週のスケジュール**: 「現状・課題把握」「実現目標の設定」「取組内容の検討」「関係機関打",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "関係機",
+          "missing_len": 3,
+          "context": "・課題把握」「実現目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "係機関",
+          "missing_len": 3,
+          "context": "課題把握」「実現目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・説",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "機関打",
+          "missing_len": 3,
+          "context": "題把握」「実現目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・説明",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "関打合",
+          "missing_len": 3,
+          "context": "把握」「実現目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・説明で",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "計画取",
+          "missing_len": 3,
+          "context": "目標の設定」「取組内容の検討」「関係機関打合せ」「計画取りまとめ」等の工程を時期・期間・説明で構成",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "最重要",
+          "missing_len": 3,
+          "context": "3. **最重要工程**: どの工程が計画の現実性を左右するかを選",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "重要工",
+          "missing_len": 3,
+          "context": "3. **最重要工程**: どの工程が計画の現実性を左右するかを選び",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "要工程",
+          "missing_len": 3,
+          "context": "3. **最重要工程**: どの工程が計画の現実性を左右するかを選び、",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "現実性",
+          "missing_len": 3,
+          "context": "3. **最重要工程**: どの工程が計画の現実性を左右するかを選び、理由を示す",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "最大障",
+          "missing_len": 3,
+          "context": "4. **実現目標・取組内容・最大障害・克服策**: 仮説として提示する。最大障害は「",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "大障害",
+          "missing_len": 3,
+          "context": "4. **実現目標・取組内容・最大障害・克服策**: 仮説として提示する。最大障害は「(",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "顕在化",
+          "missing_len": 3,
+          "context": "(2) の取組を 5 か年で拡大・定着させる過程で顕在化する構造的リスク」を特定する（例: 関係者増加によ",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "構造的",
+          "missing_len": 3,
+          "context": "取組を 5 か年で拡大・定着させる過程で顕在化する構造的リスク」を特定する（例: 関係者増加によるコミュニ",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "関係者",
+          "missing_len": 3,
+          "context": "る過程で顕在化する構造的リスク」を特定する（例: 関係者増加によるコミュニケーション負荷、人材・能力不足）",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "係者増",
+          "missing_len": 3,
+          "context": "過程で顕在化する構造的リスク」を特定する（例: 関係者増加によるコミュニケーション負荷、人材・能力不足）。",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "者増加",
+          "missing_len": 3,
+          "context": "程で顕在化する構造的リスク」を特定する（例: 関係者増加によるコミュニケーション負荷、人材・能力不足）。克",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "能力不",
+          "missing_len": 3,
+          "context": ": 関係者増加によるコミュニケーション負荷、人材・能力不足）。克服策は総合技術監理の行為（管理方法の見直し",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "力不足",
+          "missing_len": 3,
+          "context": " 関係者増加によるコミュニケーション負荷、人材・能力不足）。克服策は総合技術監理の行為（管理方法の見直し・",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "管理方",
+          "missing_len": 3,
+          "context": "荷、人材・能力不足）。克服策は総合技術監理の行為（管理方法の見直し・体制再設計・ルール整備）で示す",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "理方法",
+          "missing_len": 3,
+          "context": "、人材・能力不足）。克服策は総合技術監理の行為（管理方法の見直し・体制再設計・ルール整備）で示す",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "体制再",
+          "missing_len": 3,
+          "context": "）。克服策は総合技術監理の行為（管理方法の見直し・体制再設計・ルール整備）で示す",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "制再設",
+          "missing_len": 3,
+          "context": "。克服策は総合技術監理の行為（管理方法の見直し・体制再設計・ルール整備）で示す",
+          "confidence": "low"
+        },
+        {
+          "line": 124,
+          "missing": "再設計",
+          "missing_len": 3,
+          "context": "克服策は総合技術監理の行為（管理方法の見直し・体制再設計・ルール整備）で示す",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "術士学",
+          "missing_len": 3,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "士学園",
+          "missing_len": 3,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "模範論",
+          "missing_len": 3,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "範論文",
+          "missing_len": 3,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "論文例",
+          "missing_len": 3,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "選択科",
+          "missing_len": 3,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマ",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "択科目",
+          "missing_len": 3,
+          "context": "以下はガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "建設部",
+          "missing_len": 3,
+          "context": "ガチンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXに",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "設部門",
+          "missing_len": 3,
+          "context": "チンコ技術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによ",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "建設環",
+          "missing_len": 3,
+          "context": "術士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "設環境",
+          "missing_len": 3,
+          "context": "士学園による模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」で",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "答案使",
+          "missing_len": 3,
+          "context": "よる模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」です。",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "案使用",
+          "missing_len": 3,
+          "context": "る模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」です。",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "使用枚",
+          "missing_len": 3,
+          "context": "模範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」です。",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "用枚数",
+          "missing_len": 3,
+          "context": "範論文例です。選択科目は建設部門－建設環境、答案使用枚数は5枚、テーマは「DXによる変革」です。",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R03",
+      "kind": "primary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R03/R03_試験問題_択一式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r03-primary/article.mdx",
+      "ocr_text_len": 17483,
+      "mdx_text_lines": 297,
+      "ocr_kanji_ngrams": 3798,
+      "mismatch_total": 239,
+      "mismatch_by_confidence": {
+        "high": 41,
+        "medium": 80,
+        "low": 118
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 64,
+          "missing": "民間資金等",
+          "missing_len": 5,
+          "context": "我が国における、いわゆるPFI法（民間資金等の活用による公共施設等の整備等の促進に関する法律）",
+          "confidence": "high"
+        },
+        {
+          "line": 297,
+          "missing": "貸借対照表",
+          "missing_len": 5,
+          "context": "1. 貸借対照表において、流動負債に対する流動資産の割合が大きいほ",
+          "confidence": "high"
+        },
+        {
+          "line": 301,
+          "missing": "貸借対照表",
+          "missing_len": 5,
+          "context": "算書における現金及び現金同等物の期末残高は、通常、貸借対照表における現金及び預金と同じ程度の金額となる。",
+          "confidence": "high"
+        },
+        {
+          "line": 418,
+          "missing": "労働使用定",
+          "missing_len": 5,
+          "context": "3. 派遣先は、派遣労働者に対し派遣先事業所の労働使用定の範囲内で時間外労働や休日労働を行わせることができ",
+          "confidence": "high"
+        },
+        {
+          "line": 1103,
+          "missing": "潜在的危機",
+          "missing_len": 5,
+          "context": "グとは、作業チームの各メンバーが使用する道具に係る潜在的危機性を相互に指摘し、チーム全体で道具に起因する事故を",
+          "confidence": "high"
+        },
+        {
+          "line": 1103,
+          "missing": "在的危機性",
+          "missing_len": 5,
+          "context": "とは、作業チームの各メンバーが使用する道具に係る潜在的危機性を相互に指摘し、チーム全体で道具に起因する事故を防",
+          "confidence": "high"
+        },
+        {
+          "line": 1140,
+          "missing": "関連施行令",
+          "missing_len": 5,
+          "context": "下図は、労働安全衛生法及び関連施行令で定められた業種別の事業所規模（労働者数）に応じた",
+          "confidence": "high"
+        },
+        {
+          "line": 1146,
+          "missing": "全衛生管理",
+          "missing_len": 5,
+          "context": "業、ガス業等 | 林業、鉱業、建設業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1146,
+          "missing": "衛生管理者",
+          "missing_len": 5,
+          "context": "、ガス業等 | 林業、鉱業、建設業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1147,
+          "missing": "全衛生管理",
+          "missing_len": 5,
+          "context": " | 林業、鉱業、建設業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1147,
+          "missing": "衛生管理者",
+          "missing_len": 5,
+          "context": "| 林業、鉱業、建設業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1148,
+          "missing": "全衛生管理",
+          "missing_len": 5,
+          "context": " 製造業、電気業、ガス業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1148,
+          "missing": "衛生管理者",
+          "missing_len": 5,
+          "context": "製造業、電気業、ガス業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1149,
+          "missing": "全衛生管理",
+          "missing_len": 5,
+          "context": "建設業等 | 製造業、電気業、ガス業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1149,
+          "missing": "衛生管理者",
+          "missing_len": 5,
+          "context": "設業等 | 製造業、電気業、ガス業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1187,
+          "missing": "実施安全衛",
+          "missing_len": 5,
+          "context": "| ① | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 | 安全衛生",
+          "confidence": "high"
+        },
+        {
+          "line": 1187,
+          "missing": "施安全衛生",
+          "missing_len": 5,
+          "context": "| ① | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 | 安全衛生計",
+          "confidence": "high"
+        },
+        {
+          "line": 1187,
+          "missing": "作成危機性",
+          "missing_len": 5,
+          "context": "の設定 | 安全衛生計画の作成 | 安全衛生計画の作成危機性又は有害性等の調査の実施 | システム監査の実施 ",
+          "confidence": "high"
+        },
+        {
+          "line": 1187,
+          "missing": "成危機性又",
+          "missing_len": 5,
+          "context": "設定 | 安全衛生計画の作成 | 安全衛生計画の作成危機性又は有害性等の調査の実施 | システム監査の実施 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1188,
+          "missing": "実施安全衛",
+          "missing_len": 5,
+          "context": "| ② | 危機性又は有害性等の調査の実施安全衛生計画の作成 | 安全衛生目標の設定 | 危機性又",
+          "confidence": "high"
+        },
+        {
+          "line": 1188,
+          "missing": "施安全衛生",
+          "missing_len": 5,
+          "context": "| ② | 危機性又は有害性等の調査の実施安全衛生計画の作成 | 安全衛生目標の設定 | 危機性又は",
+          "confidence": "high"
+        },
+        {
+          "line": 1190,
+          "missing": "実施安全衛",
+          "missing_len": 5,
+          "context": "害性等の調査の実施 | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1190,
+          "missing": "施安全衛生",
+          "missing_len": 5,
+          "context": "性等の調査の実施 | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1270,
+          "missing": "動物実験管",
+          "missing_len": 5,
+          "context": "4. いわゆる動物実験管理法では、動物実験について、代替法の活用、使用数の",
+          "confidence": "high"
+        },
+        {
+          "line": 1270,
+          "missing": "物実験管理",
+          "missing_len": 5,
+          "context": "4. いわゆる動物実験管理法では、動物実験について、代替法の活用、使用数の削",
+          "confidence": "high"
+        },
+        {
+          "line": 1270,
+          "missing": "実験管理法",
+          "missing_len": 5,
+          "context": "4. いわゆる動物実験管理法では、動物実験について、代替法の活用、使用数の削減",
+          "confidence": "high"
+        },
+        {
+          "line": 1271,
+          "missing": "社会的課題",
+          "missing_len": 5,
+          "context": "5. 未来の社会変革や経済・社会的課題への対応を図るには、多様なステークホルダー間の対話",
+          "confidence": "high"
+        },
+        {
+          "line": 1466,
+          "missing": "棄物処理計",
+          "missing_len": 5,
+          "context": "の構築に関する取組指標として、地方公共団体の災害廃棄物処理計画の策定率が代表指標とされた。",
+          "confidence": "high"
+        },
+        {
+          "line": 1466,
+          "missing": "物処理計画",
+          "missing_len": 5,
+          "context": "構築に関する取組指標として、地方公共団体の災害廃棄物処理計画の策定率が代表指標とされた。",
+          "confidence": "high"
+        },
+        {
+          "line": 1546,
+          "missing": "枠組規制的",
+          "missing_len": 5,
+          "context": "的手法：大気汚染防止法によるばい煙の総量規制 | 枠組規制的手法：化学物質に関するPRTR制度 | 経済的手法",
+          "confidence": "high"
+        },
+        {
+          "line": 1547,
+          "missing": "枠組規制的",
+          "missing_len": 5,
+          "context": "的手法：大気汚染防止法によるばい煙の総量規制 | 枠組規制的手法：化学物質に関するPRTR制度 | 経済的手法",
+          "confidence": "high"
+        },
+        {
+          "line": 1548,
+          "missing": "枠組規制的",
+          "missing_len": 5,
+          "context": "的手法：大気汚染防止法によるばい煙の総量規制 | 枠組規制的手法：化学物質に関するPRTR制度 | 経済的手法",
+          "confidence": "high"
+        },
+        {
+          "line": 1550,
+          "missing": "枠組規制的",
+          "missing_len": 5,
+          "context": "制的手法：大気汚染防止法によるばい煙の総量規制、②枠組規制的手法：化学物質に関するPRTR制度、③経済的手法：",
+          "confidence": "high"
+        },
+        {
+          "line": 1552,
+          "missing": "枠組規制的",
+          "missing_len": 5,
+          "context": "制的手法：大気汚染防止法によるばい煙の総量規制、②枠組規制的手法：化学物質に関するPRTR制度、③経済的手法：",
+          "confidence": "high"
+        },
+        {
+          "line": 1554,
+          "missing": "枠組規制的",
+          "missing_len": 5,
+          "context": "制的手法：大気汚染防止法によるばい煙の総量規制、②枠組規制的手法：化学物質に関するPRTR制度、③経済的手法：",
+          "confidence": "high"
+        },
+        {
+          "line": 1598,
+          "missing": "速自動車道",
+          "missing_len": 5,
+          "context": "| ① | 高速自動車道国道 | 林道 | 下水処理場 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1598,
+          "missing": "自動車道国",
+          "missing_len": 5,
+          "context": "| ① | 高速自動車道国道 | 林道 | 下水処理場 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1598,
+          "missing": "動車道国道",
+          "missing_len": 5,
+          "context": "| ① | 高速自動車道国道 | 林道 | 下水処理場 |",
+          "confidence": "high"
+        },
+        {
+          "line": 1639,
+          "missing": "境教育等推",
+          "missing_len": 5,
+          "context": "3. いわゆる環境教育等推進法は、持続可能な社会の担い手育成の重要性に鑑み、",
+          "confidence": "high"
+        },
+        {
+          "line": 1639,
+          "missing": "教育等推進",
+          "missing_len": 5,
+          "context": "3. いわゆる環境教育等推進法は、持続可能な社会の担い手育成の重要性に鑑み、様",
+          "confidence": "high"
+        },
+        {
+          "line": 1639,
+          "missing": "育等推進法",
+          "missing_len": 5,
+          "context": "3. いわゆる環境教育等推進法は、持続可能な社会の担い手育成の重要性に鑑み、様々",
+          "confidence": "high"
+        },
+        {
+          "line": 64,
+          "missing": "間資金等",
+          "missing_len": 4,
+          "context": "我が国における、いわゆるPFI法（民間資金等の活用による公共施設等の整備等の促進に関する法律）",
+          "confidence": "medium"
+        },
+        {
+          "line": 297,
+          "missing": "貸借対照",
+          "missing_len": 4,
+          "context": "1. 貸借対照表において、流動負債に対する流動資産の割合が大きい",
+          "confidence": "medium"
+        },
+        {
+          "line": 297,
+          "missing": "借対照表",
+          "missing_len": 4,
+          "context": "1. 貸借対照表において、流動負債に対する流動資産の割合が大きいほ",
+          "confidence": "medium"
+        },
+        {
+          "line": 301,
+          "missing": "貸借対照",
+          "missing_len": 4,
+          "context": "算書における現金及び現金同等物の期末残高は、通常、貸借対照表における現金及び預金と同じ程度の金額となる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 301,
+          "missing": "借対照表",
+          "missing_len": 4,
+          "context": "書における現金及び現金同等物の期末残高は、通常、貸借対照表における現金及び預金と同じ程度の金額となる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 338,
+          "missing": "固定資産",
+          "missing_len": 4,
+          "context": "に必要な保全費には、設備の新増設、更新、改造などの固定資産に繰り入れるべき支出は含まれない。",
+          "confidence": "medium"
+        },
+        {
+          "line": 341,
+          "missing": "設備更新",
+          "missing_len": 4,
+          "context": "中の設備を取り替える場合、絶対的劣化による取替を「設備更新」といい、相対的劣化による取替を「設備取替」という",
+          "confidence": "medium"
+        },
+        {
+          "line": 341,
+          "missing": "設備取替",
+          "missing_len": 4,
+          "context": "取替を「設備更新」といい、相対的劣化による取替を「設備取替」という。",
+          "confidence": "medium"
+        },
+        {
+          "line": 378,
+          "missing": "組合活動",
+          "missing_len": 4,
+          "context": "働時間、休日などの労働条件のほか、団体交渉の手続、組合活動における施設利用の取扱いなどが交渉事項となり得る。",
+          "confidence": "medium"
+        },
+        {
+          "line": 418,
+          "missing": "労働使用",
+          "missing_len": 4,
+          "context": "3. 派遣先は、派遣労働者に対し派遣先事業所の労働使用定の範囲内で時間外労働や休日労働を行わせることがで",
+          "confidence": "medium"
+        },
+        {
+          "line": 418,
+          "missing": "働使用定",
+          "missing_len": 4,
+          "context": "3. 派遣先は、派遣労働者に対し派遣先事業所の労働使用定の範囲内で時間外労働や休日労働を行わせることができ",
+          "confidence": "medium"
+        },
+        {
+          "line": 418,
+          "missing": "休日労働",
+          "missing_len": 4,
+          "context": "対し派遣先事業所の労働使用定の範囲内で時間外労働や休日労働を行わせることができる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 494,
+          "missing": "明確化及",
+          "missing_len": 4,
+          "context": "職場におけるセクシュアルハラスメントに関する方針の明確化及びその周知・啓発、相談に応じ、適切に対応するために",
+          "confidence": "medium"
+        },
+        {
+          "line": 498,
+          "missing": "事業主又",
+          "missing_len": 4,
+          "context": "者には、事業主、上司、同僚に限らず、取引先等の他の事業主又はその雇用する労働者、顧客もなり得る。",
+          "confidence": "medium"
+        },
+        {
+          "line": 573,
+          "missing": "億円未満",
+          "missing_len": 4,
+          "context": "にみた労働分配率の比較では、「資本金1千万円以上1億円未満の企業」は、「資本金10億円以上の企業」に比べ、労",
+          "confidence": "medium"
+        },
+        {
+          "line": 611,
+          "missing": "開始当初",
+          "missing_len": 4,
+          "context": "1. メンタリング開始当初に当たり、メンターに対し実施方法に関する事前研修を",
+          "confidence": "medium"
+        },
+        {
+          "line": 696,
+          "missing": "機械学習",
+          "missing_len": 4,
+          "context": "4,500個のデータに対し、陽性か陰性かを予測する機械学習モデルによる予測結果を整理した混同行列と呼ばれるも",
+          "confidence": "medium"
+        },
+        {
+          "line": 908,
+          "missing": "程度以下",
+          "missing_len": 4,
+          "context": "接参加する者は、インターネット利用者の数パーセント程度以下のごく少数に過ぎないという複数の調査結果がある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 911,
+          "missing": "被害回復",
+          "missing_len": 4,
+          "context": "制限法では、インターネット上の誹謗中傷を受けた者の被害回復のために、匿名の発信者を特定するための発信者情報開",
+          "confidence": "medium"
+        },
+        {
+          "line": 947,
+          "missing": "処理機能",
+          "missing_len": 4,
+          "context": "は、従来のクラウドよりもユーザーに近い領域でデータ処理機能を提供することで、リアルタイム性を確保する技術であ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1022,
+          "missing": "関関事案",
+          "missing_len": 4,
+          "context": "ち、最も不適切なものはどれか。なお、以下において「関関事案」とは、消費者安全に係る事案で、各政機関の所管する",
+          "confidence": "medium"
+        },
+        {
+          "line": 1022,
+          "missing": "各政機関",
+          "missing_len": 4,
+          "context": "において「関関事案」とは、消費者安全に係る事案で、各政機関の所管する既往の法律には、その防止措置がないものを",
+          "confidence": "medium"
+        },
+        {
+          "line": 1024,
+          "missing": "関闘事案",
+          "missing_len": 4,
+          "context": "害を生じ、又はそのおそれのある事態が発生し、それが関闘事案である場合に、内閣総理大臣は事業者に対し勧告・命令",
+          "confidence": "medium"
+        },
+        {
+          "line": 1028,
+          "missing": "関関事案",
+          "missing_len": 4,
+          "context": "5. 重大事故等が関関事案に該当するか否かが一見して明確でない場合、まず消費",
+          "confidence": "medium"
+        },
+        {
+          "line": 1061,
+          "missing": "危機性又",
+          "missing_len": 4,
+          "context": "「危機性又は有害性等の調査等に関する指針」に治ってリスクアセ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1061,
+          "missing": "健康障害",
+          "missing_len": 4,
+          "context": "性等の調査を行い、その結果に基づき労働者の危機又は健康障害を防止するために必要な措置を講ずることをいう。）を",
+          "confidence": "medium"
+        },
+        {
+          "line": 1064,
+          "missing": "危機性又",
+          "missing_len": 4,
+          "context": "2. 危機性又は有害性の特定を行うための検討チームの編成では、思",
+          "confidence": "medium"
+        },
+        {
+          "line": 1103,
+          "missing": "潜在的危",
+          "missing_len": 4,
+          "context": "グとは、作業チームの各メンバーが使用する道具に係る潜在的危機性を相互に指摘し、チーム全体で道具に起因する事故",
+          "confidence": "medium"
+        },
+        {
+          "line": 1103,
+          "missing": "在的危機",
+          "missing_len": 4,
+          "context": "とは、作業チームの各メンバーが使用する道具に係る潜在的危機性を相互に指摘し、チーム全体で道具に起因する事故を",
+          "confidence": "medium"
+        },
+        {
+          "line": 1103,
+          "missing": "的危機性",
+          "missing_len": 4,
+          "context": "は、作業チームの各メンバーが使用する道具に係る潜在的危機性を相互に指摘し、チーム全体で道具に起因する事故を防",
+          "confidence": "medium"
+        },
+        {
+          "line": 1140,
+          "missing": "関連施行",
+          "missing_len": 4,
+          "context": "下図は、労働安全衛生法及び関連施行令で定められた業種別の事業所規模（労働者数）に応じ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1140,
+          "missing": "連施行令",
+          "missing_len": 4,
+          "context": "下図は、労働安全衛生法及び関連施行令で定められた業種別の事業所規模（労働者数）に応じた",
+          "confidence": "medium"
+        },
+        {
+          "line": 1146,
+          "missing": "建設業等",
+          "missing_len": 4,
+          "context": "① | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1146,
+          "missing": "衛生管理",
+          "missing_len": 4,
+          "context": "、ガス業等 | 林業、鉱業、建設業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1146,
+          "missing": "生管理者",
+          "missing_len": 4,
+          "context": "ガス業等 | 林業、鉱業、建設業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1147,
+          "missing": "建設業等",
+          "missing_len": 4,
+          "context": "② | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1147,
+          "missing": "衛生管理",
+          "missing_len": 4,
+          "context": "| 林業、鉱業、建設業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1147,
+          "missing": "生管理者",
+          "missing_len": 4,
+          "context": " 林業、鉱業、建設業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1148,
+          "missing": "建設業等",
+          "missing_len": 4,
+          "context": "| ③ | 林業、鉱業、建設業等 | 製造業、電気業、ガス業等 | 産業医 | 総",
+          "confidence": "medium"
+        },
+        {
+          "line": 1148,
+          "missing": "衛生管理",
+          "missing_len": 4,
+          "context": "製造業、電気業、ガス業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1148,
+          "missing": "生管理者",
+          "missing_len": 4,
+          "context": "造業、電気業、ガス業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1149,
+          "missing": "建設業等",
+          "missing_len": 4,
+          "context": "| ④ | 林業、鉱業、建設業等 | 製造業、電気業、ガス業等 | 総括安全衛生管",
+          "confidence": "medium"
+        },
+        {
+          "line": 1149,
+          "missing": "衛生管理",
+          "missing_len": 4,
+          "context": "設業等 | 製造業、電気業、ガス業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1149,
+          "missing": "生管理者",
+          "missing_len": 4,
+          "context": "業等 | 製造業、電気業、ガス業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1150,
+          "missing": "建設業等",
+          "missing_len": 4,
+          "context": "⑤ | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 事業部制組織 | 職能別組織 | 50 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1187,
+          "missing": "危機性又",
+          "missing_len": 4,
+          "context": "| ① | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全",
+          "confidence": "medium"
+        },
+        {
+          "line": 1187,
+          "missing": "実施安全",
+          "missing_len": 4,
+          "context": "| ① | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 | 安全衛",
+          "confidence": "medium"
+        },
+        {
+          "line": 1187,
+          "missing": "施安全衛",
+          "missing_len": 4,
+          "context": "| ① | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 | 安全衛生",
+          "confidence": "medium"
+        },
+        {
+          "line": 1187,
+          "missing": "作成危機",
+          "missing_len": 4,
+          "context": "の設定 | 安全衛生計画の作成 | 安全衛生計画の作成危機性又は有害性等の調査の実施 | システム監査の実施",
+          "confidence": "medium"
+        },
+        {
+          "line": 1187,
+          "missing": "成危機性",
+          "missing_len": 4,
+          "context": "設定 | 安全衛生計画の作成 | 安全衛生計画の作成危機性又は有害性等の調査の実施 | システム監査の実施 ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1188,
+          "missing": "危機性又",
+          "missing_len": 4,
+          "context": "| ② | 危機性又は有害性等の調査の実施安全衛生計画の作成 | 安全",
+          "confidence": "medium"
+        },
+        {
+          "line": 1188,
+          "missing": "実施安全",
+          "missing_len": 4,
+          "context": "| ② | 危機性又は有害性等の調査の実施安全衛生計画の作成 | 安全衛生目標の設定 | 危機性",
+          "confidence": "medium"
+        },
+        {
+          "line": 1188,
+          "missing": "施安全衛",
+          "missing_len": 4,
+          "context": "| ② | 危機性又は有害性等の調査の実施安全衛生計画の作成 | 安全衛生目標の設定 | 危機性又",
+          "confidence": "medium"
+        },
+        {
+          "line": 1190,
+          "missing": "危機性又",
+          "missing_len": 4,
+          "context": "| ④ | システム監査の実施 | 危機性又は有害性等の調査の実施 | 危機性又は有害性等の調",
+          "confidence": "medium"
+        },
+        {
+          "line": 1190,
+          "missing": "実施安全",
+          "missing_len": 4,
+          "context": "害性等の調査の実施 | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1190,
+          "missing": "施安全衛",
+          "missing_len": 4,
+          "context": "性等の調査の実施 | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1191,
+          "missing": "危機性又",
+          "missing_len": 4,
+          "context": " 安全衛生計画の作成 | システム監査の実施 | 危機性又は有害性等の調査の実施 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1225,
+          "missing": "独立事象",
+          "missing_len": 4,
+          "context": "のR4の値はどれか。ただし、各ユニットの故障発生は独立事象とする。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1270,
+          "missing": "物実験管",
+          "missing_len": 4,
+          "context": "4. いわゆる動物実験管理法では、動物実験について、代替法の活用、使用数の",
+          "confidence": "medium"
+        },
+        {
+          "line": 1270,
+          "missing": "実験管理",
+          "missing_len": 4,
+          "context": "4. いわゆる動物実験管理法では、動物実験について、代替法の活用、使用数の削",
+          "confidence": "medium"
+        },
+        {
+          "line": 1270,
+          "missing": "験管理法",
+          "missing_len": 4,
+          "context": "4. いわゆる動物実験管理法では、動物実験について、代替法の活用、使用数の削減",
+          "confidence": "medium"
+        },
+        {
+          "line": 1271,
+          "missing": "社会的課",
+          "missing_len": 4,
+          "context": "5. 未来の社会変革や経済・社会的課題への対応を図るには、多様なステークホルダー間の対",
+          "confidence": "medium"
+        },
+        {
+          "line": 1271,
+          "missing": "会的課題",
+          "missing_len": 4,
+          "context": "5. 未来の社会変革や経済・社会的課題への対応を図るには、多様なステークホルダー間の対話",
+          "confidence": "medium"
+        },
+        {
+          "line": 1344,
+          "missing": "開発日標",
+          "missing_len": 4,
+          "context": "針の改定版（令和元年に改定された我が国の持続可能な開発日標（SDGs）実施指針）に関する次の記述のうち、最も",
+          "confidence": "medium"
+        },
+        {
+          "line": 1347,
+          "missing": "未来都市",
+          "missing_len": 4,
+          "context": "せるため、「ジャパンSDGsアワード」や「SDGs未来都市」の選定を通じた活動の「見える化」など、広報・啓発",
+          "confidence": "medium"
+        },
+        {
+          "line": 1387,
+          "missing": "自動車等",
+          "missing_len": 4,
+          "context": "第一次石油ショック当時と比べ、エネルギー利用機器や自動車等などの省エネルギー化が進んだことから、2018年度",
+          "confidence": "medium"
+        },
+        {
+          "line": 1466,
+          "missing": "物処理計",
+          "missing_len": 4,
+          "context": "構築に関する取組指標として、地方公共団体の災害廃棄物処理計画の策定率が代表指標とされた。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1546,
+          "missing": "枠組規制",
+          "missing_len": 4,
+          "context": "的手法：大気汚染防止法によるばい煙の総量規制 | 枠組規制的手法：化学物質に関するPRTR制度 | 経済的手",
+          "confidence": "medium"
+        },
+        {
+          "line": 1547,
+          "missing": "枠組規制",
+          "missing_len": 4,
+          "context": "的手法：大気汚染防止法によるばい煙の総量規制 | 枠組規制的手法：化学物質に関するPRTR制度 | 経済的手",
+          "confidence": "medium"
+        },
+        {
+          "line": 1548,
+          "missing": "枠組規制",
+          "missing_len": 4,
+          "context": "的手法：大気汚染防止法によるばい煙の総量規制 | 枠組規制的手法：化学物質に関するPRTR制度 | 経済的手",
+          "confidence": "medium"
+        },
+        {
+          "line": 1550,
+          "missing": "枠組規制",
+          "missing_len": 4,
+          "context": "制的手法：大気汚染防止法によるばい煙の総量規制、②枠組規制的手法：化学物質に関するPRTR制度、③経済的手法",
+          "confidence": "medium"
+        },
+        {
+          "line": 1552,
+          "missing": "枠組規制",
+          "missing_len": 4,
+          "context": "制的手法：大気汚染防止法によるばい煙の総量規制、②枠組規制的手法：化学物質に関するPRTR制度、③経済的手法",
+          "confidence": "medium"
+        },
+        {
+          "line": 1554,
+          "missing": "枠組規制",
+          "missing_len": 4,
+          "context": "制的手法：大気汚染防止法によるばい煙の総量規制、②枠組規制的手法：化学物質に関するPRTR制度、③経済的手法",
+          "confidence": "medium"
+        },
+        {
+          "line": 1598,
+          "missing": "自動車道",
+          "missing_len": 4,
+          "context": "| ① | 高速自動車道国道 | 林道 | 下水処理場 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1598,
+          "missing": "動車道国",
+          "missing_len": 4,
+          "context": "| ① | 高速自動車道国道 | 林道 | 下水処理場 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1598,
+          "missing": "車道国道",
+          "missing_len": 4,
+          "context": "| ① | 高速自動車道国道 | 林道 | 下水処理場 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 1639,
+          "missing": "教育等推",
+          "missing_len": 4,
+          "context": "3. いわゆる環境教育等推進法は、持続可能な社会の担い手育成の重要性に鑑み、",
+          "confidence": "medium"
+        },
+        {
+          "line": 1639,
+          "missing": "育等推進",
+          "missing_len": 4,
+          "context": "3. いわゆる環境教育等推進法は、持続可能な社会の担い手育成の重要性に鑑み、様",
+          "confidence": "medium"
+        },
+        {
+          "line": 1639,
+          "missing": "等推進法",
+          "missing_len": 4,
+          "context": "3. いわゆる環境教育等推進法は、持続可能な社会の担い手育成の重要性に鑑み、様々",
+          "confidence": "medium"
+        },
+        {
+          "line": 1641,
+          "missing": "実施枠組",
+          "missing_len": 4,
+          "context": "することを提唱したのは日本であり、現在では国際的な実施枠組みである「ESD for 2030」がユネスコで採",
+          "confidence": "medium"
+        },
+        {
+          "line": 64,
+          "missing": "資金等",
+          "missing_len": 3,
+          "context": "我が国における、いわゆるPFI法（民間資金等の活用による公共施設等の整備等の促進に関する法律）",
+          "confidence": "low"
+        },
+        {
+          "line": 297,
+          "missing": "借対照",
+          "missing_len": 3,
+          "context": "1. 貸借対照表において、流動負債に対する流動資産の割合が大きい",
+          "confidence": "low"
+        },
+        {
+          "line": 297,
+          "missing": "対照表",
+          "missing_len": 3,
+          "context": "1. 貸借対照表において、流動負債に対する流動資産の割合が大きいほ",
+          "confidence": "low"
+        },
+        {
+          "line": 297,
+          "missing": "資金繰",
+          "missing_len": 3,
+          "context": "動負債に対する流動資産の割合が大きいほど、短期的な資金繰りは安全である。",
+          "confidence": "low"
+        },
+        {
+          "line": 301,
+          "missing": "借対照",
+          "missing_len": 3,
+          "context": "書における現金及び現金同等物の期末残高は、通常、貸借対照表における現金及び預金と同じ程度の金額となる。",
+          "confidence": "low"
+        },
+        {
+          "line": 301,
+          "missing": "対照表",
+          "missing_len": 3,
+          "context": "における現金及び現金同等物の期末残高は、通常、貸借対照表における現金及び預金と同じ程度の金額となる。",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "定資産",
+          "missing_len": 3,
+          "context": "必要な保全費には、設備の新増設、更新、改造などの固定資産に繰り入れるべき支出は含まれない。",
+          "confidence": "low"
+        },
+        {
+          "line": 341,
+          "missing": "設備更",
+          "missing_len": 3,
+          "context": "中の設備を取り替える場合、絶対的劣化による取替を「設備更新」といい、相対的劣化による取替を「設備取替」とい",
+          "confidence": "low"
+        },
+        {
+          "line": 341,
+          "missing": "備取替",
+          "missing_len": 3,
+          "context": "替を「設備更新」といい、相対的劣化による取替を「設備取替」という。",
+          "confidence": "low"
+        },
+        {
+          "line": 378,
+          "missing": "組合活",
+          "missing_len": 3,
+          "context": "働時間、休日などの労働条件のほか、団体交渉の手続、組合活動における施設利用の取扱いなどが交渉事項となり得る",
+          "confidence": "low"
+        },
+        {
+          "line": 378,
+          "missing": "合活動",
+          "missing_len": 3,
+          "context": "時間、休日などの労働条件のほか、団体交渉の手続、組合活動における施設利用の取扱いなどが交渉事項となり得る。",
+          "confidence": "low"
+        },
+        {
+          "line": 417,
+          "missing": "直社員",
+          "missing_len": 3,
+          "context": "上の定年による退職者を除き、自宅で直接雇用していた直社員、契約社員、アルバイト等を、離職後1年以内に派遣元",
+          "confidence": "low"
+        },
+        {
+          "line": 418,
+          "missing": "労働使",
+          "missing_len": 3,
+          "context": "3. 派遣先は、派遣労働者に対し派遣先事業所の労働使用定の範囲内で時間外労働や休日労働を行わせることが",
+          "confidence": "low"
+        },
+        {
+          "line": 418,
+          "missing": "働使用",
+          "missing_len": 3,
+          "context": "3. 派遣先は、派遣労働者に対し派遣先事業所の労働使用定の範囲内で時間外労働や休日労働を行わせることがで",
+          "confidence": "low"
+        },
+        {
+          "line": 418,
+          "missing": "使用定",
+          "missing_len": 3,
+          "context": "3. 派遣先は、派遣労働者に対し派遣先事業所の労働使用定の範囲内で時間外労働や休日労働を行わせることができ",
+          "confidence": "low"
+        },
+        {
+          "line": 418,
+          "missing": "日労働",
+          "missing_len": 3,
+          "context": "し派遣先事業所の労働使用定の範囲内で時間外労働や休日労働を行わせることができる。",
+          "confidence": "low"
+        },
+        {
+          "line": 457,
+          "missing": "短縮等",
+          "missing_len": 3,
+          "context": "る対象家族を介護する労働者について、所定労働時間の短縮等の措置を講ずるよう努めなければならない。",
+          "confidence": "low"
+        },
+        {
+          "line": 494,
+          "missing": "明確化",
+          "missing_len": 3,
+          "context": "職場におけるセクシュアルハラスメントに関する方針の明確化及びその周知・啓発、相談に応じ、適切に対応するため",
+          "confidence": "low"
+        },
+        {
+          "line": 498,
+          "missing": "業主又",
+          "missing_len": 3,
+          "context": "には、事業主、上司、同僚に限らず、取引先等の他の事業主又はその雇用する労働者、顧客もなり得る。",
+          "confidence": "low"
+        },
+        {
+          "line": 573,
+          "missing": "億円未",
+          "missing_len": 3,
+          "context": "にみた労働分配率の比較では、「資本金1千万円以上1億円未満の企業」は、「資本金10億円以上の企業」に比べ、",
+          "confidence": "low"
+        },
+        {
+          "line": 611,
+          "missing": "開始当",
+          "missing_len": 3,
+          "context": "1. メンタリング開始当初に当たり、メンターに対し実施方法に関する事前研修",
+          "confidence": "low"
+        },
+        {
+          "line": 611,
+          "missing": "始当初",
+          "missing_len": 3,
+          "context": "1. メンタリング開始当初に当たり、メンターに対し実施方法に関する事前研修を",
+          "confidence": "low"
+        },
+        {
+          "line": 696,
+          "missing": "械学習",
+          "missing_len": 3,
+          "context": ",500個のデータに対し、陽性か陰性かを予測する機械学習モデルによる予測結果を整理した混同行列と呼ばれるも",
+          "confidence": "low"
+        },
+        {
+          "line": 707,
+          "missing": "偽陽性",
+          "missing_len": 3,
+          "context": "| | 陰性 | 偽陽性 | 真陰性 |",
+          "confidence": "low"
+        },
+        {
+          "line": 868,
+          "missing": "変数間",
+          "missing_len": 3,
+          "context": "2. 相関分析は、分析者が変数間の因果関係を仮定し、説明変数が被説明変数に与える効",
+          "confidence": "low"
+        },
+        {
+          "line": 908,
+          "missing": "程度以",
+          "missing_len": 3,
+          "context": "接参加する者は、インターネット利用者の数パーセント程度以下のごく少数に過ぎないという複数の調査結果がある。",
+          "confidence": "low"
+        },
+        {
+          "line": 911,
+          "missing": "被害回",
+          "missing_len": 3,
+          "context": "制限法では、インターネット上の誹謗中傷を受けた者の被害回復のために、匿名の発信者を特定するための発信者情報",
+          "confidence": "low"
+        },
+        {
+          "line": 911,
+          "missing": "害回復",
+          "missing_len": 3,
+          "context": "限法では、インターネット上の誹謗中傷を受けた者の被害回復のために、匿名の発信者を特定するための発信者情報開",
+          "confidence": "low"
+        },
+        {
+          "line": 947,
+          "missing": "処理機",
+          "missing_len": 3,
+          "context": "は、従来のクラウドよりもユーザーに近い領域でデータ処理機能を提供することで、リアルタイム性を確保する技術で",
+          "confidence": "low"
+        },
+        {
+          "line": 947,
+          "missing": "理機能",
+          "missing_len": 3,
+          "context": "、従来のクラウドよりもユーザーに近い領域でデータ処理機能を提供することで、リアルタイム性を確保する技術であ",
+          "confidence": "low"
+        },
+        {
+          "line": 1022,
+          "missing": "関関事",
+          "missing_len": 3,
+          "context": "ち、最も不適切なものはどれか。なお、以下において「関関事案」とは、消費者安全に係る事案で、各政機関の所管す",
+          "confidence": "low"
+        },
+        {
+          "line": 1022,
+          "missing": "関事案",
+          "missing_len": 3,
+          "context": "、最も不適切なものはどれか。なお、以下において「関関事案」とは、消費者安全に係る事案で、各政機関の所管する",
+          "confidence": "low"
+        },
+        {
+          "line": 1022,
+          "missing": "各政機",
+          "missing_len": 3,
+          "context": "において「関関事案」とは、消費者安全に係る事案で、各政機関の所管する既往の法律には、その防止措置がないもの",
+          "confidence": "low"
+        },
+        {
+          "line": 1024,
+          "missing": "関闘事",
+          "missing_len": 3,
+          "context": "害を生じ、又はそのおそれのある事態が発生し、それが関闘事案である場合に、内閣総理大臣は事業者に対し勧告・命",
+          "confidence": "low"
+        },
+        {
+          "line": 1024,
+          "missing": "闘事案",
+          "missing_len": 3,
+          "context": "を生じ、又はそのおそれのある事態が発生し、それが関闘事案である場合に、内閣総理大臣は事業者に対し勧告・命令",
+          "confidence": "low"
+        },
+        {
+          "line": 1027,
+          "missing": "科学的",
+          "missing_len": 3,
+          "context": "、事故等の原因について、責任追及とは目的を異にする科学的かつ客観的かつ客観的な究明のための調査を実施する。",
+          "confidence": "low"
+        },
+        {
+          "line": 1028,
+          "missing": "関関事",
+          "missing_len": 3,
+          "context": "5. 重大事故等が関関事案に該当するか否かが一見して明確でない場合、まず消",
+          "confidence": "low"
+        },
+        {
+          "line": 1028,
+          "missing": "関事案",
+          "missing_len": 3,
+          "context": "5. 重大事故等が関関事案に該当するか否かが一見して明確でない場合、まず消費",
+          "confidence": "low"
+        },
+        {
+          "line": 1061,
+          "missing": "危機性",
+          "missing_len": 3,
+          "context": "「危機性又は有害性等の調査等に関する指針」に治ってリスクア",
+          "confidence": "low"
+        },
+        {
+          "line": 1061,
+          "missing": "機性又",
+          "missing_len": 3,
+          "context": "「危機性又は有害性等の調査等に関する指針」に治ってリスクアセ",
+          "confidence": "low"
+        },
+        {
+          "line": 1061,
+          "missing": "危機又",
+          "missing_len": 3,
+          "context": "又は有害性等の調査を行い、その結果に基づき労働者の危機又は健康障害を防止するために必要な措置を講ずることを",
+          "confidence": "low"
+        },
+        {
+          "line": 1061,
+          "missing": "健康障",
+          "missing_len": 3,
+          "context": "性等の調査を行い、その結果に基づき労働者の危機又は健康障害を防止するために必要な措置を講ずることをいう。）",
+          "confidence": "low"
+        },
+        {
+          "line": 1061,
+          "missing": "康障害",
+          "missing_len": 3,
+          "context": "等の調査を行い、その結果に基づき労働者の危機又は健康障害を防止するために必要な措置を講ずることをいう。）を",
+          "confidence": "low"
+        },
+        {
+          "line": 1064,
+          "missing": "危機性",
+          "missing_len": 3,
+          "context": "2. 危機性又は有害性の特定を行うための検討チームの編成では、",
+          "confidence": "low"
+        },
+        {
+          "line": 1064,
+          "missing": "機性又",
+          "missing_len": 3,
+          "context": "2. 危機性又は有害性の特定を行うための検討チームの編成では、思",
+          "confidence": "low"
+        },
+        {
+          "line": 1067,
+          "missing": "危機性",
+          "missing_len": 3,
+          "context": "排気装置等の工学的対策、オ）設計・計画段階における危機性の除去や低減、の優先順位で検討し、実施した。",
+          "confidence": "low"
+        },
+        {
+          "line": 1103,
+          "missing": "潜在的",
+          "missing_len": 3,
+          "context": "グとは、作業チームの各メンバーが使用する道具に係る潜在的危機性を相互に指摘し、チーム全体で道具に起因する事",
+          "confidence": "low"
+        },
+        {
+          "line": 1103,
+          "missing": "的危機",
+          "missing_len": 3,
+          "context": "は、作業チームの各メンバーが使用する道具に係る潜在的危機性を相互に指摘し、チーム全体で道具に起因する事故を",
+          "confidence": "low"
+        },
+        {
+          "line": 1103,
+          "missing": "危機性",
+          "missing_len": 3,
+          "context": "、作業チームの各メンバーが使用する道具に係る潜在的危機性を相互に指摘し、チーム全体で道具に起因する事故を防",
+          "confidence": "low"
+        },
+        {
+          "line": 1140,
+          "missing": "関連施",
+          "missing_len": 3,
+          "context": "下図は、労働安全衛生法及び関連施行令で定められた業種別の事業所規模（労働者数）に応",
+          "confidence": "low"
+        },
+        {
+          "line": 1140,
+          "missing": "連施行",
+          "missing_len": 3,
+          "context": "下図は、労働安全衛生法及び関連施行令で定められた業種別の事業所規模（労働者数）に応じ",
+          "confidence": "low"
+        },
+        {
+          "line": 1146,
+          "missing": "電気業",
+          "missing_len": 3,
+          "context": "| ① | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 総括安全",
+          "confidence": "low"
+        },
+        {
+          "line": 1146,
+          "missing": "建設業",
+          "missing_len": 3,
+          "context": "① | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 総括安全衛生管理者 | 産業医 | 50 ",
+          "confidence": "low"
+        },
+        {
+          "line": 1146,
+          "missing": "設業等",
+          "missing_len": 3,
+          "context": " | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1146,
+          "missing": "生管理",
+          "missing_len": 3,
+          "context": "ガス業等 | 林業、鉱業、建設業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1146,
+          "missing": "産業医",
+          "missing_len": 3,
+          "context": "林業、鉱業、建設業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1147,
+          "missing": "電気業",
+          "missing_len": 3,
+          "context": "| ② | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 産業医 ",
+          "confidence": "low"
+        },
+        {
+          "line": 1147,
+          "missing": "建設業",
+          "missing_len": 3,
+          "context": "② | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 産業医 | 総括安全衛生管理者 | 30 ",
+          "confidence": "low"
+        },
+        {
+          "line": 1147,
+          "missing": "設業等",
+          "missing_len": 3,
+          "context": " | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1147,
+          "missing": "産業医",
+          "missing_len": 3,
+          "context": "、電気業、ガス業等 | 林業、鉱業、建設業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1147,
+          "missing": "生管理",
+          "missing_len": 3,
+          "context": " 林業、鉱業、建設業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1148,
+          "missing": "建設業",
+          "missing_len": 3,
+          "context": "| ③ | 林業、鉱業、建設業等 | 製造業、電気業、ガス業等 | 産業医 | ",
+          "confidence": "low"
+        },
+        {
+          "line": 1148,
+          "missing": "設業等",
+          "missing_len": 3,
+          "context": "| ③ | 林業、鉱業、建設業等 | 製造業、電気業、ガス業等 | 産業医 | 総",
+          "confidence": "low"
+        },
+        {
+          "line": 1148,
+          "missing": "電気業",
+          "missing_len": 3,
+          "context": "| ③ | 林業、鉱業、建設業等 | 製造業、電気業、ガス業等 | 産業医 | 総括安全衛生管理者 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1148,
+          "missing": "産業医",
+          "missing_len": 3,
+          "context": "鉱業、建設業等 | 製造業、電気業、ガス業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1148,
+          "missing": "生管理",
+          "missing_len": 3,
+          "context": "造業、電気業、ガス業等 | 産業医 | 総括安全衛生管理者 | 30 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1149,
+          "missing": "建設業",
+          "missing_len": 3,
+          "context": "| ④ | 林業、鉱業、建設業等 | 製造業、電気業、ガス業等 | 総括安全衛生",
+          "confidence": "low"
+        },
+        {
+          "line": 1149,
+          "missing": "設業等",
+          "missing_len": 3,
+          "context": "| ④ | 林業、鉱業、建設業等 | 製造業、電気業、ガス業等 | 総括安全衛生管",
+          "confidence": "low"
+        },
+        {
+          "line": 1149,
+          "missing": "電気業",
+          "missing_len": 3,
+          "context": "| ④ | 林業、鉱業、建設業等 | 製造業、電気業、ガス業等 | 総括安全衛生管理者 | 産業医 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1149,
+          "missing": "生管理",
+          "missing_len": 3,
+          "context": "業等 | 製造業、電気業、ガス業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1149,
+          "missing": "産業医",
+          "missing_len": 3,
+          "context": "業、電気業、ガス業等 | 総括安全衛生管理者 | 産業医 | 50 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1150,
+          "missing": "電気業",
+          "missing_len": 3,
+          "context": "| ⑤ | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 事業部制",
+          "confidence": "low"
+        },
+        {
+          "line": 1150,
+          "missing": "建設業",
+          "missing_len": 3,
+          "context": "⑤ | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 事業部制組織 | 職能別組織 | 50 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1150,
+          "missing": "設業等",
+          "missing_len": 3,
+          "context": " | 製造業、電気業、ガス業等 | 林業、鉱業、建設業等 | 事業部制組織 | 職能別組織 | 50 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1187,
+          "missing": "危機性",
+          "missing_len": 3,
+          "context": "| ① | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安",
+          "confidence": "low"
+        },
+        {
+          "line": 1187,
+          "missing": "機性又",
+          "missing_len": 3,
+          "context": "| ① | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全",
+          "confidence": "low"
+        },
+        {
+          "line": 1187,
+          "missing": "実施安",
+          "missing_len": 3,
+          "context": "| ① | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 | 安全",
+          "confidence": "low"
+        },
+        {
+          "line": 1187,
+          "missing": "施安全",
+          "missing_len": 3,
+          "context": "| ① | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 | 安全衛",
+          "confidence": "low"
+        },
+        {
+          "line": 1187,
+          "missing": "作成危",
+          "missing_len": 3,
+          "context": "の設定 | 安全衛生計画の作成 | 安全衛生計画の作成危機性又は有害性等の調査の実施 | システム監査の実",
+          "confidence": "low"
+        },
+        {
+          "line": 1187,
+          "missing": "成危機",
+          "missing_len": 3,
+          "context": "設定 | 安全衛生計画の作成 | 安全衛生計画の作成危機性又は有害性等の調査の実施 | システム監査の実施",
+          "confidence": "low"
+        },
+        {
+          "line": 1188,
+          "missing": "危機性",
+          "missing_len": 3,
+          "context": "| ② | 危機性又は有害性等の調査の実施安全衛生計画の作成 | 安",
+          "confidence": "low"
+        },
+        {
+          "line": 1188,
+          "missing": "機性又",
+          "missing_len": 3,
+          "context": "| ② | 危機性又は有害性等の調査の実施安全衛生計画の作成 | 安全",
+          "confidence": "low"
+        },
+        {
+          "line": 1188,
+          "missing": "実施安",
+          "missing_len": 3,
+          "context": "| ② | 危機性又は有害性等の調査の実施安全衛生計画の作成 | 安全衛生目標の設定 | 危機",
+          "confidence": "low"
+        },
+        {
+          "line": 1188,
+          "missing": "施安全",
+          "missing_len": 3,
+          "context": "| ② | 危機性又は有害性等の調査の実施安全衛生計画の作成 | 安全衛生目標の設定 | 危機性",
+          "confidence": "low"
+        },
+        {
+          "line": 1190,
+          "missing": "危機性",
+          "missing_len": 3,
+          "context": "| ④ | システム監査の実施 | 危機性又は有害性等の調査の実施 | 危機性又は有害性等の",
+          "confidence": "low"
+        },
+        {
+          "line": 1190,
+          "missing": "機性又",
+          "missing_len": 3,
+          "context": "| ④ | システム監査の実施 | 危機性又は有害性等の調査の実施 | 危機性又は有害性等の調",
+          "confidence": "low"
+        },
+        {
+          "line": 1190,
+          "missing": "実施安",
+          "missing_len": 3,
+          "context": "害性等の調査の実施 | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1190,
+          "missing": "施安全",
+          "missing_len": 3,
+          "context": "性等の調査の実施 | 危機性又は有害性等の調査の実施安全衛生目標の設定 | 安全衛生計画の作成 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1191,
+          "missing": "危機性",
+          "missing_len": 3,
+          "context": " 安全衛生計画の作成 | システム監査の実施 | 危機性又は有害性等の調査の実施 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1191,
+          "missing": "機性又",
+          "missing_len": 3,
+          "context": "安全衛生計画の作成 | システム監査の実施 | 危機性又は有害性等の調査の実施 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1225,
+          "missing": "立事象",
+          "missing_len": 3,
+          "context": "R4の値はどれか。ただし、各ユニットの故障発生は独立事象とする。",
+          "confidence": "low"
+        },
+        {
+          "line": 1270,
+          "missing": "実験管",
+          "missing_len": 3,
+          "context": "4. いわゆる動物実験管理法では、動物実験について、代替法の活用、使用数の",
+          "confidence": "low"
+        },
+        {
+          "line": 1270,
+          "missing": "験管理",
+          "missing_len": 3,
+          "context": "4. いわゆる動物実験管理法では、動物実験について、代替法の活用、使用数の削",
+          "confidence": "low"
+        },
+        {
+          "line": 1270,
+          "missing": "代替法",
+          "missing_len": 3,
+          "context": ". いわゆる動物実験管理法では、動物実験について、代替法の活用、使用数の削減、苦痛の軽減の考え方が示されて",
+          "confidence": "low"
+        },
+        {
+          "line": 1271,
+          "missing": "会的課",
+          "missing_len": 3,
+          "context": "5. 未来の社会変革や経済・社会的課題への対応を図るには、多様なステークホルダー間の対",
+          "confidence": "low"
+        },
+        {
+          "line": 1271,
+          "missing": "的課題",
+          "missing_len": 3,
+          "context": "5. 未来の社会変革や経済・社会的課題への対応を図るには、多様なステークホルダー間の対話",
+          "confidence": "low"
+        },
+        {
+          "line": 1308,
+          "missing": "危機性",
+          "missing_len": 3,
+          "context": "の心身の活力が低下し、生活機能障害や要介護状態等の危機性が高くなった状態をいう。",
+          "confidence": "low"
+        },
+        {
+          "line": 1344,
+          "missing": "開発日",
+          "missing_len": 3,
+          "context": "針の改定版（令和元年に改定された我が国の持続可能な開発日標（SDGs）実施指針）に関する次の記述のうち、最",
+          "confidence": "low"
+        },
+        {
+          "line": 1344,
+          "missing": "発日標",
+          "missing_len": 3,
+          "context": "の改定版（令和元年に改定された我が国の持続可能な開発日標（SDGs）実施指針）に関する次の記述のうち、最も",
+          "confidence": "low"
+        },
+        {
+          "line": 1346,
+          "missing": "国内外",
+          "missing_len": 3,
+          "context": "DGs推進の中長期的な国家戦略としてSDGsに係る国内外における最新の動向を踏まえ日本の取組みの方向性を示",
+          "confidence": "low"
+        },
+        {
+          "line": 1347,
+          "missing": "来都市",
+          "missing_len": 3,
+          "context": "るため、「ジャパンSDGsアワード」や「SDGs未来都市」の選定を通じた活動の「見える化」など、広報・啓発",
+          "confidence": "low"
+        },
+        {
+          "line": 1348,
+          "missing": "三側面",
+          "missing_len": 3,
+          "context": "取組を実施する際には、SDGsが経済、社会、環境の三側面を含むものであること、及びこれらの相互関連性を意識",
+          "confidence": "low"
+        },
+        {
+          "line": 1387,
+          "missing": "動車等",
+          "missing_len": 3,
+          "context": "一次石油ショック当時と比べ、エネルギー利用機器や自動車等などの省エネルギー化が進んだことから、2018年度",
+          "confidence": "low"
+        },
+        {
+          "line": 1427,
+          "missing": "繰択後",
+          "missing_len": 3,
+          "context": "括的に保全するための国際的な枠組みであり、そのその繰択後それを補完するために、希少種や特定の地域の生物種の",
+          "confidence": "low"
+        },
+        {
+          "line": 1546,
+          "missing": "枠組規",
+          "missing_len": 3,
+          "context": "的手法：大気汚染防止法によるばい煙の総量規制 | 枠組規制的手法：化学物質に関するPRTR制度 | 経済的",
+          "confidence": "low"
+        },
+        {
+          "line": 1547,
+          "missing": "枠組規",
+          "missing_len": 3,
+          "context": "的手法：大気汚染防止法によるばい煙の総量規制 | 枠組規制的手法：化学物質に関するPRTR制度 | 経済的",
+          "confidence": "low"
+        },
+        {
+          "line": 1548,
+          "missing": "枠組規",
+          "missing_len": 3,
+          "context": "的手法：大気汚染防止法によるばい煙の総量規制 | 枠組規制的手法：化学物質に関するPRTR制度 | 経済的",
+          "confidence": "low"
+        },
+        {
+          "line": 1550,
+          "missing": "枠組規",
+          "missing_len": 3,
+          "context": "制的手法：大気汚染防止法によるばい煙の総量規制、②枠組規制的手法：化学物質に関するPRTR制度、③経済的手",
+          "confidence": "low"
+        },
+        {
+          "line": 1552,
+          "missing": "枠組規",
+          "missing_len": 3,
+          "context": "制的手法：大気汚染防止法によるばい煙の総量規制、②枠組規制的手法：化学物質に関するPRTR制度、③経済的手",
+          "confidence": "low"
+        },
+        {
+          "line": 1554,
+          "missing": "枠組規",
+          "missing_len": 3,
+          "context": "制的手法：大気汚染防止法によるばい煙の総量規制、②枠組規制的手法：化学物質に関するPRTR制度、③経済的手",
+          "confidence": "low"
+        },
+        {
+          "line": 1598,
+          "missing": "動車道",
+          "missing_len": 3,
+          "context": "| ① | 高速自動車道国道 | 林道 | 下水処理場 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1598,
+          "missing": "車道国",
+          "missing_len": 3,
+          "context": "| ① | 高速自動車道国道 | 林道 | 下水処理場 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1598,
+          "missing": "道国道",
+          "missing_len": 3,
+          "context": "| ① | 高速自動車道国道 | 林道 | 下水処理場 |",
+          "confidence": "low"
+        },
+        {
+          "line": 1639,
+          "missing": "育等推",
+          "missing_len": 3,
+          "context": "3. いわゆる環境教育等推進法は、持続可能な社会の担い手育成の重要性に鑑み、",
+          "confidence": "low"
+        },
+        {
+          "line": 1639,
+          "missing": "等推進",
+          "missing_len": 3,
+          "context": "3. いわゆる環境教育等推進法は、持続可能な社会の担い手育成の重要性に鑑み、様",
+          "confidence": "low"
+        },
+        {
+          "line": 1639,
+          "missing": "推進法",
+          "missing_len": 3,
+          "context": "3. いわゆる環境教育等推進法は、持続可能な社会の担い手育成の重要性に鑑み、様々",
+          "confidence": "low"
+        },
+        {
+          "line": 1640,
+          "missing": "各教科",
+          "missing_len": 3,
+          "context": "「地理歴史」、「公民」、「理科」、「保健体育」等の各教科や「総合的な学習の時間」などにおいて行われている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1641,
+          "missing": "施枠組",
+          "missing_len": 3,
+          "context": "ることを提唱したのは日本であり、現在では国際的な実施枠組みである「ESD for 2030」がユネスコで採",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R03",
+      "kind": "secondary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R03/R03_試験問題_記述式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r03-secondary/article.mdx",
+      "ocr_text_len": 2220,
+      "mdx_text_lines": 55,
+      "ocr_kanji_ngrams": 313,
+      "mismatch_total": 136,
+      "mismatch_by_confidence": {
+        "high": 15,
+        "medium": 42,
+        "low": 79
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 68,
+          "missing": "記述式試験",
+          "missing_len": 5,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3 ",
+          "confidence": "high"
+        },
+        {
+          "line": 73,
+          "missing": "定量的知見",
+          "missing_len": 5,
+          "context": "にわたる推進戦略。勘・経験に依存していた意思決定を定量的知見に置き換える取組、ナレッジマネジメントやデジタル・",
+          "confidence": "high"
+        },
+        {
+          "line": 77,
+          "missing": "技術的進展",
+          "missing_len": 5,
+          "context": "- **近年の技術的進展**: データ収集・解析が従来にない形で可能に",
+          "confidence": "high"
+        },
+        {
+          "line": 79,
+          "missing": "合理的意思",
+          "missing_len": 5,
+          "context": "に頼っていた部分を **定量的な知見** に基づき合理的意思決定",
+          "confidence": "high"
+        },
+        {
+          "line": 79,
+          "missing": "理的意思決",
+          "missing_len": 5,
+          "context": "頼っていた部分を **定量的な知見** に基づき合理的意思決定",
+          "confidence": "high"
+        },
+        {
+          "line": 79,
+          "missing": "的意思決定",
+          "missing_len": 5,
+          "context": "っていた部分を **定量的な知見** に基づき合理的意思決定",
+          "confidence": "high"
+        },
+        {
+          "line": 80,
+          "missing": "利活用効果",
+          "missing_len": 5,
+          "context": "やデジタル・コミュニケーション・ツールの援用による利活用効果の追求",
+          "confidence": "high"
+        },
+        {
+          "line": 99,
+          "missing": "段階的発展",
+          "missing_len": 5,
+          "context": "現状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "high"
+        },
+        {
+          "line": 100,
+          "missing": "利活用方法",
+          "missing_len": 5,
+          "context": "| 論文全体のまとまり | 3 つの利活用方法（近未来 2 つ＋将来 1 つ）が互いに補完・展開",
+          "confidence": "high"
+        },
+        {
+          "line": 108,
+          "missing": "利活用状況",
+          "missing_len": 5,
+          "context": "事業・プロジェクトの概要と、現在のデータ利活用状況を記述する。「どのようなデータを収集・解析している",
+          "confidence": "high"
+        },
+        {
+          "line": 108,
+          "missing": "利活用不足",
+          "missing_len": 5,
+          "context": "段の施策・将来展望の必要性を際立たせるには、現状の利活用不足を前提条件として置く方が論理がつながりやすい。",
+          "confidence": "high"
+        },
+        {
+          "line": 112,
+          "missing": "今後導入可",
+          "missing_len": 5,
+          "context": "**現在既に利用できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "high"
+        },
+        {
+          "line": 112,
+          "missing": "後導入可能",
+          "missing_len": 5,
+          "context": "*現在既に利用できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "high"
+        },
+        {
+          "line": 112,
+          "missing": "利活用方法",
+          "missing_len": 5,
+          "context": "用できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "high"
+        },
+        {
+          "line": 122,
+          "missing": "利活用方法",
+          "missing_len": 5,
+          "context": "るデータや実現されると思われる技術を用いて、新たな利活用方法を 1 つ提示する。事業・プロジェクトの内容や形態",
+          "confidence": "high"
+        },
+        {
+          "line": 27,
+          "missing": "論文全体",
+          "missing_len": 4,
+          "context": "視点の広さ，記述の明確さと論理的なつながり，そして論文全体のまとまりを特に重視する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 53,
+          "missing": "管理分野",
+          "missing_len": 4,
+          "context": "を記せ。ただし，2つの方法それぞれについて，5つの管理分野（経済性管理，安全管理，人的資源管理，情報管理，社",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "記述式試",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "述式試験",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3 ",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "解答戦略",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3 年度の問題",
+          "confidence": "medium"
+        },
+        {
+          "line": 68,
+          "missing": "三層構造",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3 年度の問題文に当てはめた例。本問題",
+          "confidence": "medium"
+        },
+        {
+          "line": 73,
+          "missing": "推進戦略",
+          "missing_len": 4,
+          "context": "タ収集及び利活用** の現状・近未来・将来にわたる推進戦略。勘・経験に依存していた意思決定を定量的知見に置き",
+          "confidence": "medium"
+        },
+        {
+          "line": 73,
+          "missing": "定量的知",
+          "missing_len": 4,
+          "context": "にわたる推進戦略。勘・経験に依存していた意思決定を定量的知見に置き換える取組、ナレッジマネジメントやデジタル",
+          "confidence": "medium"
+        },
+        {
+          "line": 73,
+          "missing": "量的知見",
+          "missing_len": 4,
+          "context": "わたる推進戦略。勘・経験に依存していた意思決定を定量的知見に置き換える取組、ナレッジマネジメントやデジタル・",
+          "confidence": "medium"
+        },
+        {
+          "line": 77,
+          "missing": "技術的進",
+          "missing_len": 4,
+          "context": "- **近年の技術的進展**: データ収集・解析が従来にない形で可能に",
+          "confidence": "medium"
+        },
+        {
+          "line": 77,
+          "missing": "術的進展",
+          "missing_len": 4,
+          "context": "- **近年の技術的進展**: データ収集・解析が従来にない形で可能に",
+          "confidence": "medium"
+        },
+        {
+          "line": 79,
+          "missing": "合理的意",
+          "missing_len": 4,
+          "context": "に頼っていた部分を **定量的な知見** に基づき合理的意思決定",
+          "confidence": "medium"
+        },
+        {
+          "line": 79,
+          "missing": "理的意思",
+          "missing_len": 4,
+          "context": "頼っていた部分を **定量的な知見** に基づき合理的意思決定",
+          "confidence": "medium"
+        },
+        {
+          "line": 79,
+          "missing": "的意思決",
+          "missing_len": 4,
+          "context": "っていた部分を **定量的な知見** に基づき合理的意思決定",
+          "confidence": "medium"
+        },
+        {
+          "line": 80,
+          "missing": "利活用効",
+          "missing_len": 4,
+          "context": "やデジタル・コミュニケーション・ツールの援用による利活用効果の追求",
+          "confidence": "medium"
+        },
+        {
+          "line": 80,
+          "missing": "活用効果",
+          "missing_len": 4,
+          "context": "デジタル・コミュニケーション・ツールの援用による利活用効果の追求",
+          "confidence": "medium"
+        },
+        {
+          "line": 82,
+          "missing": "経済性等",
+          "missing_len": 4,
+          "context": "化** している（セキュリティ、データ品質、人材、経済性等）",
+          "confidence": "medium"
+        },
+        {
+          "line": 86,
+          "missing": "要求事項",
+          "missing_len": 4,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 95,
+          "missing": "評価項目",
+          "missing_len": 4,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 97,
+          "missing": "明記要求",
+          "missing_len": 4,
+          "context": "から課題・リスクが示されているか（設問 (2) で明記要求） |",
+          "confidence": "medium"
+        },
+        {
+          "line": 99,
+          "missing": "既存技術",
+          "missing_len": 4,
+          "context": "| 論理的なつながり | 現状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "medium"
+        },
+        {
+          "line": 99,
+          "missing": "段階的発",
+          "missing_len": 4,
+          "context": "現状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "medium"
+        },
+        {
+          "line": 99,
+          "missing": "階的発展",
+          "missing_len": 4,
+          "context": "状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "medium"
+        },
+        {
+          "line": 100,
+          "missing": "論文全体",
+          "missing_len": 4,
+          "context": "| 論文全体のまとまり | 3 つの利活用方法（近未来 2 つ",
+          "confidence": "medium"
+        },
+        {
+          "line": 100,
+          "missing": "利活用方",
+          "missing_len": 4,
+          "context": "| 論文全体のまとまり | 3 つの利活用方法（近未来 2 つ＋将来 1 つ）が互いに補完・展",
+          "confidence": "medium"
+        },
+        {
+          "line": 100,
+          "missing": "活用方法",
+          "missing_len": 4,
+          "context": "| 論文全体のまとまり | 3 つの利活用方法（近未来 2 つ＋将来 1 つ）が互いに補完・展開",
+          "confidence": "medium"
+        },
+        {
+          "line": 108,
+          "missing": "利活用状",
+          "missing_len": 4,
+          "context": "事業・プロジェクトの概要と、現在のデータ利活用状況を記述する。「どのようなデータを収集・解析してい",
+          "confidence": "medium"
+        },
+        {
+          "line": 108,
+          "missing": "活用状況",
+          "missing_len": 4,
+          "context": "事業・プロジェクトの概要と、現在のデータ利活用状況を記述する。「どのようなデータを収集・解析している",
+          "confidence": "medium"
+        },
+        {
+          "line": 108,
+          "missing": "将来展望",
+          "missing_len": 4,
+          "context": "して記述することを妨げない — むしろ後段の施策・将来展望の必要性を際立たせるには、現状の利活用不足を前提条",
+          "confidence": "medium"
+        },
+        {
+          "line": 108,
+          "missing": "利活用不",
+          "missing_len": 4,
+          "context": "段の施策・将来展望の必要性を際立たせるには、現状の利活用不足を前提条件として置く方が論理がつながりやすい。",
+          "confidence": "medium"
+        },
+        {
+          "line": 108,
+          "missing": "活用不足",
+          "missing_len": 4,
+          "context": "の施策・将来展望の必要性を際立たせるには、現状の利活用不足を前提条件として置く方が論理がつながりやすい。",
+          "confidence": "medium"
+        },
+        {
+          "line": 108,
+          "missing": "前提条件",
+          "missing_len": 4,
+          "context": "来展望の必要性を際立たせるには、現状の利活用不足を前提条件として置く方が論理がつながりやすい。",
+          "confidence": "medium"
+        },
+        {
+          "line": 112,
+          "missing": "後導入可",
+          "missing_len": 4,
+          "context": "*現在既に利用できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "medium"
+        },
+        {
+          "line": 112,
+          "missing": "導入可能",
+          "missing_len": 4,
+          "context": "現在既に利用できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "medium"
+        },
+        {
+          "line": 112,
+          "missing": "利活用方",
+          "missing_len": 4,
+          "context": "用できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "medium"
+        },
+        {
+          "line": 112,
+          "missing": "活用方法",
+          "missing_len": 4,
+          "context": "できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "medium"
+        },
+        {
+          "line": 118,
+          "missing": "視点指定",
+          "missing_len": 4,
+          "context": "5 管理の視点指定がある（＝採点者が明示的に確認する）ので、管理間の",
+          "confidence": "medium"
+        },
+        {
+          "line": 118,
+          "missing": "需要予測",
+          "missing_len": 4,
+          "context": "理間のトレードオフを意識して設計する。例: AI 需要予測（経済性↔情報管理）、IoT センサ監視（安全↔人",
+          "confidence": "medium"
+        },
+        {
+          "line": 120,
+          "missing": "延長線上",
+          "missing_len": 4,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "medium"
+        },
+        {
+          "line": 120,
+          "missing": "将来展望",
+          "missing_len": 4,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "medium"
+        },
+        {
+          "line": 122,
+          "missing": "利活用方",
+          "missing_len": 4,
+          "context": "るデータや実現されると思われる技術を用いて、新たな利活用方法を 1 つ提示する。事業・プロジェクトの内容や形",
+          "confidence": "medium"
+        },
+        {
+          "line": 122,
+          "missing": "活用方法",
+          "missing_len": 4,
+          "context": "データや実現されると思われる技術を用いて、新たな利活用方法を 1 つ提示する。事業・プロジェクトの内容や形態",
+          "confidence": "medium"
+        },
+        {
+          "line": 23,
+          "missing": "合理的",
+          "missing_len": 3,
+          "context": "勘や経験に頼っていた部分をより定量的な知見に基づき合理的なものとするための試み，2）ナレッジマネジメントや",
+          "confidence": "low"
+        },
+        {
+          "line": 27,
+          "missing": "論文全",
+          "missing_len": 3,
+          "context": "視点の広さ，記述の明確さと論理的なつながり，そして論文全体のまとまりを特に重視する。",
+          "confidence": "low"
+        },
+        {
+          "line": 27,
+          "missing": "文全体",
+          "missing_len": 3,
+          "context": "点の広さ，記述の明確さと論理的なつながり，そして論文全体のまとまりを特に重視する。",
+          "confidence": "low"
+        },
+        {
+          "line": 53,
+          "missing": "理分野",
+          "missing_len": 3,
+          "context": "記せ。ただし，2つの方法それぞれについて，5つの管理分野（経済性管理，安全管理，人的資源管理，情報管理，社",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 ",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "述式試",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "式試験",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3 ",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "解答戦",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3 年度の問",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "答戦略",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3 年度の問題",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "三層構",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3 年度の問題文に当てはめた例。本問",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "層構造",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 3 年度の問題文に当てはめた例。本問題",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "問題文",
+          "missing_len": 3,
+          "context": "戦略 で論じている「三層構造」を、令和 3 年度の問題文に当てはめた例。本問題は設問 (1)(2)(3) ",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "本問題",
+          "missing_len": 3,
+          "context": "層構造」を、令和 3 年度の問題文に当てはめた例。本問題は設問 (1)(2)(3) が「現在 → 近い将来",
+          "confidence": "low"
+        },
+        {
+          "line": 68,
+          "missing": "時間軸",
+          "missing_len": 3,
+          "context": "が「現在 → 近い将来 → 5〜10 年後」という時間軸で設計されており、三層構造と時間軸が綺麗に対応する",
+          "confidence": "low"
+        },
+        {
+          "line": 73,
+          "missing": "近未来",
+          "missing_len": 3,
+          "context": "**データ収集及び利活用** の現状・近未来・将来にわたる推進戦略。勘・経験に依存していた意思",
+          "confidence": "low"
+        },
+        {
+          "line": 73,
+          "missing": "推進戦",
+          "missing_len": 3,
+          "context": "タ収集及び利活用** の現状・近未来・将来にわたる推進戦略。勘・経験に依存していた意思決定を定量的知見に置",
+          "confidence": "low"
+        },
+        {
+          "line": 73,
+          "missing": "進戦略",
+          "missing_len": 3,
+          "context": "収集及び利活用** の現状・近未来・将来にわたる推進戦略。勘・経験に依存していた意思決定を定量的知見に置き",
+          "confidence": "low"
+        },
+        {
+          "line": 73,
+          "missing": "量的知",
+          "missing_len": 3,
+          "context": "わたる推進戦略。勘・経験に依存していた意思決定を定量的知見に置き換える取組、ナレッジマネジメントやデジタル",
+          "confidence": "low"
+        },
+        {
+          "line": 73,
+          "missing": "的知見",
+          "missing_len": 3,
+          "context": "たる推進戦略。勘・経験に依存していた意思決定を定量的知見に置き換える取組、ナレッジマネジメントやデジタル・",
+          "confidence": "low"
+        },
+        {
+          "line": 77,
+          "missing": "技術的",
+          "missing_len": 3,
+          "context": "- **近年の技術的進展**: データ収集・解析が従来にない形で可能に",
+          "confidence": "low"
+        },
+        {
+          "line": 77,
+          "missing": "術的進",
+          "missing_len": 3,
+          "context": "- **近年の技術的進展**: データ収集・解析が従来にない形で可能に",
+          "confidence": "low"
+        },
+        {
+          "line": 77,
+          "missing": "的進展",
+          "missing_len": 3,
+          "context": "- **近年の技術的進展**: データ収集・解析が従来にない形で可能に",
+          "confidence": "low"
+        },
+        {
+          "line": 79,
+          "missing": "合理的",
+          "missing_len": 3,
+          "context": "に頼っていた部分を **定量的な知見** に基づき合理的意思決定",
+          "confidence": "low"
+        },
+        {
+          "line": 79,
+          "missing": "理的意",
+          "missing_len": 3,
+          "context": "頼っていた部分を **定量的な知見** に基づき合理的意思決定",
+          "confidence": "low"
+        },
+        {
+          "line": 79,
+          "missing": "的意思",
+          "missing_len": 3,
+          "context": "っていた部分を **定量的な知見** に基づき合理的意思決定",
+          "confidence": "low"
+        },
+        {
+          "line": 80,
+          "missing": "活用効",
+          "missing_len": 3,
+          "context": "デジタル・コミュニケーション・ツールの援用による利活用効果の追求",
+          "confidence": "low"
+        },
+        {
+          "line": 80,
+          "missing": "用効果",
+          "missing_len": 3,
+          "context": "ジタル・コミュニケーション・ツールの援用による利活用効果の追求",
+          "confidence": "low"
+        },
+        {
+          "line": 82,
+          "missing": "済性等",
+          "missing_len": 3,
+          "context": "** している（セキュリティ、データ品質、人材、経済性等）",
+          "confidence": "low"
+        },
+        {
+          "line": 86,
+          "missing": "要求事",
+          "missing_len": 3,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "low"
+        },
+        {
+          "line": 86,
+          "missing": "求事項",
+          "missing_len": 3,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "low"
+        },
+        {
+          "line": 88,
+          "missing": "技術者",
+          "missing_len": 3,
+          "context": "| 立場 | 総合技術監理の技術者として |",
+          "confidence": "low"
+        },
+        {
+          "line": 95,
+          "missing": "評価項",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 95,
+          "missing": "価項目",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 95,
+          "missing": "着眼点",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 97,
+          "missing": "明記要",
+          "missing_len": 3,
+          "context": "から課題・リスクが示されているか（設問 (2) で明記要求） |",
+          "confidence": "low"
+        },
+        {
+          "line": 97,
+          "missing": "記要求",
+          "missing_len": 3,
+          "context": "ら課題・リスクが示されているか（設問 (2) で明記要求） |",
+          "confidence": "low"
+        },
+        {
+          "line": 98,
+          "missing": "具体的",
+          "missing_len": 3,
+          "context": "の明確さ | どのようなデータを、どう活用するかが具体的か |",
+          "confidence": "low"
+        },
+        {
+          "line": 99,
+          "missing": "近未来",
+          "missing_len": 3,
+          "context": "| 論理的なつながり | 現状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然",
+          "confidence": "low"
+        },
+        {
+          "line": 99,
+          "missing": "既存技",
+          "missing_len": 3,
+          "context": "| 論理的なつながり | 現状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "low"
+        },
+        {
+          "line": 99,
+          "missing": "存技術",
+          "missing_len": 3,
+          "context": "| 論理的なつながり | 現状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "low"
+        },
+        {
+          "line": 99,
+          "missing": "新技術",
+          "missing_len": 3,
+          "context": "がり | 現状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "low"
+        },
+        {
+          "line": 99,
+          "missing": "段階的",
+          "missing_len": 3,
+          "context": "現状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "low"
+        },
+        {
+          "line": 99,
+          "missing": "階的発",
+          "missing_len": 3,
+          "context": "状 → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "low"
+        },
+        {
+          "line": 99,
+          "missing": "的発展",
+          "missing_len": 3,
+          "context": " → 近未来（既存技術） → 将来（新技術）の段階的発展が自然か |",
+          "confidence": "low"
+        },
+        {
+          "line": 100,
+          "missing": "論文全",
+          "missing_len": 3,
+          "context": "| 論文全体のまとまり | 3 つの利活用方法（近未来 2 ",
+          "confidence": "low"
+        },
+        {
+          "line": 100,
+          "missing": "文全体",
+          "missing_len": 3,
+          "context": "| 論文全体のまとまり | 3 つの利活用方法（近未来 2 つ",
+          "confidence": "low"
+        },
+        {
+          "line": 100,
+          "missing": "活用方",
+          "missing_len": 3,
+          "context": "| 論文全体のまとまり | 3 つの利活用方法（近未来 2 つ＋将来 1 つ）が互いに補完・展",
+          "confidence": "low"
+        },
+        {
+          "line": 100,
+          "missing": "用方法",
+          "missing_len": 3,
+          "context": "| 論文全体のまとまり | 3 つの利活用方法（近未来 2 つ＋将来 1 つ）が互いに補完・展開",
+          "confidence": "low"
+        },
+        {
+          "line": 100,
+          "missing": "近未来",
+          "missing_len": 3,
+          "context": "| 論文全体のまとまり | 3 つの利活用方法（近未来 2 つ＋将来 1 つ）が互いに補完・展開する関係",
+          "confidence": "low"
+        },
+        {
+          "line": 106,
+          "missing": "設計図",
+          "missing_len": 3,
+          "context": "**(1) 設計図として置くべき前提**（設問 (1) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "活用状",
+          "missing_len": 3,
+          "context": "事業・プロジェクトの概要と、現在のデータ利活用状況を記述する。「どのようなデータを収集・解析してい",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "用状況",
+          "missing_len": 3,
+          "context": "事業・プロジェクトの概要と、現在のデータ利活用状況を記述する。「どのようなデータを収集・解析している",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "留意点",
+          "missing_len": 3,
+          "context": "タを収集・解析しているか」「どう活用しているか」「留意点」「問題点・課題」の 4 項目すべてを含む。**現",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "将来展",
+          "missing_len": 3,
+          "context": "して記述することを妨げない — むしろ後段の施策・将来展望の必要性を際立たせるには、現状の利活用不足を前提",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "来展望",
+          "missing_len": 3,
+          "context": "て記述することを妨げない — むしろ後段の施策・将来展望の必要性を際立たせるには、現状の利活用不足を前提条",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "必要性",
+          "missing_len": 3,
+          "context": "ることを妨げない — むしろ後段の施策・将来展望の必要性を際立たせるには、現状の利活用不足を前提条件として",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "活用不",
+          "missing_len": 3,
+          "context": "の施策・将来展望の必要性を際立たせるには、現状の利活用不足を前提条件として置く方が論理がつながりやすい。",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "用不足",
+          "missing_len": 3,
+          "context": "施策・将来展望の必要性を際立たせるには、現状の利活用不足を前提条件として置く方が論理がつながりやすい。",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "前提条",
+          "missing_len": 3,
+          "context": "来展望の必要性を際立たせるには、現状の利活用不足を前提条件として置く方が論理がつながりやすい。",
+          "confidence": "low"
+        },
+        {
+          "line": 108,
+          "missing": "提条件",
+          "missing_len": 3,
+          "context": "展望の必要性を際立たせるには、現状の利活用不足を前提条件として置く方が論理がつながりやすい。",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "導入可",
+          "missing_len": 3,
+          "context": "現在既に利用できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "入可能",
+          "missing_len": 3,
+          "context": "在既に利用できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "活用方",
+          "missing_len": 3,
+          "context": "できる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "用方法",
+          "missing_len": 3,
+          "context": "きる** データや技術を用いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "各方法",
+          "missing_len": 3,
+          "context": "いて、今後導入可能な利活用方法を 2 つ提示する。各方法について:",
+          "confidence": "low"
+        },
+        {
+          "line": 116,
+          "missing": "分野名",
+          "missing_len": 3,
+          "context": "2 つ以上** の視点からの課題・リスク（解答欄に分野名を明記）",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "視点指",
+          "missing_len": 3,
+          "context": "5 管理の視点指定がある（＝採点者が明示的に確認する）ので、管理間",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "点指定",
+          "missing_len": 3,
+          "context": "5 管理の視点指定がある（＝採点者が明示的に確認する）ので、管理間の",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "採点者",
+          "missing_len": 3,
+          "context": "5 管理の視点指定がある（＝採点者が明示的に確認する）ので、管理間のトレードオフを意",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "明示的",
+          "missing_len": 3,
+          "context": "5 管理の視点指定がある（＝採点者が明示的に確認する）ので、管理間のトレードオフを意識して設",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "管理間",
+          "missing_len": 3,
+          "context": "視点指定がある（＝採点者が明示的に確認する）ので、管理間のトレードオフを意識して設計する。例: AI 需要",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "需要予",
+          "missing_len": 3,
+          "context": "理間のトレードオフを意識して設計する。例: AI 需要予測（経済性↔情報管理）、IoT センサ監視（安全↔",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "要予測",
+          "missing_len": 3,
+          "context": "間のトレードオフを意識して設計する。例: AI 需要予測（経済性↔情報管理）、IoT センサ監視（安全↔人",
+          "confidence": "low"
+        },
+        {
+          "line": 120,
+          "missing": "延長線",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応",
+          "confidence": "low"
+        },
+        {
+          "line": 120,
+          "missing": "長線上",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 120,
+          "missing": "将来展",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 120,
+          "missing": "来展望",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "活用方",
+          "missing_len": 3,
+          "context": "データや実現されると思われる技術を用いて、新たな利活用方法を 1 つ提示する。事業・プロジェクトの内容や形",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "用方法",
+          "missing_len": 3,
+          "context": "ータや実現されると思われる技術を用いて、新たな利活用方法を 1 つ提示する。事業・プロジェクトの内容や形態",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R02",
+      "kind": "primary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R02/R02_試験問題_択一式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r02-primary/article.mdx",
+      "ocr_text_len": 18595,
+      "mdx_text_lines": 310,
+      "ocr_kanji_ngrams": 3944,
+      "mismatch_total": 274,
+      "mismatch_by_confidence": {
+        "high": 63,
+        "medium": 96,
+        "low": 115
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 197,
+          "missing": "代替供給体",
+          "missing_len": 5,
+          "context": "3. 利用可能な複数サプライヤによる代替供給体制の構築",
+          "confidence": "high"
+        },
+        {
+          "line": 197,
+          "missing": "替供給体制",
+          "missing_len": 5,
+          "context": "3. 利用可能な複数サプライヤによる代替供給体制の構築",
+          "confidence": "high"
+        },
+        {
+          "line": 233,
+          "missing": "利益差異及",
+          "missing_len": 5,
+          "context": "ことにある。原価差異は、その正負により、それぞれを利益差異及び不利益差異と呼ばれる。参考のため、これらの原価差",
+          "confidence": "high"
+        },
+        {
+          "line": 233,
+          "missing": "不利益差異",
+          "missing_len": 5,
+          "context": "原価差異は、その正負により、それぞれを利益差異及び不利益差異と呼ばれる。参考のため、これらの原価差異分析でよく",
+          "confidence": "high"
+        },
+        {
+          "line": 235,
+          "missing": "標準原価設",
+          "missing_len": 5,
+          "context": "製造企業のA社は、品目Xについて、次に示す標準原価設定している。",
+          "confidence": "high"
+        },
+        {
+          "line": 235,
+          "missing": "準原価設定",
+          "missing_len": 5,
+          "context": "製造企業のA社は、品目Xについて、次に示す標準原価設定している。",
+          "confidence": "high"
+        },
+        {
+          "line": 288,
+          "missing": "担短計算書",
+          "missing_len": 5,
+          "context": "1. 担短計算書には、前期末から当期末までの期間において、銀行から",
+          "confidence": "high"
+        },
+        {
+          "line": 289,
+          "missing": "貸借対照表",
+          "missing_len": 5,
+          "context": "2. 貸借対照表には、前期末から当期末までの期間において、合計の現",
+          "confidence": "high"
+        },
+        {
+          "line": 370,
+          "missing": "雇用機会均",
+          "missing_len": 5,
+          "context": "進展に伴い、関係法令が整備されてきた。いわゆる男女雇用機会均等法、高年齢者雇用安定法等の諸法令に関する次の記述",
+          "confidence": "high"
+        },
+        {
+          "line": 370,
+          "missing": "用機会均等",
+          "missing_len": 5,
+          "context": "展に伴い、関係法令が整備されてきた。いわゆる男女雇用機会均等法、高年齢者雇用安定法等の諸法令に関する次の記述の",
+          "confidence": "high"
+        },
+        {
+          "line": 370,
+          "missing": "機会均等法",
+          "missing_len": 5,
+          "context": "に伴い、関係法令が整備されてきた。いわゆる男女雇用機会均等法、高年齢者雇用安定法等の諸法令に関する次の記述のう",
+          "confidence": "high"
+        },
+        {
+          "line": 451,
+          "missing": "知的障害者",
+          "missing_len": 5,
+          "context": "雇用納付金制度の対象となる障害者とは、身体障害者、知的障害者、精神障害者（精神障害者保健福祉手帳の交付を受けて",
+          "confidence": "high"
+        },
+        {
+          "line": 528,
+          "missing": "有期雇用職",
+          "missing_len": 5,
+          "context": "1. 長期雇用を前提とする正職員よりも有期雇用職員に対しての適用性が高い。",
+          "confidence": "high"
+        },
+        {
+          "line": 528,
+          "missing": "期雇用職員",
+          "missing_len": 5,
+          "context": "1. 長期雇用を前提とする正職員よりも有期雇用職員に対しての適用性が高い。",
+          "confidence": "high"
+        },
+        {
+          "line": 615,
+          "missing": "間題解決能",
+          "missing_len": 5,
+          "context": "（オ）E君には、間題解決能力を高めるために、ブレインストーミングの社内研修に",
+          "confidence": "high"
+        },
+        {
+          "line": 722,
+          "missing": "年以降徐々",
+          "missing_len": 5,
+          "context": "際出願のうち国内移行したものを含む。）は、2009年以降徐々に減少傾向であったが、ここ数年、ほぼ横ばいで推移し",
+          "confidence": "high"
+        },
+        {
+          "line": 723,
+          "missing": "比較的推移",
+          "missing_len": 5,
+          "context": "意匠登録の出願件数は、多少の増減を繰り返しながらも比較的推移している。",
+          "confidence": "high"
+        },
+        {
+          "line": 725,
+          "missing": "実用新案登",
+          "missing_len": 5,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数の",
+          "confidence": "high"
+        },
+        {
+          "line": 725,
+          "missing": "用新案登録",
+          "missing_len": 5,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数のほ",
+          "confidence": "high"
+        },
+        {
+          "line": 725,
+          "missing": "新案登録出",
+          "missing_len": 5,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数のほぼ",
+          "confidence": "high"
+        },
+        {
+          "line": 725,
+          "missing": "案登録出願",
+          "missing_len": 5,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数のほぼ1",
+          "confidence": "high"
+        },
+        {
+          "line": 725,
+          "missing": "登録出願件",
+          "missing_len": 5,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数のほぼ1／",
+          "confidence": "high"
+        },
+        {
+          "line": 798,
+          "missing": "平均故障間",
+          "missing_len": 5,
+          "context": "使用しており、いずれの機種のカタログにもMTBF（平均故障間隔）は1,000時間と記載されている。使用している",
+          "confidence": "high"
+        },
+        {
+          "line": 798,
+          "missing": "均故障間隔",
+          "missing_len": 5,
+          "context": "用しており、いずれの機種のカタログにもMTBF（平均故障間隔）は1,000時間と記載されている。使用しているす",
+          "confidence": "high"
+        },
+        {
+          "line": 895,
+          "missing": "類社会発展",
+          "missing_len": 5,
+          "context": "、狩猟社会、農耕社会、工業社会、情報社会に続く、人類社会発展の歴史における5番目の新しい社会を指す。",
+          "confidence": "high"
+        },
+        {
+          "line": 938,
+          "missing": "名簿業者以",
+          "missing_len": 5,
+          "context": "の届出義務の主な対象者は、いわゆる名簿業者であり、名簿業者以外の事業者の場合、届出が必要となるかどうかは個別の",
+          "confidence": "high"
+        },
+        {
+          "line": 938,
+          "missing": "簿業者以外",
+          "missing_len": 5,
+          "context": "届出義務の主な対象者は、いわゆる名簿業者であり、名簿業者以外の事業者の場合、届出が必要となるかどうかは個別の判",
+          "confidence": "high"
+        },
+        {
+          "line": 1115,
+          "missing": "絶括安全衛",
+          "missing_len": 5,
+          "context": "3. 絶括安全衛生管理者の選任に係る事業場の規模を算定するための労",
+          "confidence": "high"
+        },
+        {
+          "line": 1116,
+          "missing": "安全衛生士",
+          "missing_len": 5,
+          "context": "4. 派遣先事業者は、雇い入れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置",
+          "confidence": "high"
+        },
+        {
+          "line": 1116,
+          "missing": "全衛生士教",
+          "missing_len": 5,
+          "context": "4. 派遣先事業者は、雇い入れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置を",
+          "confidence": "high"
+        },
+        {
+          "line": 1116,
+          "missing": "衛生士教育",
+          "missing_len": 5,
+          "context": "4. 派遣先事業者は、雇い入れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置を講",
+          "confidence": "high"
+        },
+        {
+          "line": 1116,
+          "missing": "全衛生法上",
+          "missing_len": 5,
+          "context": "れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置を講じなければならない。",
+          "confidence": "high"
+        },
+        {
+          "line": 1155,
+          "missing": "遠隔操作自",
+          "missing_len": 5,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基準",
+          "confidence": "high"
+        },
+        {
+          "line": 1155,
+          "missing": "隔操作自動",
+          "missing_len": 5,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基準を",
+          "confidence": "high"
+        },
+        {
+          "line": 1155,
+          "missing": "操作自動運",
+          "missing_len": 5,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基準を満",
+          "confidence": "high"
+        },
+        {
+          "line": 1155,
+          "missing": "作自動運転",
+          "missing_len": 5,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基準を満た",
+          "confidence": "high"
+        },
+        {
+          "line": 1235,
+          "missing": "離科学的専",
+          "missing_len": 5,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリオ",
+          "confidence": "high"
+        },
+        {
+          "line": 1235,
+          "missing": "科学的専門",
+          "missing_len": 5,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリオな",
+          "confidence": "high"
+        },
+        {
+          "line": 1235,
+          "missing": "学的専門用",
+          "missing_len": 5,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリオなど",
+          "confidence": "high"
+        },
+        {
+          "line": 1235,
+          "missing": "的専門用語",
+          "missing_len": 5,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリオなどを",
+          "confidence": "high"
+        },
+        {
+          "line": 1361,
+          "missing": "費生活用製",
+          "missing_len": 5,
+          "context": "月の小型ガス滸沸器に係る死亡事故等を背景として、消費生活用製品安全法に基づく長期使用製品安全点検制度が設けられ",
+          "confidence": "high"
+        },
+        {
+          "line": 1361,
+          "missing": "生活用製品",
+          "missing_len": 5,
+          "context": "の小型ガス滸沸器に係る死亡事故等を背景として、消費生活用製品安全法に基づく長期使用製品安全点検制度が設けられた",
+          "confidence": "high"
+        },
+        {
+          "line": 1361,
+          "missing": "活用製品安",
+          "missing_len": 5,
+          "context": "小型ガス滸沸器に係る死亡事故等を背景として、消費生活用製品安全法に基づく長期使用製品安全点検制度が設けられた。",
+          "confidence": "high"
+        },
+        {
+          "line": 1361,
+          "missing": "所有者登録",
+          "missing_len": 5,
+          "context": "品」（9品目が定められている。）を購入した所有者が所有者登録することで、メーカー等からの点検時期の通知によって",
+          "confidence": "high"
+        },
+        {
+          "line": 1365,
+          "missing": "用腸間滸沸",
+          "missing_len": 5,
+          "context": "3. 屋外式のガス用腸間滸沸器",
+          "confidence": "high"
+        },
+        {
+          "line": 1365,
+          "missing": "腸間滸沸器",
+          "missing_len": 5,
+          "context": "3. 屋外式のガス用腸間滸沸器",
+          "confidence": "high"
+        },
+        {
+          "line": 1402,
+          "missing": "都道府県及",
+          "missing_len": 5,
+          "context": " 政府には、気候変動適応計画を策定する義務があり、都道府県及び市町村は、その区域における地域気候変動適応計画を",
+          "confidence": "high"
+        },
+        {
+          "line": 1402,
+          "missing": "地域気候変",
+          "missing_len": 5,
+          "context": "義務があり、都道府県及び市町村は、その区域における地域気候変動適応計画を策定する努力義務がある。",
+          "confidence": "high"
+        },
+        {
+          "line": 1402,
+          "missing": "域気候変動",
+          "missing_len": 5,
+          "context": "務があり、都道府県及び市町村は、その区域における地域気候変動適応計画を策定する努力義務がある。",
+          "confidence": "high"
+        },
+        {
+          "line": 1405,
+          "missing": "気候変動動",
+          "missing_len": 5,
+          "context": "境研究所が拠となるべき役割として、気候変動影響及び気候変動動適応に関する情報の収集、整理、分析などを行うことが",
+          "confidence": "high"
+        },
+        {
+          "line": 1405,
+          "missing": "候変動動適",
+          "missing_len": 5,
+          "context": "研究所が拠となるべき役割として、気候変動影響及び気候変動動適応に関する情報の収集、整理、分析などを行うことが定",
+          "confidence": "high"
+        },
+        {
+          "line": 1405,
+          "missing": "変動動適応",
+          "missing_len": 5,
+          "context": "究所が拠となるべき役割として、気候変動影響及び気候変動動適応に関する情報の収集、整理、分析などを行うことが定め",
+          "confidence": "high"
+        },
+        {
+          "line": 1406,
+          "missing": "気候変動動",
+          "missing_len": 5,
+          "context": "5. 気候変動動適応に関する施策の効果の提示・評価については、適切",
+          "confidence": "high"
+        },
+        {
+          "line": 1406,
+          "missing": "候変動動適",
+          "missing_len": 5,
+          "context": "5. 気候変動動適応に関する施策の効果の提示・評価については、適切な",
+          "confidence": "high"
+        },
+        {
+          "line": 1406,
+          "missing": "変動動適応",
+          "missing_len": 5,
+          "context": "5. 気候変動動適応に関する施策の効果の提示・評価については、適切な指",
+          "confidence": "high"
+        },
+        {
+          "line": 1441,
+          "missing": "国内希少生",
+          "missing_len": 5,
+          "context": "則や生息地の保護など、保全に必要な措置の対象となる国内希少生動植物種は、環境省のレッドリストに掲載された野生動",
+          "confidence": "high"
+        },
+        {
+          "line": 1441,
+          "missing": "内希少生動",
+          "missing_len": 5,
+          "context": "や生息地の保護など、保全に必要な措置の対象となる国内希少生動植物種は、環境省のレッドリストに掲載された野生動植",
+          "confidence": "high"
+        },
+        {
+          "line": 1441,
+          "missing": "希少生動植",
+          "missing_len": 5,
+          "context": "生息地の保護など、保全に必要な措置の対象となる国内希少生動植物種は、環境省のレッドリストに掲載された野生動植物",
+          "confidence": "high"
+        },
+        {
+          "line": 1441,
+          "missing": "少生動植物",
+          "missing_len": 5,
+          "context": "息地の保護など、保全に必要な措置の対象となる国内希少生動植物種は、環境省のレッドリストに掲載された野生動植物種",
+          "confidence": "high"
+        },
+        {
+          "line": 1481,
+          "missing": "指定集積袋",
+          "missing_len": 5,
+          "context": "1. 可燃ゴミ指定集積袋など、焼却させるなを得ないプラスチックには、カーボ",
+          "confidence": "high"
+        },
+        {
+          "line": 1525,
+          "missing": "自動車廃棄",
+          "missing_len": 5,
+          "context": "5. いわゆる自動車リサイクル法では、自動車廃棄残さ、フロン類、エアバッグの3品目については、自動",
+          "confidence": "high"
+        },
+        {
+          "line": 1525,
+          "missing": "動車廃棄残",
+          "missing_len": 5,
+          "context": "5. いわゆる自動車リサイクル法では、自動車廃棄残さ、フロン類、エアバッグの3品目については、自動車",
+          "confidence": "high"
+        },
+        {
+          "line": 1605,
+          "missing": "災害廃棄物",
+          "missing_len": 5,
+          "context": "からの復旧・創生とともに、南海トラフ地震等における災害廃棄物の処理等の事例の対応を、重点戦略の根拠の1つと位置",
+          "confidence": "high"
+        },
+        {
+          "line": 27,
+          "missing": "製造工程",
+          "missing_len": 4,
+          "context": "いて、日々の不適合品率が一定範囲内で推移しており、製造工程は安定した状態にある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 115,
+          "missing": "三点見積",
+          "missing_len": 4,
+          "context": "間の見積りやコストの見積りに用いられる技法として、三点見積りやパラメトリック見積りがある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 197,
+          "missing": "代替供給",
+          "missing_len": 4,
+          "context": "3. 利用可能な複数サプライヤによる代替供給体制の構築",
+          "confidence": "medium"
+        },
+        {
+          "line": 197,
+          "missing": "替供給体",
+          "missing_len": 4,
+          "context": "3. 利用可能な複数サプライヤによる代替供給体制の構築",
+          "confidence": "medium"
+        },
+        {
+          "line": 233,
+          "missing": "利益差異",
+          "missing_len": 4,
+          "context": "ことにある。原価差異は、その正負により、それぞれを利益差異及び不利益差異と呼ばれる。参考のため、これらの原価",
+          "confidence": "medium"
+        },
+        {
+          "line": 233,
+          "missing": "益差異及",
+          "missing_len": 4,
+          "context": "とにある。原価差異は、その正負により、それぞれを利益差異及び不利益差異と呼ばれる。参考のため、これらの原価差",
+          "confidence": "medium"
+        },
+        {
+          "line": 233,
+          "missing": "不利益差",
+          "missing_len": 4,
+          "context": "原価差異は、その正負により、それぞれを利益差異及び不利益差異と呼ばれる。参考のため、これらの原価差異分析でよ",
+          "confidence": "medium"
+        },
+        {
+          "line": 235,
+          "missing": "準原価設",
+          "missing_len": 4,
+          "context": "製造企業のA社は、品目Xについて、次に示す標準原価設定している。",
+          "confidence": "medium"
+        },
+        {
+          "line": 235,
+          "missing": "原価設定",
+          "missing_len": 4,
+          "context": "製造企業のA社は、品目Xについて、次に示す標準原価設定している。",
+          "confidence": "medium"
+        },
+        {
+          "line": 288,
+          "missing": "担短計算",
+          "missing_len": 4,
+          "context": "1. 担短計算書には、前期末から当期末までの期間において、銀行か",
+          "confidence": "medium"
+        },
+        {
+          "line": 288,
+          "missing": "短計算書",
+          "missing_len": 4,
+          "context": "1. 担短計算書には、前期末から当期末までの期間において、銀行から",
+          "confidence": "medium"
+        },
+        {
+          "line": 289,
+          "missing": "貸借対照",
+          "missing_len": 4,
+          "context": "2. 貸借対照表には、前期末から当期末までの期間において、合計の",
+          "confidence": "medium"
+        },
+        {
+          "line": 289,
+          "missing": "借対照表",
+          "missing_len": 4,
+          "context": "2. 貸借対照表には、前期末から当期末までの期間において、合計の現",
+          "confidence": "medium"
+        },
+        {
+          "line": 370,
+          "missing": "用機会均",
+          "missing_len": 4,
+          "context": "展に伴い、関係法令が整備されてきた。いわゆる男女雇用機会均等法、高年齢者雇用安定法等の諸法令に関する次の記述",
+          "confidence": "medium"
+        },
+        {
+          "line": 370,
+          "missing": "機会均等",
+          "missing_len": 4,
+          "context": "に伴い、関係法令が整備されてきた。いわゆる男女雇用機会均等法、高年齢者雇用安定法等の諸法令に関する次の記述の",
+          "confidence": "medium"
+        },
+        {
+          "line": 370,
+          "missing": "会均等法",
+          "missing_len": 4,
+          "context": "伴い、関係法令が整備されてきた。いわゆる男女雇用機会均等法、高年齢者雇用安定法等の諸法令に関する次の記述のう",
+          "confidence": "medium"
+        },
+        {
+          "line": 411,
+          "missing": "保持増進",
+          "missing_len": 4,
+          "context": "けられている事業場においては、労働者の精神的健康の保持増進を図るための対策の樹立について、衛生委員会が調査審",
+          "confidence": "medium"
+        },
+        {
+          "line": 451,
+          "missing": "的障害者",
+          "missing_len": 4,
+          "context": "用納付金制度の対象となる障害者とは、身体障害者、知的障害者、精神障害者（精神障害者保健福祉手帳の交付を受けて",
+          "confidence": "medium"
+        },
+        {
+          "line": 454,
+          "missing": "当時雇用",
+          "missing_len": 4,
+          "context": "る労働者の算定に当たっては、パート、アルバイトは、当時雇用する労働者の総数に含まれない。",
+          "confidence": "medium"
+        },
+        {
+          "line": 487,
+          "missing": "雇用形態",
+          "missing_len": 4,
+          "context": "けるダイバーシティ・マネジメントとは、性別、人種、雇用形態などが異なる多様な人材を適材適所で活用することとさ",
+          "confidence": "medium"
+        },
+        {
+          "line": 528,
+          "missing": "期雇用職",
+          "missing_len": 4,
+          "context": "1. 長期雇用を前提とする正職員よりも有期雇用職員に対しての適用性が高い。",
+          "confidence": "medium"
+        },
+        {
+          "line": 528,
+          "missing": "雇用職員",
+          "missing_len": 4,
+          "context": "1. 長期雇用を前提とする正職員よりも有期雇用職員に対しての適用性が高い。",
+          "confidence": "medium"
+        },
+        {
+          "line": 615,
+          "missing": "間題解決",
+          "missing_len": 4,
+          "context": "（オ）E君には、間題解決能力を高めるために、ブレインストーミングの社内研修",
+          "confidence": "medium"
+        },
+        {
+          "line": 722,
+          "missing": "年以降徐",
+          "missing_len": 4,
+          "context": "際出願のうち国内移行したものを含む。）は、2009年以降徐々に減少傾向であったが、ここ数年、ほぼ横ばいで推移",
+          "confidence": "medium"
+        },
+        {
+          "line": 722,
+          "missing": "以降徐々",
+          "missing_len": 4,
+          "context": "出願のうち国内移行したものを含む。）は、2009年以降徐々に減少傾向であったが、ここ数年、ほぼ横ばいで推移し",
+          "confidence": "medium"
+        },
+        {
+          "line": 722,
+          "missing": "減少傾向",
+          "missing_len": 4,
+          "context": "国内移行したものを含む。）は、2009年以降徐々に減少傾向であったが、ここ数年、ほぼ横ばいで推移している。",
+          "confidence": "medium"
+        },
+        {
+          "line": 723,
+          "missing": "意匠登録",
+          "missing_len": 4,
+          "context": "3. 意匠登録の出願件数は、多少の増減を繰り返しながらも比較的推",
+          "confidence": "medium"
+        },
+        {
+          "line": 723,
+          "missing": "比較的推",
+          "missing_len": 4,
+          "context": "意匠登録の出願件数は、多少の増減を繰り返しながらも比較的推移している。",
+          "confidence": "medium"
+        },
+        {
+          "line": 723,
+          "missing": "較的推移",
+          "missing_len": 4,
+          "context": "匠登録の出願件数は、多少の増減を繰り返しながらも比較的推移している。",
+          "confidence": "medium"
+        },
+        {
+          "line": 724,
+          "missing": "商標登録",
+          "missing_len": 4,
+          "context": "4. 商標登録の出願件数は、ここ数年、増加傾向が続いている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 725,
+          "missing": "用新案登",
+          "missing_len": 4,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数の",
+          "confidence": "medium"
+        },
+        {
+          "line": 725,
+          "missing": "新案登録",
+          "missing_len": 4,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数のほ",
+          "confidence": "medium"
+        },
+        {
+          "line": 725,
+          "missing": "案登録出",
+          "missing_len": 4,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数のほぼ",
+          "confidence": "medium"
+        },
+        {
+          "line": 725,
+          "missing": "登録出願",
+          "missing_len": 4,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数のほぼ1",
+          "confidence": "medium"
+        },
+        {
+          "line": 798,
+          "missing": "平均故障",
+          "missing_len": 4,
+          "context": "使用しており、いずれの機種のカタログにもMTBF（平均故障間隔）は1,000時間と記載されている。使用してい",
+          "confidence": "medium"
+        },
+        {
+          "line": 798,
+          "missing": "均故障間",
+          "missing_len": 4,
+          "context": "用しており、いずれの機種のカタログにもMTBF（平均故障間隔）は1,000時間と記載されている。使用している",
+          "confidence": "medium"
+        },
+        {
+          "line": 798,
+          "missing": "故障間隔",
+          "missing_len": 4,
+          "context": "しており、いずれの機種のカタログにもMTBF（平均故障間隔）は1,000時間と記載されている。使用しているす",
+          "confidence": "medium"
+        },
+        {
+          "line": 895,
+          "missing": "社会発展",
+          "missing_len": 4,
+          "context": "狩猟社会、農耕社会、工業社会、情報社会に続く、人類社会発展の歴史における5番目の新しい社会を指す。",
+          "confidence": "medium"
+        },
+        {
+          "line": 933,
+          "missing": "個人同意",
+          "missing_len": 4,
+          "context": "関する法律における個人情報の第三者への提供に関する個人同意を確認する方法として、オプトインとオプトアウトの2",
+          "confidence": "medium"
+        },
+        {
+          "line": 938,
+          "missing": "名簿業者",
+          "missing_len": 4,
+          "context": "オプトアウト手続の届出義務の主な対象者は、いわゆる名簿業者であり、名簿業者以外の事業者の場合、届出が必要とな",
+          "confidence": "medium"
+        },
+        {
+          "line": 938,
+          "missing": "簿業者以",
+          "missing_len": 4,
+          "context": "届出義務の主な対象者は、いわゆる名簿業者であり、名簿業者以外の事業者の場合、届出が必要となるかどうかは個別の",
+          "confidence": "medium"
+        },
+        {
+          "line": 938,
+          "missing": "業者以外",
+          "missing_len": 4,
+          "context": "出義務の主な対象者は、いわゆる名簿業者であり、名簿業者以外の事業者の場合、届出が必要となるかどうかは個別の判",
+          "confidence": "medium"
+        },
+        {
+          "line": 1064,
+          "missing": "直上事象",
+          "missing_len": 4,
+          "context": "（イ）直上事象の発生に必要な条件と要因の因果関係を明らかにし、そ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1115,
+          "missing": "絶括安全",
+          "missing_len": 4,
+          "context": "3. 絶括安全衛生管理者の選任に係る事業場の規模を算定するための",
+          "confidence": "medium"
+        },
+        {
+          "line": 1116,
+          "missing": "全衛生士",
+          "missing_len": 4,
+          "context": "4. 派遣先事業者は、雇い入れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置",
+          "confidence": "medium"
+        },
+        {
+          "line": 1116,
+          "missing": "衛生士教",
+          "missing_len": 4,
+          "context": "4. 派遣先事業者は、雇い入れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置を",
+          "confidence": "medium"
+        },
+        {
+          "line": 1116,
+          "missing": "生士教育",
+          "missing_len": 4,
+          "context": "4. 派遣先事業者は、雇い入れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置を講",
+          "confidence": "medium"
+        },
+        {
+          "line": 1116,
+          "missing": "衛生法上",
+          "missing_len": 4,
+          "context": "時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置を講じなければならない。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1153,
+          "missing": "機械回復",
+          "missing_len": 4,
+          "context": "2. 患者と一体となって運動する機械回復ロボットの安全性については、国際標準が発行されたこ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1155,
+          "missing": "遠隔操作",
+          "missing_len": 4,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基",
+          "confidence": "medium"
+        },
+        {
+          "line": 1155,
+          "missing": "隔操作自",
+          "missing_len": 4,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基準",
+          "confidence": "medium"
+        },
+        {
+          "line": 1155,
+          "missing": "操作自動",
+          "missing_len": 4,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基準を",
+          "confidence": "medium"
+        },
+        {
+          "line": 1155,
+          "missing": "作自動運",
+          "missing_len": 4,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基準を満",
+          "confidence": "medium"
+        },
+        {
+          "line": 1155,
+          "missing": "遠隔操縦",
+          "missing_len": 4,
+          "context": "実験においても、一定の基準を満たす場合には、1名の遠隔操縦・操作者が複数台の実験車両を走行させることができる",
+          "confidence": "medium"
+        },
+        {
+          "line": 1233,
+          "missing": "困難行動",
+          "missing_len": 4,
+          "context": "教育として、想定されている浸水域への思い込みなどが困難行動の障害とならないよう、津波対処の主体的な姿勢を身に",
+          "confidence": "medium"
+        },
+        {
+          "line": 1235,
+          "missing": "離科学的",
+          "missing_len": 4,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1235,
+          "missing": "科学的専",
+          "missing_len": 4,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリオ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1235,
+          "missing": "学的専門",
+          "missing_len": 4,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリオな",
+          "confidence": "medium"
+        },
+        {
+          "line": 1235,
+          "missing": "的専門用",
+          "missing_len": 4,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリオなど",
+          "confidence": "medium"
+        },
+        {
+          "line": 1324,
+          "missing": "問題提起",
+          "missing_len": 4,
+          "context": "あり、当時の原子力安全の考え方や意識そのもの人への問題提起であった。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1361,
+          "missing": "生活用製",
+          "missing_len": 4,
+          "context": "の小型ガス滸沸器に係る死亡事故等を背景として、消費生活用製品安全法に基づく長期使用製品安全点検制度が設けられ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1361,
+          "missing": "活用製品",
+          "missing_len": 4,
+          "context": "小型ガス滸沸器に係る死亡事故等を背景として、消費生活用製品安全法に基づく長期使用製品安全点検制度が設けられた",
+          "confidence": "medium"
+        },
+        {
+          "line": 1361,
+          "missing": "所有者登",
+          "missing_len": 4,
+          "context": "品」（9品目が定められている。）を購入した所有者が所有者登録することで、メーカー等からの点検時期の通知によっ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1361,
+          "missing": "有者登録",
+          "missing_len": 4,
+          "context": "」（9品目が定められている。）を購入した所有者が所有者登録することで、メーカー等からの点検時期の通知によって",
+          "confidence": "medium"
+        },
+        {
+          "line": 1365,
+          "missing": "用腸間滸",
+          "missing_len": 4,
+          "context": "3. 屋外式のガス用腸間滸沸器",
+          "confidence": "medium"
+        },
+        {
+          "line": 1365,
+          "missing": "腸間滸沸",
+          "missing_len": 4,
+          "context": "3. 屋外式のガス用腸間滸沸器",
+          "confidence": "medium"
+        },
+        {
+          "line": 1365,
+          "missing": "間滸沸器",
+          "missing_len": 4,
+          "context": "3. 屋外式のガス用腸間滸沸器",
+          "confidence": "medium"
+        },
+        {
+          "line": 1402,
+          "missing": "道府県及",
+          "missing_len": 4,
+          "context": "政府には、気候変動適応計画を策定する義務があり、都道府県及び市町村は、その区域における地域気候変動適応計画を",
+          "confidence": "medium"
+        },
+        {
+          "line": 1402,
+          "missing": "地域気候",
+          "missing_len": 4,
+          "context": "義務があり、都道府県及び市町村は、その区域における地域気候変動適応計画を策定する努力義務がある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1402,
+          "missing": "域気候変",
+          "missing_len": 4,
+          "context": "務があり、都道府県及び市町村は、その区域における地域気候変動適応計画を策定する努力義務がある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1404,
+          "missing": "排出目標",
+          "missing_len": 4,
+          "context": "合計画であり、主な内容として、国内の温室効果ガスの排出目標と日標達成のための対策が取り上げられている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1404,
+          "missing": "日標達成",
+          "missing_len": 4,
+          "context": "り、主な内容として、国内の温室効果ガスの排出目標と日標達成のための対策が取り上げられている。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1405,
+          "missing": "候変動動",
+          "missing_len": 4,
+          "context": "研究所が拠となるべき役割として、気候変動影響及び気候変動動適応に関する情報の収集、整理、分析などを行うことが",
+          "confidence": "medium"
+        },
+        {
+          "line": 1405,
+          "missing": "変動動適",
+          "missing_len": 4,
+          "context": "究所が拠となるべき役割として、気候変動影響及び気候変動動適応に関する情報の収集、整理、分析などを行うことが定",
+          "confidence": "medium"
+        },
+        {
+          "line": 1405,
+          "missing": "動動適応",
+          "missing_len": 4,
+          "context": "所が拠となるべき役割として、気候変動影響及び気候変動動適応に関する情報の収集、整理、分析などを行うことが定め",
+          "confidence": "medium"
+        },
+        {
+          "line": 1406,
+          "missing": "候変動動",
+          "missing_len": 4,
+          "context": "5. 気候変動動適応に関する施策の効果の提示・評価については、適切",
+          "confidence": "medium"
+        },
+        {
+          "line": 1406,
+          "missing": "変動動適",
+          "missing_len": 4,
+          "context": "5. 気候変動動適応に関する施策の効果の提示・評価については、適切な",
+          "confidence": "medium"
+        },
+        {
+          "line": 1406,
+          "missing": "動動適応",
+          "missing_len": 4,
+          "context": "5. 気候変動動適応に関する施策の効果の提示・評価については、適切な指",
+          "confidence": "medium"
+        },
+        {
+          "line": 1441,
+          "missing": "内希少生",
+          "missing_len": 4,
+          "context": "や生息地の保護など、保全に必要な措置の対象となる国内希少生動植物種は、環境省のレッドリストに掲載された野生動",
+          "confidence": "medium"
+        },
+        {
+          "line": 1441,
+          "missing": "希少生動",
+          "missing_len": 4,
+          "context": "生息地の保護など、保全に必要な措置の対象となる国内希少生動植物種は、環境省のレッドリストに掲載された野生動植",
+          "confidence": "medium"
+        },
+        {
+          "line": 1441,
+          "missing": "少生動植",
+          "missing_len": 4,
+          "context": "息地の保護など、保全に必要な措置の対象となる国内希少生動植物種は、環境省のレッドリストに掲載された野生動植物",
+          "confidence": "medium"
+        },
+        {
+          "line": 1444,
+          "missing": "産業植造",
+          "missing_len": 4,
+          "context": "4. 産業植造の変化等に伴う里山林などの資源利用の減少は、我が国",
+          "confidence": "medium"
+        },
+        {
+          "line": 1444,
+          "missing": "里地里山",
+          "missing_len": 4,
+          "context": "う里山林などの資源利用の減少は、我が国全体として、里地里山における生物多様性の質と量の両面での向上につながる",
+          "confidence": "medium"
+        },
+        {
+          "line": 1481,
+          "missing": "指定集積",
+          "missing_len": 4,
+          "context": "1. 可燃ゴミ指定集積袋など、焼却させるなを得ないプラスチックには、カー",
+          "confidence": "medium"
+        },
+        {
+          "line": 1481,
+          "missing": "定集積袋",
+          "missing_len": 4,
+          "context": "1. 可燃ゴミ指定集積袋など、焼却させるなを得ないプラスチックには、カーボ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1521,
+          "missing": "特定容器",
+          "missing_len": 4,
+          "context": "クル法には、消費者の分別排出、市町村の分別集、及び特定容器を製造する事業者に対する一定量の再商品化についての",
+          "confidence": "medium"
+        },
+        {
+          "line": 1525,
+          "missing": "自動車廃",
+          "missing_len": 4,
+          "context": "5. いわゆる自動車リサイクル法では、自動車廃棄残さ、フロン類、エアバッグの3品目については、自",
+          "confidence": "medium"
+        },
+        {
+          "line": 1525,
+          "missing": "動車廃棄",
+          "missing_len": 4,
+          "context": "5. いわゆる自動車リサイクル法では、自動車廃棄残さ、フロン類、エアバッグの3品目については、自動",
+          "confidence": "medium"
+        },
+        {
+          "line": 1525,
+          "missing": "車廃棄残",
+          "missing_len": 4,
+          "context": "5. いわゆる自動車リサイクル法では、自動車廃棄残さ、フロン類、エアバッグの3品目については、自動車",
+          "confidence": "medium"
+        },
+        {
+          "line": 1562,
+          "missing": "上昇速度",
+          "missing_len": 4,
+          "context": "1. 年平均気温は上昇しており、その上昇速度は世界の平均より大きい。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1602,
+          "missing": "排出目標",
+          "missing_len": 4,
+          "context": "な開発のための2030アジェンダや、温室効果ガスの排出目標に係るパリ協定などと踏まえ、定められた。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1604,
+          "missing": "固有課題",
+          "missing_len": 4,
+          "context": ". 第五次環境基本計画では、様々な環境分野における固有課題を直接的に解決することに比重を置いた分野別の重点戦",
+          "confidence": "medium"
+        },
+        {
+          "line": 1605,
+          "missing": "災害廃棄",
+          "missing_len": 4,
+          "context": "からの復旧・創生とともに、南海トラフ地震等における災害廃棄物の処理等の事例の対応を、重点戦略の根拠の1つと位",
+          "confidence": "medium"
+        },
+        {
+          "line": 1643,
+          "missing": "調査結果",
+          "missing_len": 4,
+          "context": "環境影響評価の結果のうち、環境影響評価の項目ごとの調査結果の概要並びに予測及び評価の結果とともに、環境の保全",
+          "confidence": "medium"
+        },
+        {
+          "line": 1683,
+          "missing": "国際融合",
+          "missing_len": 4,
+          "context": "ている企業を直接・別別にして行う投資のことといい、国際融合が提唱した責任投資原則の基本となる考え方である。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1684,
+          "missing": "環境会計",
+          "missing_len": 4,
+          "context": "5. 環境会計とは、企業等が、事業活動における環境保全のためのコ",
+          "confidence": "medium"
+        },
+        {
+          "line": 27,
+          "missing": "造工程",
+          "missing_len": 3,
+          "context": "て、日々の不適合品率が一定範囲内で推移しており、製造工程は安定した状態にある。",
+          "confidence": "low"
+        },
+        {
+          "line": 115,
+          "missing": "点見積",
+          "missing_len": 3,
+          "context": "の見積りやコストの見積りに用いられる技法として、三点見積りやパラメトリック見積りがある。",
+          "confidence": "low"
+        },
+        {
+          "line": 197,
+          "missing": "代替供",
+          "missing_len": 3,
+          "context": "3. 利用可能な複数サプライヤによる代替供給体制の構築",
+          "confidence": "low"
+        },
+        {
+          "line": 197,
+          "missing": "替供給",
+          "missing_len": 3,
+          "context": "3. 利用可能な複数サプライヤによる代替供給体制の構築",
+          "confidence": "low"
+        },
+        {
+          "line": 233,
+          "missing": "利益差",
+          "missing_len": 3,
+          "context": "ことにある。原価差異は、その正負により、それぞれを利益差異及び不利益差異と呼ばれる。参考のため、これらの原",
+          "confidence": "low"
+        },
+        {
+          "line": 233,
+          "missing": "益差異",
+          "missing_len": 3,
+          "context": "とにある。原価差異は、その正負により、それぞれを利益差異及び不利益差異と呼ばれる。参考のため、これらの原価",
+          "confidence": "low"
+        },
+        {
+          "line": 233,
+          "missing": "不利益",
+          "missing_len": 3,
+          "context": "原価差異は、その正負により、それぞれを利益差異及び不利益差異と呼ばれる。参考のため、これらの原価差異分析で",
+          "confidence": "low"
+        },
+        {
+          "line": 235,
+          "missing": "原価設",
+          "missing_len": 3,
+          "context": "製造企業のA社は、品目Xについて、次に示す標準原価設定している。",
+          "confidence": "low"
+        },
+        {
+          "line": 235,
+          "missing": "価設定",
+          "missing_len": 3,
+          "context": "製造企業のA社は、品目Xについて、次に示す標準原価設定している。",
+          "confidence": "low"
+        },
+        {
+          "line": 288,
+          "missing": "担短計",
+          "missing_len": 3,
+          "context": "1. 担短計算書には、前期末から当期末までの期間において、銀行",
+          "confidence": "low"
+        },
+        {
+          "line": 288,
+          "missing": "短計算",
+          "missing_len": 3,
+          "context": "1. 担短計算書には、前期末から当期末までの期間において、銀行か",
+          "confidence": "low"
+        },
+        {
+          "line": 289,
+          "missing": "借対照",
+          "missing_len": 3,
+          "context": "2. 貸借対照表には、前期末から当期末までの期間において、合計の",
+          "confidence": "low"
+        },
+        {
+          "line": 289,
+          "missing": "対照表",
+          "missing_len": 3,
+          "context": "2. 貸借対照表には、前期末から当期末までの期間において、合計の現",
+          "confidence": "low"
+        },
+        {
+          "line": 328,
+          "missing": "設備時",
+          "missing_len": 3,
+          "context": "しにくい設備に改善したりするための「改善活動」と、設備時の技術的側面を正常・良好な状態に保ち、効率的な生産",
+          "confidence": "low"
+        },
+        {
+          "line": 370,
+          "missing": "機会均",
+          "missing_len": 3,
+          "context": "に伴い、関係法令が整備されてきた。いわゆる男女雇用機会均等法、高年齢者雇用安定法等の諸法令に関する次の記述",
+          "confidence": "low"
+        },
+        {
+          "line": 370,
+          "missing": "会均等",
+          "missing_len": 3,
+          "context": "伴い、関係法令が整備されてきた。いわゆる男女雇用機会均等法、高年齢者雇用安定法等の諸法令に関する次の記述の",
+          "confidence": "low"
+        },
+        {
+          "line": 411,
+          "missing": "保持増",
+          "missing_len": 3,
+          "context": "けられている事業場においては、労働者の精神的健康の保持増進を図るための対策の樹立について、衛生委員会が調査",
+          "confidence": "low"
+        },
+        {
+          "line": 414,
+          "missing": "意見等",
+          "missing_len": 3,
+          "context": "ための選定基準は、医師等のストレスチェック実施者の意見等を踏まえ事業者が決定する。",
+          "confidence": "low"
+        },
+        {
+          "line": 454,
+          "missing": "当時雇",
+          "missing_len": 3,
+          "context": "る労働者の算定に当たっては、パート、アルバイトは、当時雇用する労働者の総数に含まれない。",
+          "confidence": "low"
+        },
+        {
+          "line": 487,
+          "missing": "用形態",
+          "missing_len": 3,
+          "context": "るダイバーシティ・マネジメントとは、性別、人種、雇用形態などが異なる多様な人材を適材適所で活用することとさ",
+          "confidence": "low"
+        },
+        {
+          "line": 528,
+          "missing": "雇用職",
+          "missing_len": 3,
+          "context": "1. 長期雇用を前提とする正職員よりも有期雇用職員に対しての適用性が高い。",
+          "confidence": "low"
+        },
+        {
+          "line": 528,
+          "missing": "用職員",
+          "missing_len": 3,
+          "context": "1. 長期雇用を前提とする正職員よりも有期雇用職員に対しての適用性が高い。",
+          "confidence": "low"
+        },
+        {
+          "line": 605,
+          "missing": "部下下",
+          "missing_len": 3,
+          "context": "ある管理職が、次の（ア）～（オ）のような部下下の能力開発について検討を行っている。それぞれの部下",
+          "confidence": "low"
+        },
+        {
+          "line": 615,
+          "missing": "間題解",
+          "missing_len": 3,
+          "context": "（オ）E君には、間題解決能力を高めるために、ブレインストーミングの社内研",
+          "confidence": "low"
+        },
+        {
+          "line": 722,
+          "missing": "以降徐",
+          "missing_len": 3,
+          "context": "出願のうち国内移行したものを含む。）は、2009年以降徐々に減少傾向であったが、ここ数年、ほぼ横ばいで推移",
+          "confidence": "low"
+        },
+        {
+          "line": 722,
+          "missing": "降徐々",
+          "missing_len": 3,
+          "context": "願のうち国内移行したものを含む。）は、2009年以降徐々に減少傾向であったが、ここ数年、ほぼ横ばいで推移し",
+          "confidence": "low"
+        },
+        {
+          "line": 722,
+          "missing": "減少傾",
+          "missing_len": 3,
+          "context": "国内移行したものを含む。）は、2009年以降徐々に減少傾向であったが、ここ数年、ほぼ横ばいで推移している。",
+          "confidence": "low"
+        },
+        {
+          "line": 722,
+          "missing": "少傾向",
+          "missing_len": 3,
+          "context": "内移行したものを含む。）は、2009年以降徐々に減少傾向であったが、ここ数年、ほぼ横ばいで推移している。",
+          "confidence": "low"
+        },
+        {
+          "line": 723,
+          "missing": "意匠登",
+          "missing_len": 3,
+          "context": "3. 意匠登録の出願件数は、多少の増減を繰り返しながらも比較的",
+          "confidence": "low"
+        },
+        {
+          "line": 723,
+          "missing": "匠登録",
+          "missing_len": 3,
+          "context": "3. 意匠登録の出願件数は、多少の増減を繰り返しながらも比較的推",
+          "confidence": "low"
+        },
+        {
+          "line": 723,
+          "missing": "比較的",
+          "missing_len": 3,
+          "context": "意匠登録の出願件数は、多少の増減を繰り返しながらも比較的推移している。",
+          "confidence": "low"
+        },
+        {
+          "line": 723,
+          "missing": "較的推",
+          "missing_len": 3,
+          "context": "匠登録の出願件数は、多少の増減を繰り返しながらも比較的推移している。",
+          "confidence": "low"
+        },
+        {
+          "line": 723,
+          "missing": "的推移",
+          "missing_len": 3,
+          "context": "登録の出願件数は、多少の増減を繰り返しながらも比較的推移している。",
+          "confidence": "low"
+        },
+        {
+          "line": 724,
+          "missing": "商標登",
+          "missing_len": 3,
+          "context": "4. 商標登録の出願件数は、ここ数年、増加傾向が続いている。",
+          "confidence": "low"
+        },
+        {
+          "line": 724,
+          "missing": "標登録",
+          "missing_len": 3,
+          "context": "4. 商標登録の出願件数は、ここ数年、増加傾向が続いている。",
+          "confidence": "low"
+        },
+        {
+          "line": 725,
+          "missing": "新案登",
+          "missing_len": 3,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数の",
+          "confidence": "low"
+        },
+        {
+          "line": 725,
+          "missing": "案登録",
+          "missing_len": 3,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数のほ",
+          "confidence": "low"
+        },
+        {
+          "line": 725,
+          "missing": "登録出",
+          "missing_len": 3,
+          "context": "5. 実用新案登録出願件数は、多少の増減はあるものの特許出願件数のほぼ",
+          "confidence": "low"
+        },
+        {
+          "line": 798,
+          "missing": "平均故",
+          "missing_len": 3,
+          "context": "使用しており、いずれの機種のカタログにもMTBF（平均故障間隔）は1,000時間と記載されている。使用して",
+          "confidence": "low"
+        },
+        {
+          "line": 798,
+          "missing": "均故障",
+          "missing_len": 3,
+          "context": "用しており、いずれの機種のカタログにもMTBF（平均故障間隔）は1,000時間と記載されている。使用してい",
+          "confidence": "low"
+        },
+        {
+          "line": 798,
+          "missing": "故障間",
+          "missing_len": 3,
+          "context": "しており、いずれの機種のカタログにもMTBF（平均故障間隔）は1,000時間と記載されている。使用している",
+          "confidence": "low"
+        },
+        {
+          "line": 895,
+          "missing": "会発展",
+          "missing_len": 3,
+          "context": "猟社会、農耕社会、工業社会、情報社会に続く、人類社会発展の歴史における5番目の新しい社会を指す。",
+          "confidence": "low"
+        },
+        {
+          "line": 933,
+          "missing": "個人同",
+          "missing_len": 3,
+          "context": "関する法律における個人情報の第三者への提供に関する個人同意を確認する方法として、オプトインとオプトアウトの",
+          "confidence": "low"
+        },
+        {
+          "line": 933,
+          "missing": "人同意",
+          "missing_len": 3,
+          "context": "する法律における個人情報の第三者への提供に関する個人同意を確認する方法として、オプトインとオプトアウトの2",
+          "confidence": "low"
+        },
+        {
+          "line": 938,
+          "missing": "名簿業",
+          "missing_len": 3,
+          "context": "オプトアウト手続の届出義務の主な対象者は、いわゆる名簿業者であり、名簿業者以外の事業者の場合、届出が必要と",
+          "confidence": "low"
+        },
+        {
+          "line": 938,
+          "missing": "簿業者",
+          "missing_len": 3,
+          "context": "プトアウト手続の届出義務の主な対象者は、いわゆる名簿業者であり、名簿業者以外の事業者の場合、届出が必要とな",
+          "confidence": "low"
+        },
+        {
+          "line": 938,
+          "missing": "者以外",
+          "missing_len": 3,
+          "context": "義務の主な対象者は、いわゆる名簿業者であり、名簿業者以外の事業者の場合、届出が必要となるかどうかは個別の判",
+          "confidence": "low"
+        },
+        {
+          "line": 1015,
+          "missing": "復号化",
+          "missing_len": 3,
+          "context": "られる鍵を長くするほど安全性は向上するが、暗号化と復号化で選ぶという欠点がある。",
+          "confidence": "low"
+        },
+        {
+          "line": 1016,
+          "missing": "暗号号",
+          "missing_len": 3,
+          "context": "では、送信者によるメッセージの暗号化と受信者による暗号号の復号に同じ鍵が用いられることから、送信者と受信者",
+          "confidence": "low"
+        },
+        {
+          "line": 1064,
+          "missing": "直上事",
+          "missing_len": 3,
+          "context": "（イ）直上事象の発生に必要な条件と要因の因果関係を明らかにし、",
+          "confidence": "low"
+        },
+        {
+          "line": 1115,
+          "missing": "絶括安",
+          "missing_len": 3,
+          "context": "3. 絶括安全衛生管理者の選任に係る事業場の規模を算定するため",
+          "confidence": "low"
+        },
+        {
+          "line": 1116,
+          "missing": "衛生士",
+          "missing_len": 3,
+          "context": "4. 派遣先事業者は、雇い入れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置",
+          "confidence": "low"
+        },
+        {
+          "line": 1116,
+          "missing": "生士教",
+          "missing_len": 3,
+          "context": "4. 派遣先事業者は、雇い入れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置を",
+          "confidence": "low"
+        },
+        {
+          "line": 1116,
+          "missing": "士教育",
+          "missing_len": 3,
+          "context": "4. 派遣先事業者は、雇い入れ時の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置を講",
+          "confidence": "low"
+        },
+        {
+          "line": 1116,
+          "missing": "生法上",
+          "missing_len": 3,
+          "context": "の安全衛生士教育、一般健康診断の実施等の労働安全衛生法上の措置を講じなければならない。",
+          "confidence": "low"
+        },
+        {
+          "line": 1153,
+          "missing": "機械回",
+          "missing_len": 3,
+          "context": "2. 患者と一体となって運動する機械回復ロボットの安全性については、国際標準が発行された",
+          "confidence": "low"
+        },
+        {
+          "line": 1153,
+          "missing": "械回復",
+          "missing_len": 3,
+          "context": "2. 患者と一体となって運動する機械回復ロボットの安全性については、国際標準が発行されたこ",
+          "confidence": "low"
+        },
+        {
+          "line": 1155,
+          "missing": "遠隔操",
+          "missing_len": 3,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の",
+          "confidence": "low"
+        },
+        {
+          "line": 1155,
+          "missing": "隔操作",
+          "missing_len": 3,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基",
+          "confidence": "low"
+        },
+        {
+          "line": 1155,
+          "missing": "操作自",
+          "missing_len": 3,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基準",
+          "confidence": "low"
+        },
+        {
+          "line": 1155,
+          "missing": "作自動",
+          "missing_len": 3,
+          "context": "4. 遠隔操作自動運転システムの公道実証実験においても、一定の基準を",
+          "confidence": "low"
+        },
+        {
+          "line": 1155,
+          "missing": "隔操縦",
+          "missing_len": 3,
+          "context": "験においても、一定の基準を満たす場合には、1名の遠隔操縦・操作者が複数台の実験車両を走行させることができる",
+          "confidence": "low"
+        },
+        {
+          "line": 1190,
+          "missing": "主電源",
+          "missing_len": 3,
+          "context": "受ける緊急電源が2台とも稼働すれば電を避けられる。主電源の1つが稼働を止める確率はそれぞれpであり、緊急電",
+          "confidence": "low"
+        },
+        {
+          "line": 1233,
+          "missing": "浸水域",
+          "missing_len": 3,
+          "context": "2. 津波防災教育として、想定されている浸水域への思い込みなどが困難行動の障害とならないよう、津",
+          "confidence": "low"
+        },
+        {
+          "line": 1233,
+          "missing": "困難行",
+          "missing_len": 3,
+          "context": "教育として、想定されている浸水域への思い込みなどが困難行動の障害とならないよう、津波対処の主体的な姿勢を身",
+          "confidence": "low"
+        },
+        {
+          "line": 1235,
+          "missing": "離科学",
+          "missing_len": 3,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナ",
+          "confidence": "low"
+        },
+        {
+          "line": 1235,
+          "missing": "学的専",
+          "missing_len": 3,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリオ",
+          "confidence": "low"
+        },
+        {
+          "line": 1235,
+          "missing": "的専門",
+          "missing_len": 3,
+          "context": "4. 技術士などの専門家が、離科学的専門用語を避け、データの意味や不確実性の高いシナリオな",
+          "confidence": "low"
+        },
+        {
+          "line": 1272,
+          "missing": "過大評",
+          "missing_len": 3,
+          "context": "ないが、被害規模が巨大な事象に対して、そのリスクを過大評する傾向のことである。",
+          "confidence": "low"
+        },
+        {
+          "line": 1324,
+          "missing": "問題提",
+          "missing_len": 3,
+          "context": "あり、当時の原子力安全の考え方や意識そのもの人への問題提起であった。",
+          "confidence": "low"
+        },
+        {
+          "line": 1325,
+          "missing": "雰囲気",
+          "missing_len": 3,
+          "context": "いので、厳格な検査や監査による他者の指摘を重視する雰囲気を構成する必要がある。",
+          "confidence": "low"
+        },
+        {
+          "line": 1361,
+          "missing": "滸沸器",
+          "missing_len": 3,
+          "context": "平成19年2月の小型ガス滸沸器に係る死亡事故等を背景として、消費生活用製品安全法",
+          "confidence": "low"
+        },
+        {
+          "line": 1361,
+          "missing": "活用製",
+          "missing_len": 3,
+          "context": "小型ガス滸沸器に係る死亡事故等を背景として、消費生活用製品安全法に基づく長期使用製品安全点検制度が設けられ",
+          "confidence": "low"
+        },
+        {
+          "line": 1361,
+          "missing": "有者登",
+          "missing_len": 3,
+          "context": "」（9品目が定められている。）を購入した所有者が所有者登録することで、メーカー等からの点検時期の通知によっ",
+          "confidence": "low"
+        },
+        {
+          "line": 1361,
+          "missing": "者登録",
+          "missing_len": 3,
+          "context": "（9品目が定められている。）を購入した所有者が所有者登録することで、メーカー等からの点検時期の通知によって",
+          "confidence": "low"
+        },
+        {
+          "line": 1365,
+          "missing": "用腸間",
+          "missing_len": 3,
+          "context": "3. 屋外式のガス用腸間滸沸器",
+          "confidence": "low"
+        },
+        {
+          "line": 1365,
+          "missing": "腸間滸",
+          "missing_len": 3,
+          "context": "3. 屋外式のガス用腸間滸沸器",
+          "confidence": "low"
+        },
+        {
+          "line": 1365,
+          "missing": "間滸沸",
+          "missing_len": 3,
+          "context": "3. 屋外式のガス用腸間滸沸器",
+          "confidence": "low"
+        },
+        {
+          "line": 1365,
+          "missing": "滸沸器",
+          "missing_len": 3,
+          "context": "3. 屋外式のガス用腸間滸沸器",
+          "confidence": "low"
+        },
+        {
+          "line": 1402,
+          "missing": "府県及",
+          "missing_len": 3,
+          "context": "府には、気候変動適応計画を策定する義務があり、都道府県及び市町村は、その区域における地域気候変動適応計画を",
+          "confidence": "low"
+        },
+        {
+          "line": 1402,
+          "missing": "域気候",
+          "missing_len": 3,
+          "context": "務があり、都道府県及び市町村は、その区域における地域気候変動適応計画を策定する努力義務がある。",
+          "confidence": "low"
+        },
+        {
+          "line": 1404,
+          "missing": "排出目",
+          "missing_len": 3,
+          "context": "合計画であり、主な内容として、国内の温室効果ガスの排出目標と日標達成のための対策が取り上げられている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1404,
+          "missing": "出目標",
+          "missing_len": 3,
+          "context": "計画であり、主な内容として、国内の温室効果ガスの排出目標と日標達成のための対策が取り上げられている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1404,
+          "missing": "日標達",
+          "missing_len": 3,
+          "context": "り、主な内容として、国内の温室効果ガスの排出目標と日標達成のための対策が取り上げられている。",
+          "confidence": "low"
+        },
+        {
+          "line": 1405,
+          "missing": "変動動",
+          "missing_len": 3,
+          "context": "究所が拠となるべき役割として、気候変動影響及び気候変動動適応に関する情報の収集、整理、分析などを行うことが",
+          "confidence": "low"
+        },
+        {
+          "line": 1405,
+          "missing": "動動適",
+          "missing_len": 3,
+          "context": "所が拠となるべき役割として、気候変動影響及び気候変動動適応に関する情報の収集、整理、分析などを行うことが定",
+          "confidence": "low"
+        },
+        {
+          "line": 1406,
+          "missing": "変動動",
+          "missing_len": 3,
+          "context": "5. 気候変動動適応に関する施策の効果の提示・評価については、適切",
+          "confidence": "low"
+        },
+        {
+          "line": 1406,
+          "missing": "動動適",
+          "missing_len": 3,
+          "context": "5. 気候変動動適応に関する施策の効果の提示・評価については、適切な",
+          "confidence": "low"
+        },
+        {
+          "line": 1441,
+          "missing": "保全法",
+          "missing_len": 3,
+          "context": "1. いわゆる種の保全法による個体の取扱い規則や生息地の保護など、保全に必",
+          "confidence": "low"
+        },
+        {
+          "line": 1441,
+          "missing": "希少生",
+          "missing_len": 3,
+          "context": "生息地の保護など、保全に必要な措置の対象となる国内希少生動植物種は、環境省のレッドリストに掲載された野生動",
+          "confidence": "low"
+        },
+        {
+          "line": 1441,
+          "missing": "少生動",
+          "missing_len": 3,
+          "context": "息地の保護など、保全に必要な措置の対象となる国内希少生動植物種は、環境省のレッドリストに掲載された野生動植",
+          "confidence": "low"
+        },
+        {
+          "line": 1444,
+          "missing": "産業植",
+          "missing_len": 3,
+          "context": "4. 産業植造の変化等に伴う里山林などの資源利用の減少は、我が",
+          "confidence": "low"
+        },
+        {
+          "line": 1444,
+          "missing": "業植造",
+          "missing_len": 3,
+          "context": "4. 産業植造の変化等に伴う里山林などの資源利用の減少は、我が国",
+          "confidence": "low"
+        },
+        {
+          "line": 1444,
+          "missing": "地里山",
+          "missing_len": 3,
+          "context": "里山林などの資源利用の減少は、我が国全体として、里地里山における生物多様性の質と量の両面での向上につながる",
+          "confidence": "low"
+        },
+        {
+          "line": 1481,
+          "missing": "指定集",
+          "missing_len": 3,
+          "context": "1. 可燃ゴミ指定集積袋など、焼却させるなを得ないプラスチックには、カ",
+          "confidence": "low"
+        },
+        {
+          "line": 1481,
+          "missing": "定集積",
+          "missing_len": 3,
+          "context": "1. 可燃ゴミ指定集積袋など、焼却させるなを得ないプラスチックには、カー",
+          "confidence": "low"
+        },
+        {
+          "line": 1481,
+          "missing": "集積袋",
+          "missing_len": 3,
+          "context": "1. 可燃ゴミ指定集積袋など、焼却させるなを得ないプラスチックには、カーボ",
+          "confidence": "low"
+        },
+        {
+          "line": 1521,
+          "missing": "分別集",
+          "missing_len": 3,
+          "context": "器包装リサイクル法には、消費者の分別排出、市町村の分別集、及び特定容器を製造する事業者に対する一定量の再商",
+          "confidence": "low"
+        },
+        {
+          "line": 1521,
+          "missing": "特定容",
+          "missing_len": 3,
+          "context": "クル法には、消費者の分別排出、市町村の分別集、及び特定容器を製造する事業者に対する一定量の再商品化について",
+          "confidence": "low"
+        },
+        {
+          "line": 1521,
+          "missing": "定容器",
+          "missing_len": 3,
+          "context": "ル法には、消費者の分別排出、市町村の分別集、及び特定容器を製造する事業者に対する一定量の再商品化についての",
+          "confidence": "low"
+        },
+        {
+          "line": 1525,
+          "missing": "動車廃",
+          "missing_len": 3,
+          "context": "5. いわゆる自動車リサイクル法では、自動車廃棄残さ、フロン類、エアバッグの3品目については、自",
+          "confidence": "low"
+        },
+        {
+          "line": 1525,
+          "missing": "車廃棄",
+          "missing_len": 3,
+          "context": "5. いわゆる自動車リサイクル法では、自動車廃棄残さ、フロン類、エアバッグの3品目については、自動",
+          "confidence": "low"
+        },
+        {
+          "line": 1525,
+          "missing": "廃棄残",
+          "missing_len": 3,
+          "context": "5. いわゆる自動車リサイクル法では、自動車廃棄残さ、フロン類、エアバッグの3品目については、自動車",
+          "confidence": "low"
+        },
+        {
+          "line": 1562,
+          "missing": "上昇速",
+          "missing_len": 3,
+          "context": "1. 年平均気温は上昇しており、その上昇速度は世界の平均より大きい。",
+          "confidence": "low"
+        },
+        {
+          "line": 1562,
+          "missing": "昇速度",
+          "missing_len": 3,
+          "context": "1. 年平均気温は上昇しており、その上昇速度は世界の平均より大きい。",
+          "confidence": "low"
+        },
+        {
+          "line": 1602,
+          "missing": "排出目",
+          "missing_len": 3,
+          "context": "な開発のための2030アジェンダや、温室効果ガスの排出目標に係るパリ協定などと踏まえ、定められた。",
+          "confidence": "low"
+        },
+        {
+          "line": 1602,
+          "missing": "出目標",
+          "missing_len": 3,
+          "context": "開発のための2030アジェンダや、温室効果ガスの排出目標に係るパリ協定などと踏まえ、定められた。",
+          "confidence": "low"
+        },
+        {
+          "line": 1604,
+          "missing": "固有課",
+          "missing_len": 3,
+          "context": ". 第五次環境基本計画では、様々な環境分野における固有課題を直接的に解決することに比重を置いた分野別の重点",
+          "confidence": "low"
+        },
+        {
+          "line": 1604,
+          "missing": "有課題",
+          "missing_len": 3,
+          "context": " 第五次環境基本計画では、様々な環境分野における固有課題を直接的に解決することに比重を置いた分野別の重点戦",
+          "confidence": "low"
+        },
+        {
+          "line": 1605,
+          "missing": "地震等",
+          "missing_len": 3,
+          "context": "、東日本大震災からの復旧・創生とともに、南海トラフ地震等における災害廃棄物の処理等の事例の対応を、重点戦略",
+          "confidence": "low"
+        },
+        {
+          "line": 1605,
+          "missing": "災害廃",
+          "missing_len": 3,
+          "context": "からの復旧・創生とともに、南海トラフ地震等における災害廃棄物の処理等の事例の対応を、重点戦略の根拠の1つと",
+          "confidence": "low"
+        },
+        {
+          "line": 1643,
+          "missing": "調査結",
+          "missing_len": 3,
+          "context": "環境影響評価の結果のうち、環境影響評価の項目ごとの調査結果の概要並びに予測及び評価の結果とともに、環境の保",
+          "confidence": "low"
+        },
+        {
+          "line": 1683,
+          "missing": "国際融",
+          "missing_len": 3,
+          "context": "ている企業を直接・別別にして行う投資のことといい、国際融合が提唱した責任投資原則の基本となる考え方である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1683,
+          "missing": "際融合",
+          "missing_len": 3,
+          "context": "いる企業を直接・別別にして行う投資のことといい、国際融合が提唱した責任投資原則の基本となる考え方である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1684,
+          "missing": "環境会",
+          "missing_len": 3,
+          "context": "5. 環境会計とは、企業等が、事業活動における環境保全のための",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R02",
+      "kind": "secondary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R02/R02_試験問題_記述式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r02-secondary/article.mdx",
+      "ocr_text_len": 2852,
+      "mdx_text_lines": 56,
+      "ocr_kanji_ngrams": 395,
+      "mismatch_total": 194,
+      "mismatch_by_confidence": {
+        "high": 17,
+        "medium": 59,
+        "low": 118
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 20,
+          "missing": "総監記述式",
+          "missing_len": 5,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）** ",
+          "confidence": "high"
+        },
+        {
+          "line": 20,
+          "missing": "作問委員任",
+          "missing_len": 5,
+          "context": "降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは",
+          "confidence": "high"
+        },
+        {
+          "line": 20,
+          "missing": "問委員任期",
+          "missing_len": 5,
+          "context": "の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは ",
+          "confidence": "high"
+        },
+        {
+          "line": 31,
+          "missing": "専門分野外",
+          "missing_len": 5,
+          "context": "被害や対策が事業場にとって特徴的で，かつその説明が専門分野外の人（例えば専門が異なる総合技術監理部門の技術士）",
+          "confidence": "high"
+        },
+        {
+          "line": 75,
+          "missing": "記述式試験",
+          "missing_len": 5,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2 ",
+          "confidence": "high"
+        },
+        {
+          "line": 86,
+          "missing": "物理的被害",
+          "missing_len": 5,
+          "context": "- **被害の範囲**: 直接的な物理的被害に加え、人的被害・業務上の被害（サプライチェーン途",
+          "confidence": "high"
+        },
+        {
+          "line": 87,
+          "missing": "堤防改修等",
+          "missing_len": 5,
+          "context": "が **自主的に行える** ものに限る（国の道路・堤防改修等は除外）",
+          "confidence": "high"
+        },
+        {
+          "line": 114,
+          "missing": "事業場特性",
+          "missing_len": 5,
+          "context": " (2) で取り上げる被害 3 つが成立するような事業場特性** を意図的に置く（例: 海と河川に近い低地、線",
+          "confidence": "high"
+        },
+        {
+          "line": 123,
+          "missing": "非常用電源",
+          "missing_len": 5,
+          "context": "↔情報」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔",
+          "confidence": "high"
+        },
+        {
+          "line": 123,
+          "missing": "常用電源整",
+          "missing_len": 5,
+          "context": "情報」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重",
+          "confidence": "high"
+        },
+        {
+          "line": 123,
+          "missing": "用電源整備",
+          "missing_len": 5,
+          "context": "報」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要",
+          "confidence": "high"
+        },
+        {
+          "line": 123,
+          "missing": "経済性投資",
+          "missing_len": 5,
+          "context": "ドオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改",
+          "confidence": "high"
+        },
+        {
+          "line": 123,
+          "missing": "防風柵整備",
+          "missing_len": 5,
+          "context": "る。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔抜本",
+          "confidence": "high"
+        },
+        {
+          "line": 127,
+          "missing": "被害発生可",
+          "missing_len": 5,
+          "context": "を提示する。優先順位の根拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経済性」から組み立て、**",
+          "confidence": "high"
+        },
+        {
+          "line": 127,
+          "missing": "害発生可能",
+          "missing_len": 5,
+          "context": "提示する。優先順位の根拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経済性」から組み立て、**短",
+          "confidence": "high"
+        },
+        {
+          "line": 132,
+          "missing": "模範解答例",
+          "missing_len": 5,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テーマは「異常な",
+          "confidence": "high"
+        },
+        {
+          "line": 252,
+          "missing": "模範解答例",
+          "missing_len": 5,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは「",
+          "confidence": "high"
+        },
+        {
+          "line": 20,
+          "missing": "総監記述",
+          "missing_len": 4,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）**",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "監記述式",
+          "missing_len": 4,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）** ",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "出題形式",
+          "missing_len": 4,
+          "context": "属し、現在（R03 以降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "作問委員",
+          "missing_len": 4,
+          "context": "降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まず",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "問委員任",
+          "missing_len": 4,
+          "context": "の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "委員任期",
+          "missing_len": 4,
+          "context": " **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは ",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "形式変化",
+          "missing_len": 4,
+          "context": "が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "解答戦略",
+          "missing_len": 4,
+          "context": " 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "三層構造",
+          "missing_len": 4,
+          "context": "年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度 記述式 ",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "論点抽出",
+          "missing_len": 4,
+          "context": "分） と 令和 7 年度 記述式 を学習してから、論点抽出の素材として本ページを参照することを推奨します。",
+          "confidence": "medium"
+        },
+        {
+          "line": 29,
+          "missing": "情報管理",
+          "missing_len": 4,
+          "context": "全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に関する総合的な分析，評価に基づいて",
+          "confidence": "medium"
+        },
+        {
+          "line": 31,
+          "missing": "専門分野",
+          "missing_len": 4,
+          "context": "被害や対策が事業場にとって特徴的で，かつその説明が専門分野外の人（例えば専門が異なる総合技術監理部門の技術士",
+          "confidence": "medium"
+        },
+        {
+          "line": 31,
+          "missing": "門分野外",
+          "missing_len": 4,
+          "context": "害や対策が事業場にとって特徴的で，かつその説明が専門分野外の人（例えば専門が異なる総合技術監理部門の技術士）",
+          "confidence": "medium"
+        },
+        {
+          "line": 58,
+          "missing": "電気設備",
+          "missing_len": 4,
+          "context": "- A：〇〇〇〇…（「停電」，「床上浸水による電気設備の故障」など，1番目の被害とその説明）",
+          "confidence": "medium"
+        },
+        {
+          "line": 75,
+          "missing": "記述式試",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2",
+          "confidence": "medium"
+        },
+        {
+          "line": 75,
+          "missing": "述式試験",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2 ",
+          "confidence": "medium"
+        },
+        {
+          "line": 75,
+          "missing": "解答戦略",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2 年度の問題",
+          "confidence": "medium"
+        },
+        {
+          "line": 75,
+          "missing": "三層構造",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2 年度の問題文に当てはめた例。本問題",
+          "confidence": "medium"
+        },
+        {
+          "line": 75,
+          "missing": "設問構成",
+          "missing_len": 4,
+          "context": ")(3) の 3 階層で、三層構造の原型がそのまま設問構成に対応する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 80,
+          "missing": "事前対策",
+          "missing_len": 4,
+          "context": "将来の **自然災害リスクに対する事前対策**（BCP）。特定の事業場に甚大な被害を及ぼす可",
+          "confidence": "medium"
+        },
+        {
+          "line": 85,
+          "missing": "複合形態",
+          "missing_len": 4,
+          "context": "雨、豪雪、洪水、高潮、地震、津波、噴火、台風などの複合形態。感染症は含まない",
+          "confidence": "medium"
+        },
+        {
+          "line": 86,
+          "missing": "物理的被",
+          "missing_len": 4,
+          "context": "- **被害の範囲**: 直接的な物理的被害に加え、人的被害・業務上の被害（サプライチェーン",
+          "confidence": "medium"
+        },
+        {
+          "line": 86,
+          "missing": "理的被害",
+          "missing_len": 4,
+          "context": "- **被害の範囲**: 直接的な物理的被害に加え、人的被害・業務上の被害（サプライチェーン途",
+          "confidence": "medium"
+        },
+        {
+          "line": 87,
+          "missing": "堤防改修",
+          "missing_len": 4,
+          "context": "が **自主的に行える** ものに限る（国の道路・堤防改修等は除外）",
+          "confidence": "medium"
+        },
+        {
+          "line": 87,
+          "missing": "防改修等",
+          "missing_len": 4,
+          "context": " **自主的に行える** ものに限る（国の道路・堤防改修等は除外）",
+          "confidence": "medium"
+        },
+        {
+          "line": 88,
+          "missing": "記述形式",
+          "missing_len": 4,
+          "context": "- **記述形式**: 被害 A/B/C のラベル付け、対策は A",
+          "confidence": "medium"
+        },
+        {
+          "line": 92,
+          "missing": "要求事項",
+          "missing_len": 4,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 96,
+          "missing": "情報管理",
+          "missing_len": 4,
+          "context": "| 視点 | 経済性管理・人的資源管理・情報管理・安全管理・社会環境管理の 5 管理 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 101,
+          "missing": "評価項目",
+          "missing_len": 4,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "周辺環境",
+          "missing_len": 4,
+          "context": "事業場を 1 つ選定し、立地・規模・機能・周辺環境を記述する。**後段の設問 (2) で取り上げる被",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "事業場特",
+          "missing_len": 4,
+          "context": " (2) で取り上げる被害 3 つが成立するような事業場特性** を意図的に置く（例: 海と河川に近い低地、",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "業場特性",
+          "missing_len": 4,
+          "context": "(2) で取り上げる被害 3 つが成立するような事業場特性** を意図的に置く（例: 海と河川に近い低地、線",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "強風環境",
+          "missing_len": 4,
+          "context": "河川に近い低地、線路下の改札、地下デッキ、沿岸部の強風環境など）。設定した事業場の特性が、選定する自然現象（",
+          "confidence": "medium"
+        },
+        {
+          "line": 121,
+          "missing": "実施可能",
+          "missing_len": 4,
+          "context": "*A1, A2**（追加対策）: 事業場が自主的に実施可能で、近い将来に導入可能な対策",
+          "confidence": "medium"
+        },
+        {
+          "line": 121,
+          "missing": "導入可能",
+          "missing_len": 4,
+          "context": "加対策）: 事業場が自主的に実施可能で、近い将来に導入可能な対策",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "非常用電",
+          "missing_len": 4,
+          "context": "↔情報」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "常用電源",
+          "missing_len": 4,
+          "context": "情報」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "用電源整",
+          "missing_len": 4,
+          "context": "報」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "電源整備",
+          "missing_len": 4,
+          "context": "」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "経済性投",
+          "missing_len": 4,
+          "context": "ドオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "済性投資",
+          "missing_len": 4,
+          "context": "オフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "安全確保",
+          "missing_len": 4,
+          "context": "る形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "防風柵整",
+          "missing_len": 4,
+          "context": "る。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔抜",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "風柵整備",
+          "missing_len": 4,
+          "context": "。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔抜本",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "設備改修",
+          "missing_len": 4,
+          "context": "性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔抜本対策）。",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "抜本対策",
+          "missing_len": 4,
+          "context": "整備（コスト↔重要度）、設備改修・移転（高コスト↔抜本対策）。",
+          "confidence": "medium"
+        },
+        {
+          "line": 125,
+          "missing": "延長線上",
+          "missing_len": 4,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "medium"
+        },
+        {
+          "line": 125,
+          "missing": "将来展望",
+          "missing_len": 4,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "medium"
+        },
+        {
+          "line": 127,
+          "missing": "被害規模",
+          "missing_len": 4,
+          "context": "* を付けた実施計画を提示する。優先順位の根拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経済",
+          "confidence": "medium"
+        },
+        {
+          "line": 127,
+          "missing": "被害発生",
+          "missing_len": 4,
+          "context": "を提示する。優先順位の根拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経済性」から組み立て、*",
+          "confidence": "medium"
+        },
+        {
+          "line": 127,
+          "missing": "害発生可",
+          "missing_len": 4,
+          "context": "提示する。優先順位の根拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経済性」から組み立て、**",
+          "confidence": "medium"
+        },
+        {
+          "line": 132,
+          "missing": "模範解答",
+          "missing_len": 4,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テーマは「異常",
+          "confidence": "medium"
+        },
+        {
+          "line": 132,
+          "missing": "範解答例",
+          "missing_len": 4,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テーマは「異常な",
+          "confidence": "medium"
+        },
+        {
+          "line": 132,
+          "missing": "選択科目",
+          "missing_len": 4,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テーマは「異常な自然現象（台",
+          "confidence": "medium"
+        },
+        {
+          "line": 252,
+          "missing": "模範解答",
+          "missing_len": 4,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは",
+          "confidence": "medium"
+        },
+        {
+          "line": 252,
+          "missing": "範解答例",
+          "missing_len": 4,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは「",
+          "confidence": "medium"
+        },
+        {
+          "line": 252,
+          "missing": "選択科目",
+          "missing_len": 4,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは「地震災害に対",
+          "confidence": "medium"
+        },
+        {
+          "line": 252,
+          "missing": "上下水道",
+          "missing_len": 4,
+          "context": "2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは「地震災害に対する事前の備え",
+          "confidence": "medium"
+        },
+        {
+          "line": 252,
+          "missing": "地震災害",
+          "missing_len": 4,
+          "context": "②。選択科目は**上下水道－下水道**、テーマは「地震災害に対する事前の備え」です。",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "総監記",
+          "missing_len": 3,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）*",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "監記述",
+          "missing_len": 3,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）**",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）** ",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "転換期",
+          "missing_len": 3,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）** に属し、現在（R03 以降",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "出題形",
+          "missing_len": 3,
+          "context": "属し、現在（R03 以降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "題形式",
+          "missing_len": 3,
+          "context": "し、現在（R03 以降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "作問委",
+          "missing_len": 3,
+          "context": "降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。ま",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "問委員",
+          "missing_len": 3,
+          "context": "の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まず",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "委員任",
+          "missing_len": 3,
+          "context": " **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "員任期",
+          "missing_len": 3,
+          "context": "**第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは ",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "年周期",
+          "missing_len": 3,
+          "context": "出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "形式変",
+          "missing_len": 3,
+          "context": "が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 ",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "式変化",
+          "missing_len": 3,
+          "context": "異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "解答戦",
+          "missing_len": 3,
+          "context": " 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "答戦略",
+          "missing_len": 3,
+          "context": "3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "三層構",
+          "missing_len": 3,
+          "context": "年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度 記述式",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "層構造",
+          "missing_len": 3,
+          "context": "周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度 記述式 ",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "論点抽",
+          "missing_len": 3,
+          "context": "分） と 令和 7 年度 記述式 を学習してから、論点抽出の素材として本ページを参照することを推奨します。",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "点抽出",
+          "missing_len": 3,
+          "context": "） と 令和 7 年度 記述式 を学習してから、論点抽出の素材として本ページを参照することを推奨します。",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "情報管",
+          "missing_len": 3,
+          "context": "全体を俯瞰し，経済性管理，安全管理，人的資源管理，情報管理，社会環境管理に関する総合的な分析，評価に基づい",
+          "confidence": "low"
+        },
+        {
+          "line": 31,
+          "missing": "専門分",
+          "missing_len": 3,
+          "context": "被害や対策が事業場にとって特徴的で，かつその説明が専門分野外の人（例えば専門が異なる総合技術監理部門の技術",
+          "confidence": "low"
+        },
+        {
+          "line": 31,
+          "missing": "門分野",
+          "missing_len": 3,
+          "context": "害や対策が事業場にとって特徴的で，かつその説明が専門分野外の人（例えば専門が異なる総合技術監理部門の技術士",
+          "confidence": "low"
+        },
+        {
+          "line": 58,
+          "missing": "電気設",
+          "missing_len": 3,
+          "context": "- A：〇〇〇〇…（「停電」，「床上浸水による電気設備の故障」など，1番目の被害とその説明）",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 ",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "述式試",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "式試験",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2 ",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "解答戦",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2 年度の問",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "答戦略",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2 年度の問題",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "三層構",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2 年度の問題文に当てはめた例。本問",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "層構造",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和 2 年度の問題文に当てはめた例。本問題",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "問題文",
+          "missing_len": 3,
+          "context": "戦略 で論じている「三層構造」を、令和 2 年度の問題文に当てはめた例。本問題は (1)(2)(3) の ",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "本問題",
+          "missing_len": 3,
+          "context": "層構造」を、令和 2 年度の問題文に当てはめた例。本問題は (1)(2)(3) の 3 階層で、三層構造の",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "設問構",
+          "missing_len": 3,
+          "context": ")(3) の 3 階層で、三層構造の原型がそのまま設問構成に対応する。",
+          "confidence": "low"
+        },
+        {
+          "line": 75,
+          "missing": "問構成",
+          "missing_len": 3,
+          "context": "(3) の 3 階層で、三層構造の原型がそのまま設問構成に対応する。",
+          "confidence": "low"
+        },
+        {
+          "line": 80,
+          "missing": "事前対",
+          "missing_len": 3,
+          "context": "将来の **自然災害リスクに対する事前対策**（BCP）。特定の事業場に甚大な被害を及ぼす",
+          "confidence": "low"
+        },
+        {
+          "line": 80,
+          "missing": "前対策",
+          "missing_len": 3,
+          "context": "将来の **自然災害リスクに対する事前対策**（BCP）。特定の事業場に甚大な被害を及ぼす可",
+          "confidence": "low"
+        },
+        {
+          "line": 85,
+          "missing": "複合形",
+          "missing_len": 3,
+          "context": "雨、豪雪、洪水、高潮、地震、津波、噴火、台風などの複合形態。感染症は含まない",
+          "confidence": "low"
+        },
+        {
+          "line": 85,
+          "missing": "合形態",
+          "missing_len": 3,
+          "context": "、豪雪、洪水、高潮、地震、津波、噴火、台風などの複合形態。感染症は含まない",
+          "confidence": "low"
+        },
+        {
+          "line": 86,
+          "missing": "直接的",
+          "missing_len": 3,
+          "context": "- **被害の範囲**: 直接的な物理的被害に加え、人的被害・業務上の被害（サプラ",
+          "confidence": "low"
+        },
+        {
+          "line": 86,
+          "missing": "理的被",
+          "missing_len": 3,
+          "context": "- **被害の範囲**: 直接的な物理的被害に加え、人的被害・業務上の被害（サプライチェーン",
+          "confidence": "low"
+        },
+        {
+          "line": 86,
+          "missing": "途絶等",
+          "missing_len": 3,
+          "context": "害に加え、人的被害・業務上の被害（サプライチェーン途絶等）も含めてよい",
+          "confidence": "low"
+        },
+        {
+          "line": 87,
+          "missing": "堤防改",
+          "missing_len": 3,
+          "context": "が **自主的に行える** ものに限る（国の道路・堤防改修等は除外）",
+          "confidence": "low"
+        },
+        {
+          "line": 87,
+          "missing": "防改修",
+          "missing_len": 3,
+          "context": " **自主的に行える** ものに限る（国の道路・堤防改修等は除外）",
+          "confidence": "low"
+        },
+        {
+          "line": 87,
+          "missing": "改修等",
+          "missing_len": 3,
+          "context": "**自主的に行える** ものに限る（国の道路・堤防改修等は除外）",
+          "confidence": "low"
+        },
+        {
+          "line": 88,
+          "missing": "記述形",
+          "missing_len": 3,
+          "context": "- **記述形式**: 被害 A/B/C のラベル付け、対策は ",
+          "confidence": "low"
+        },
+        {
+          "line": 88,
+          "missing": "述形式",
+          "missing_len": 3,
+          "context": "- **記述形式**: 被害 A/B/C のラベル付け、対策は A",
+          "confidence": "low"
+        },
+        {
+          "line": 92,
+          "missing": "要求事",
+          "missing_len": 3,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "low"
+        },
+        {
+          "line": 92,
+          "missing": "求事項",
+          "missing_len": 3,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "low"
+        },
+        {
+          "line": 94,
+          "missing": "技術者",
+          "missing_len": 3,
+          "context": "| 立場 | 総合技術監理の技術者として |",
+          "confidence": "low"
+        },
+        {
+          "line": 96,
+          "missing": "情報管",
+          "missing_len": 3,
+          "context": "| 視点 | 経済性管理・人的資源管理・情報管理・安全管理・社会環境管理の 5 管理 |",
+          "confidence": "low"
+        },
+        {
+          "line": 101,
+          "missing": "評価項",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 101,
+          "missing": "価項目",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 101,
+          "missing": "着眼点",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 104,
+          "missing": "専門外",
+          "missing_len": 3,
+          "context": " 被害と対策が事業場にとって **特徴的** か、専門外の人にも分かりやすいか |",
+          "confidence": "low"
+        },
+        {
+          "line": 106,
+          "missing": "対策間",
+          "missing_len": 3,
+          "context": "| 論文全体のまとまり | 3 被害の対策間で整合性があり、優先順位の理由が妥当か |",
+          "confidence": "low"
+        },
+        {
+          "line": 106,
+          "missing": "整合性",
+          "missing_len": 3,
+          "context": "| 論文全体のまとまり | 3 被害の対策間で整合性があり、優先順位の理由が妥当か |",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "設計図",
+          "missing_len": 3,
+          "context": "**(1) 設計図として置くべき前提**（設問 (1) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "周辺環",
+          "missing_len": 3,
+          "context": "事業場を 1 つ選定し、立地・規模・機能・周辺環境を記述する。**後段の設問 (2) で取り上げる",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "辺環境",
+          "missing_len": 3,
+          "context": "事業場を 1 つ選定し、立地・規模・機能・周辺環境を記述する。**後段の設問 (2) で取り上げる被",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "業場特",
+          "missing_len": 3,
+          "context": "(2) で取り上げる被害 3 つが成立するような事業場特性** を意図的に置く（例: 海と河川に近い低地、",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "場特性",
+          "missing_len": 3,
+          "context": "2) で取り上げる被害 3 つが成立するような事業場特性** を意図的に置く（例: 海と河川に近い低地、線",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "意図的",
+          "missing_len": 3,
+          "context": "げる被害 3 つが成立するような事業場特性** を意図的に置く（例: 海と河川に近い低地、線路下の改札、地",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "線路下",
+          "missing_len": 3,
+          "context": "性** を意図的に置く（例: 海と河川に近い低地、線路下の改札、地下デッキ、沿岸部の強風環境など）。設定し",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "沿岸部",
+          "missing_len": 3,
+          "context": ": 海と河川に近い低地、線路下の改札、地下デッキ、沿岸部の強風環境など）。設定した事業場の特性が、選定する",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "強風環",
+          "missing_len": 3,
+          "context": "河川に近い低地、線路下の改札、地下デッキ、沿岸部の強風環境など）。設定した事業場の特性が、選定する自然現象",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "風環境",
+          "missing_len": 3,
+          "context": "川に近い低地、線路下の改札、地下デッキ、沿岸部の強風環境など）。設定した事業場の特性が、選定する自然現象（",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "地震等",
+          "missing_len": 3,
+          "context": "。設定した事業場の特性が、選定する自然現象（台風・地震等）による被害を必然化する構造を作る。",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "必然化",
+          "missing_len": 3,
+          "context": "性が、選定する自然現象（台風・地震等）による被害を必然化する構造を作る。",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "各被害",
+          "missing_len": 3,
+          "context": "自然現象により想定される主要な被害を 3 つ挙げ、各被害について:",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "実施可",
+          "missing_len": 3,
+          "context": "*A1, A2**（追加対策）: 事業場が自主的に実施可能で、近い将来に導入可能な対策",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "施可能",
+          "missing_len": 3,
+          "context": "A1, A2**（追加対策）: 事業場が自主的に実施可能で、近い将来に導入可能な対策",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "導入可",
+          "missing_len": 3,
+          "context": "加対策）: 事業場が自主的に実施可能で、近い将来に導入可能な対策",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "入可能",
+          "missing_len": 3,
+          "context": "対策）: 事業場が自主的に実施可能で、近い将来に導入可能な対策",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "非常用",
+          "missing_len": 3,
+          "context": "↔情報」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コス",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "常用電",
+          "missing_len": 3,
+          "context": "情報」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "用電源",
+          "missing_len": 3,
+          "context": "報」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "電源整",
+          "missing_len": 3,
+          "context": "」のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "源整備",
+          "missing_len": 3,
+          "context": "のトレードオフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "済性投",
+          "missing_len": 3,
+          "context": "オフが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "性投資",
+          "missing_len": 3,
+          "context": "フが見える形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "安全確",
+          "missing_len": 3,
+          "context": "る形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "全確保",
+          "missing_len": 3,
+          "context": "形で提示する。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "防風柵",
+          "missing_len": 3,
+          "context": "る。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "風柵整",
+          "missing_len": 3,
+          "context": "。例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔抜",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "柵整備",
+          "missing_len": 3,
+          "context": "例: 非常用電源整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔抜本",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "重要度",
+          "missing_len": 3,
+          "context": "整備（経済性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔抜本対策）。",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "設備改",
+          "missing_len": 3,
+          "context": "性投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔抜本対策）。",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "備改修",
+          "missing_len": 3,
+          "context": "投資↔安全確保）、防風柵整備（コスト↔重要度）、設備改修・移転（高コスト↔抜本対策）。",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "抜本対",
+          "missing_len": 3,
+          "context": "整備（コスト↔重要度）、設備改修・移転（高コスト↔抜本対策）。",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "本対策",
+          "missing_len": 3,
+          "context": "備（コスト↔重要度）、設備改修・移転（高コスト↔抜本対策）。",
+          "confidence": "low"
+        },
+        {
+          "line": 125,
+          "missing": "延長線",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応",
+          "confidence": "low"
+        },
+        {
+          "line": 125,
+          "missing": "長線上",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 125,
+          "missing": "将来展",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 125,
+          "missing": "来展望",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**（設問 (3) に対応）",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "被害規",
+          "missing_len": 3,
+          "context": "* を付けた実施計画を提示する。優先順位の根拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "害規模",
+          "missing_len": 3,
+          "context": " を付けた実施計画を提示する。優先順位の根拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経済",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "被害発",
+          "missing_len": 3,
+          "context": "を提示する。優先順位の根拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経済性」から組み立て、",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "害発生",
+          "missing_len": 3,
+          "context": "提示する。優先順位の根拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経済性」から組み立て、*",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "緊急性",
+          "missing_len": 3,
+          "context": "拠は「被害規模の大きさ」「被害発生可能性」「対応の緊急性」「経済性」から組み立て、**短期（0〜5 年）*",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "中長期",
+          "missing_len": 3,
+          "context": "から組み立て、**短期（0〜5 年）** と **中長期（5 年以上）** に切り分ける。これは設問 (3",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "年以上",
+          "missing_len": 3,
+          "context": "、**短期（0〜5 年）** と **中長期（5 年以上）** に切り分ける。これは設問 (3) が問う「",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "最適化",
+          "missing_len": 3,
+          "context": "リスクとその制御」に相当し、限られたリソース下での最適化（監理）を示す工程となる。",
+          "confidence": "low"
+        },
+        {
+          "line": 132,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テー",
+          "confidence": "low"
+        },
+        {
+          "line": 132,
+          "missing": "模範解",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テーマは「異",
+          "confidence": "low"
+        },
+        {
+          "line": 132,
+          "missing": "範解答",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テーマは「異常",
+          "confidence": "low"
+        },
+        {
+          "line": 132,
+          "missing": "解答例",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テーマは「異常な",
+          "confidence": "low"
+        },
+        {
+          "line": 132,
+          "missing": "選択科",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テーマは「異常な自然現象（",
+          "confidence": "low"
+        },
+        {
+          "line": 132,
+          "missing": "択科目",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例①。選択科目は**建設－鉄道**、テーマは「異常な自然現象（台",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "模範解",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマ",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "範解答",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "解答例",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは「",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "選択科",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは「地震災害に",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "択科目",
+          "missing_len": 3,
+          "context": "令和2年度（2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは「地震災害に対",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "上下水",
+          "missing_len": 3,
+          "context": "2020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは「地震災害に対する事前の備",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "下水道",
+          "missing_len": 3,
+          "context": "020年度）記述式の模範解答例②。選択科目は**上下水道－下水道**、テーマは「地震災害に対する事前の備え",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "地震災",
+          "missing_len": 3,
+          "context": "②。選択科目は**上下水道－下水道**、テーマは「地震災害に対する事前の備え」です。",
+          "confidence": "low"
+        },
+        {
+          "line": 252,
+          "missing": "震災害",
+          "missing_len": 3,
+          "context": "。選択科目は**上下水道－下水道**、テーマは「地震災害に対する事前の備え」です。",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R01",
+      "kind": "primary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R01/R01_試験問題_択一式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r01-primary/article.mdx",
+      "ocr_text_len": 19037,
+      "mdx_text_lines": 298,
+      "ocr_kanji_ngrams": 3860,
+      "mismatch_total": 248,
+      "mismatch_by_confidence": {
+        "high": 39,
+        "medium": 74,
+        "low": 135
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 29,
+          "missing": "平均故障間",
+          "missing_len": 5,
+          "context": "| M | 保全性 | 平均故障間隔 |",
+          "confidence": "high"
+        },
+        {
+          "line": 29,
+          "missing": "均故障間隔",
+          "missing_len": 5,
+          "context": "| M | 保全性 | 平均故障間隔 |",
+          "confidence": "high"
+        },
+        {
+          "line": 35,
+          "missing": "平均故障間",
+          "missing_len": 5,
+          "context": "4. ④ M - 保全性 - 平均故障間隔",
+          "confidence": "high"
+        },
+        {
+          "line": 35,
+          "missing": "均故障間隔",
+          "missing_len": 5,
+          "context": "4. ④ M - 保全性 - 平均故障間隔",
+          "confidence": "high"
+        },
+        {
+          "line": 209,
+          "missing": "営意思決定",
+          "missing_len": 5,
+          "context": "表の作成や、販売価格の算定、原価管理、利益管理、経営意思決定などのために用いられる。",
+          "confidence": "high"
+        },
+        {
+          "line": 210,
+          "missing": "費目別原価",
+          "missing_len": 5,
+          "context": "じめに製品別原価計算、次いで部門別原価計算、最後に費目別原価計算を行う。",
+          "confidence": "high"
+        },
+        {
+          "line": 210,
+          "missing": "目別原価計",
+          "missing_len": 5,
+          "context": "めに製品別原価計算、次いで部門別原価計算、最後に費目別原価計算を行う。",
+          "confidence": "high"
+        },
+        {
+          "line": 292,
+          "missing": "初期故障期",
+          "missing_len": 5,
+          "context": "1. A、B、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 292,
+          "missing": "期故障期間",
+          "missing_len": 5,
+          "context": "1. A、B、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 292,
+          "missing": "摩耗故障期",
+          "missing_len": 5,
+          "context": "、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 292,
+          "missing": "耗故障期間",
+          "missing_len": 5,
+          "context": "Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 292,
+          "missing": "偶発故障期",
+          "missing_len": 5,
+          "context": "、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 292,
+          "missing": "発故障期間",
+          "missing_len": 5,
+          "context": "時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "high"
+        },
+        {
+          "line": 397,
+          "missing": "不当労行為",
+          "missing_len": 5,
+          "context": "めの経費の支払いについき管理上の援助を与えることは不当労行為として禁止されているが、最小限の広さの組合事務所の",
+          "confidence": "high"
+        },
+        {
+          "line": 399,
+          "missing": "給争当事者",
+          "missing_len": 5,
+          "context": "5. 労働委員会が行うあっせんは、給争当事者双方の主張のとりなしや団体交渉のとりもちなどをあっ",
+          "confidence": "high"
+        },
+        {
+          "line": 399,
+          "missing": "争当事者双",
+          "missing_len": 5,
+          "context": "5. 労働委員会が行うあっせんは、給争当事者双方の主張のとりなしや団体交渉のとりもちなどをあっせ",
+          "confidence": "high"
+        },
+        {
+          "line": 399,
+          "missing": "当事者双方",
+          "missing_len": 5,
+          "context": "5. 労働委員会が行うあっせんは、給争当事者双方の主張のとりなしや団体交渉のとりもちなどをあっせん",
+          "confidence": "high"
+        },
+        {
+          "line": 466,
+          "missing": "具体的事実",
+          "missing_len": 5,
+          "context": "評価してしまいがちである。これを防ぐため、評価者は具体的事実や評価要素に沿った評価を行い、私的感情の除去努める",
+          "confidence": "high"
+        },
+        {
+          "line": 468,
+          "missing": "各評価項目",
+          "missing_len": 5,
+          "context": "4. 各評価項目について、評価者が自身で被評価者の業務を行ったとし",
+          "confidence": "high"
+        },
+        {
+          "line": 618,
+          "missing": "錯痕消費用",
+          "missing_len": 5,
+          "context": "1. 錯痕消費用の湿布薬に付けられた香りなどの、香り商標",
+          "confidence": "high"
+        },
+        {
+          "line": 848,
+          "missing": "暗号化強度",
+          "missing_len": 5,
+          "context": "ワークを行う際に、通信傍受を防ぐため、WPA2より暗号化強度が強い「WEPで保護」と表示されているアクセスポイ",
+          "confidence": "high"
+        },
+        {
+          "line": 849,
+          "missing": "標的型攻撃",
+          "missing_len": 5,
+          "context": "取りの内容と全く異なる不自然なメールが届いたため、標的型攻撃メールなどを疑い、添付ファイルは開かず、情報管理者",
+          "confidence": "high"
+        },
+        {
+          "line": 898,
+          "missing": "産性向上策",
+          "missing_len": 5,
+          "context": "**生産性向上策の事例**",
+          "confidence": "high"
+        },
+        {
+          "line": 945,
+          "missing": "心理的負担",
+          "missing_len": 5,
+          "context": "による疾病、過労死は労災補償の対象とされているが、心理的負担による精神障害などについては、因果関係の特定が因難",
+          "confidence": "high"
+        },
+        {
+          "line": 974,
+          "missing": "対象本部長",
+          "missing_len": 5,
+          "context": "どれか。法の名称には通常を含む。なお、以下における対象本部長、ある いは政府対策本部長は、通常は内閣総理大臣を",
+          "confidence": "high"
+        },
+        {
+          "line": 977,
+          "missing": "市町村長及",
+          "missing_len": 5,
+          "context": "置法：原子力規制委員会は、原子力緊急事態を宣言し、市町村長及び都道府県知事に対し、屋内への退避の勧告や指示を行",
+          "confidence": "high"
+        },
+        {
+          "line": 978,
+          "missing": "対象本部長",
+          "missing_len": 5,
+          "context": "3. 国民保護法：対象本部長は、武力攻撃から国民の生命、身体又は財産を保護する",
+          "confidence": "high"
+        },
+        {
+          "line": 979,
+          "missing": "等緊急事態",
+          "missing_len": 5,
+          "context": "策特別措置法：政府対策本部長は、新型インフルエンザ等緊急事態において、特定の都道府県の住民に対して、感染を防止",
+          "confidence": "high"
+        },
+        {
+          "line": 1047,
+          "missing": "衛生特別教",
+          "missing_len": 5,
+          "context": "ハーネス型」のものを用いて業務を行う労働者は、安全衛生特別教育が免除される。",
+          "confidence": "high"
+        },
+        {
+          "line": 1047,
+          "missing": "生特別教育",
+          "missing_len": 5,
+          "context": "ーネス型」のものを用いて業務を行う労働者は、安全衛生特別教育が免除される。",
+          "confidence": "high"
+        },
+        {
+          "line": 1202,
+          "missing": "各原因事象",
+          "missing_len": 5,
+          "context": "の記述のうち、必ずTが生起するものはどれか。なお、各原因事象間には特段の因果関係は無いものとする。",
+          "confidence": "high"
+        },
+        {
+          "line": 1202,
+          "missing": "原因事象間",
+          "missing_len": 5,
+          "context": "記述のうち、必ずTが生起するものはどれか。なお、各原因事象間には特段の因果関係は無いものとする。",
+          "confidence": "high"
+        },
+        {
+          "line": 1282,
+          "missing": "経済効率性",
+          "missing_len": 5,
+          "context": "、安全性を前提に、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、同",
+          "confidence": "high"
+        },
+        {
+          "line": 1348,
+          "missing": "検出下限値",
+          "missing_len": 5,
+          "context": "する県のうち福島県以外の県といい、放射性セシウムの検出下限値は、水質が1Bq/L、底質が10Bq/kgである。",
+          "confidence": "high"
+        },
+        {
+          "line": 1350,
+          "missing": "割程度完了",
+          "missing_len": 5,
+          "context": "難区域を除けば、当該計画に従う面的除染はおおむね7割程度完了している。",
+          "confidence": "high"
+        },
+        {
+          "line": 1388,
+          "missing": "未然防止原",
+          "missing_len": 5,
+          "context": "4. 未然防止原則とは、環境の保全は、環境上の支障が生じてからでは",
+          "confidence": "high"
+        },
+        {
+          "line": 1388,
+          "missing": "然防止原則",
+          "missing_len": 5,
+          "context": "4. 未然防止原則とは、環境の保全は、環境上の支障が生じてからではな",
+          "confidence": "high"
+        },
+        {
+          "line": 1454,
+          "missing": "年間排出量",
+          "missing_len": 5,
+          "context": "有害であるとして法令で定められたものについて、その年間排出量を国に報告するための任務をいう。",
+          "confidence": "high"
+        },
+        {
+          "line": 1489,
+          "missing": "対象期間全",
+          "missing_len": 5,
+          "context": "、環境基準の達成率が前年度を下回る年度があったが、対象期間全体では達成率は向上傾向を示し、平成28年度の達成率",
+          "confidence": "high"
+        },
+        {
+          "line": 29,
+          "missing": "平均故障",
+          "missing_len": 4,
+          "context": "| M | 保全性 | 平均故障間隔 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 29,
+          "missing": "均故障間",
+          "missing_len": 4,
+          "context": "| M | 保全性 | 平均故障間隔 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 29,
+          "missing": "故障間隔",
+          "missing_len": 4,
+          "context": "| M | 保全性 | 平均故障間隔 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 35,
+          "missing": "平均故障",
+          "missing_len": 4,
+          "context": "4. ④ M - 保全性 - 平均故障間隔",
+          "confidence": "medium"
+        },
+        {
+          "line": 35,
+          "missing": "均故障間",
+          "missing_len": 4,
+          "context": "4. ④ M - 保全性 - 平均故障間隔",
+          "confidence": "medium"
+        },
+        {
+          "line": 35,
+          "missing": "故障間隔",
+          "missing_len": 4,
+          "context": "4. ④ M - 保全性 - 平均故障間隔",
+          "confidence": "medium"
+        },
+        {
+          "line": 104,
+          "missing": "原因因上",
+          "missing_len": 4,
+          "context": "特性要因図を、原因が複雑に絡み合った問題に対して、原因因上の因果関係を整理するために用いる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 170,
+          "missing": "既去費用",
+          "missing_len": 4,
+          "context": "100万円で買い戻してもよえる。なお、設置費用及び既去費用は無料とする。",
+          "confidence": "medium"
+        },
+        {
+          "line": 210,
+          "missing": "費目別原",
+          "missing_len": 4,
+          "context": "じめに製品別原価計算、次いで部門別原価計算、最後に費目別原価計算を行う。",
+          "confidence": "medium"
+        },
+        {
+          "line": 210,
+          "missing": "目別原価",
+          "missing_len": 4,
+          "context": "めに製品別原価計算、次いで部門別原価計算、最後に費目別原価計算を行う。",
+          "confidence": "medium"
+        },
+        {
+          "line": 243,
+          "missing": "経常損益",
+          "missing_len": 4,
+          "context": "では、はじめに売上総利益を計算し、次いで営業損益、経常損益などを経て、当期純損益の順に損益が計算される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 292,
+          "missing": "初期故障",
+          "missing_len": 4,
+          "context": "1. A、B、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 292,
+          "missing": "期故障期",
+          "missing_len": 4,
+          "context": "1. A、B、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 292,
+          "missing": "故障期間",
+          "missing_len": 4,
+          "context": ". A、B、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 292,
+          "missing": "摩耗故障",
+          "missing_len": 4,
+          "context": "、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 292,
+          "missing": "耗故障期",
+          "missing_len": 4,
+          "context": "Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 292,
+          "missing": "偶発故障",
+          "missing_len": 4,
+          "context": "、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 292,
+          "missing": "発故障期",
+          "missing_len": 4,
+          "context": "時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 294,
+          "missing": "実働時間",
+          "missing_len": 4,
+          "context": "3. B期間では、設備の故障率はそれまでの実働時間にほとんど依存しない。",
+          "confidence": "medium"
+        },
+        {
+          "line": 295,
+          "missing": "材質変化",
+          "missing_len": 4,
+          "context": "化して、機械的な障損や疲労、化学的な腐食、経年的な材質変化などに起因する故障が生ずる。",
+          "confidence": "medium"
+        },
+        {
+          "line": 362,
+          "missing": "超過時間",
+          "missing_len": 4,
+          "context": "きで法律に規定され、違法反の有無は所定外労働時間の超過時間で判断される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 396,
+          "missing": "常時従業",
+          "missing_len": 4,
+          "context": "2. 1つの事業場の常時従業される同種の労働者の過半数が1つの労働協約の適用を",
+          "confidence": "medium"
+        },
+        {
+          "line": 397,
+          "missing": "不当労行",
+          "missing_len": 4,
+          "context": "めの経費の支払いについき管理上の援助を与えることは不当労行為として禁止されているが、最小限の広さの組合事務所",
+          "confidence": "medium"
+        },
+        {
+          "line": 397,
+          "missing": "当労行為",
+          "missing_len": 4,
+          "context": "の経費の支払いについき管理上の援助を与えることは不当労行為として禁止されているが、最小限の広さの組合事務所の",
+          "confidence": "medium"
+        },
+        {
+          "line": 399,
+          "missing": "給争当事",
+          "missing_len": 4,
+          "context": "5. 労働委員会が行うあっせんは、給争当事者双方の主張のとりなしや団体交渉のとりもちなどをあ",
+          "confidence": "medium"
+        },
+        {
+          "line": 399,
+          "missing": "当事者双",
+          "missing_len": 4,
+          "context": "5. 労働委員会が行うあっせんは、給争当事者双方の主張のとりなしや団体交渉のとりもちなどをあっせ",
+          "confidence": "medium"
+        },
+        {
+          "line": 399,
+          "missing": "事者双方",
+          "missing_len": 4,
+          "context": "5. 労働委員会が行うあっせんは、給争当事者双方の主張のとりなしや団体交渉のとりもちなどをあっせん",
+          "confidence": "medium"
+        },
+        {
+          "line": 432,
+          "missing": "人間関係",
+          "missing_len": 4,
+          "context": "ントの行為類型として、身体的な攻撃、精神的な攻撃、人間関係からの切り離し、過大な要求、過小な要求などがある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 466,
+          "missing": "具体的事",
+          "missing_len": 4,
+          "context": "評価してしまいがちである。これを防ぐため、評価者は具体的事実や評価要素に沿った評価を行い、私的感情の除去努め",
+          "confidence": "medium"
+        },
+        {
+          "line": 468,
+          "missing": "各評価項",
+          "missing_len": 4,
+          "context": "4. 各評価項目について、評価者が自身で被評価者の業務を行ったと",
+          "confidence": "medium"
+        },
+        {
+          "line": 616,
+          "missing": "出国家付",
+          "missing_len": 4,
+          "context": "平成27年4月1日より出国家付が開始された、新しい5タイプの商標に関する次の記述",
+          "confidence": "medium"
+        },
+        {
+          "line": 618,
+          "missing": "錯痕消費",
+          "missing_len": 4,
+          "context": "1. 錯痕消費用の湿布薬に付けられた香りなどの、香り商標",
+          "confidence": "medium"
+        },
+        {
+          "line": 618,
+          "missing": "痕消費用",
+          "missing_len": 4,
+          "context": "1. 錯痕消費用の湿布薬に付けられた香りなどの、香り商標",
+          "confidence": "medium"
+        },
+        {
+          "line": 622,
+          "missing": "位置商標",
+          "missing_len": 4,
+          "context": "トに付けるロゴが入った赤ラベルの取付け位置などの、位置商標",
+          "confidence": "medium"
+        },
+        {
+          "line": 652,
+          "missing": "累積人数",
+          "missing_len": 4,
+          "context": "| 得点 | 人数 | 累積人数 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 810,
+          "missing": "付加機能",
+          "missing_len": 4,
+          "context": "に加え、ファイルの版管理やアクセス権限の設定などの付加機能を持つものもある。",
+          "confidence": "medium"
+        },
+        {
+          "line": 848,
+          "missing": "公共無線",
+          "missing_len": 4,
+          "context": "4. 公共無線LANを用いてテレワークを行う際に、通信傍受を防ぐ",
+          "confidence": "medium"
+        },
+        {
+          "line": 848,
+          "missing": "暗号化強",
+          "missing_len": 4,
+          "context": "ワークを行う際に、通信傍受を防ぐため、WPA2より暗号化強度が強い「WEPで保護」と表示されているアクセスポ",
+          "confidence": "medium"
+        },
+        {
+          "line": 849,
+          "missing": "標的型攻",
+          "missing_len": 4,
+          "context": "取りの内容と全く異なる不自然なメールが届いたため、標的型攻撃メールなどを疑い、添付ファイルは開かず、情報管理",
+          "confidence": "medium"
+        },
+        {
+          "line": 849,
+          "missing": "的型攻撃",
+          "missing_len": 4,
+          "context": "りの内容と全く異なる不自然なメールが届いたため、標的型攻撃メールなどを疑い、添付ファイルは開かず、情報管理者",
+          "confidence": "medium"
+        },
+        {
+          "line": 898,
+          "missing": "性向上策",
+          "missing_len": 4,
+          "context": "**生産性向上策の事例**",
+          "confidence": "medium"
+        },
+        {
+          "line": 944,
+          "missing": "直接交付",
+          "missing_len": 4,
+          "context": "クを実施した事業者は、医師等から労働者の検査結果を直接交付し確認して適切な就労上の措置を講じた後に、労働者に",
+          "confidence": "medium"
+        },
+        {
+          "line": 945,
+          "missing": "理的負担",
+          "missing_len": 4,
+          "context": "よる疾病、過労死は労災補償の対象とされているが、心理的負担による精神障害などについては、因果関係の特定が因難",
+          "confidence": "medium"
+        },
+        {
+          "line": 974,
+          "missing": "対象本部",
+          "missing_len": 4,
+          "context": "どれか。法の名称には通常を含む。なお、以下における対象本部長、ある いは政府対策本部長は、通常は内閣総理大臣",
+          "confidence": "medium"
+        },
+        {
+          "line": 974,
+          "missing": "象本部長",
+          "missing_len": 4,
+          "context": "れか。法の名称には通常を含む。なお、以下における対象本部長、ある いは政府対策本部長は、通常は内閣総理大臣を",
+          "confidence": "medium"
+        },
+        {
+          "line": 977,
+          "missing": "町村長及",
+          "missing_len": 4,
+          "context": "法：原子力規制委員会は、原子力緊急事態を宣言し、市町村長及び都道府県知事に対し、屋内への退避の勧告や指示を行",
+          "confidence": "medium"
+        },
+        {
+          "line": 978,
+          "missing": "対象本部",
+          "missing_len": 4,
+          "context": "3. 国民保護法：対象本部長は、武力攻撃から国民の生命、身体又は財産を保護す",
+          "confidence": "medium"
+        },
+        {
+          "line": 978,
+          "missing": "象本部長",
+          "missing_len": 4,
+          "context": "3. 国民保護法：対象本部長は、武力攻撃から国民の生命、身体又は財産を保護する",
+          "confidence": "medium"
+        },
+        {
+          "line": 979,
+          "missing": "等緊急事",
+          "missing_len": 4,
+          "context": "策特別措置法：政府対策本部長は、新型インフルエンザ等緊急事態において、特定の都道府県の住民に対して、感染を防",
+          "confidence": "medium"
+        },
+        {
+          "line": 1014,
+          "missing": "警戒宣言",
+          "missing_len": 4,
+          "context": "度が高い地震の予測が可能となっていることを踏まえ、警戒宣言による地震発生前の避難や各種規制措置が、主たる対策",
+          "confidence": "medium"
+        },
+        {
+          "line": 1047,
+          "missing": "生特別教",
+          "missing_len": 4,
+          "context": "ーネス型」のものを用いて業務を行う労働者は、安全衛生特別教育が免除される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1047,
+          "missing": "特別教育",
+          "missing_len": 4,
+          "context": "ネス型」のものを用いて業務を行う労働者は、安全衛生特別教育が免除される。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1172,
+          "missing": "運転特性",
+          "missing_len": 4,
+          "context": "は、ガードや保護装置を使用しないで、機械の設計又は運転特性を変更することによって、危険源を除去する又は危険源",
+          "confidence": "medium"
+        },
+        {
+          "line": 1202,
+          "missing": "因事象間",
+          "missing_len": 4,
+          "context": "述のうち、必ずTが生起するものはどれか。なお、各原因事象間には特段の因果関係は無いものとする。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1282,
+          "missing": "経済効率",
+          "missing_len": 4,
+          "context": "、安全性を前提に、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、",
+          "confidence": "medium"
+        },
+        {
+          "line": 1282,
+          "missing": "済効率性",
+          "missing_len": 4,
+          "context": "安全性を前提に、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、同",
+          "confidence": "medium"
+        },
+        {
+          "line": 1284,
+          "missing": "相互参入",
+          "missing_len": 4,
+          "context": "る競争の活性化のためには、既存のエネルギー事業者の相互参入や異業種からの新規参入、さらに地域単位でエネルギー",
+          "confidence": "medium"
+        },
+        {
+          "line": 1284,
+          "missing": "備給管理",
+          "missing_len": 4,
+          "context": "や異業種からの新規参入、さらに地域単位でエネルギー備給管理サービスを行う自治体や非営利法人等がエネルギー供給",
+          "confidence": "medium"
+        },
+        {
+          "line": 1285,
+          "missing": "一般水力",
+          "missing_len": 4,
+          "context": "」、「ミドル電源」、「ピーク電源」に分類した場合、一般水力（流れ込み方式）、原子力、石油はベースロード電源の",
+          "confidence": "medium"
+        },
+        {
+          "line": 1348,
+          "missing": "検出下限",
+          "missing_len": 4,
+          "context": "する県のうち福島県以外の県といい、放射性セシウムの検出下限値は、水質が1Bq/L、底質が10Bq/kgである",
+          "confidence": "medium"
+        },
+        {
+          "line": 1348,
+          "missing": "出下限値",
+          "missing_len": 4,
+          "context": "る県のうち福島県以外の県といい、放射性セシウムの検出下限値は、水質が1Bq/L、底質が10Bq/kgである。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1350,
+          "missing": "除染実績",
+          "missing_len": 4,
+          "context": "1. 土壌等の除染は除染実績が進められてきており、帰還困難区域を除けば、当該計",
+          "confidence": "medium"
+        },
+        {
+          "line": 1350,
+          "missing": "程度完了",
+          "missing_len": 4,
+          "context": "区域を除けば、当該計画に従う面的除染はおおむね7割程度完了している。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1353,
+          "missing": "福島県内",
+          "missing_len": 4,
+          "context": "6年度のモニタリング結果において放射性セシウムは、福島県内では検出されているが、周辺県ではすべて不検出である",
+          "confidence": "medium"
+        },
+        {
+          "line": 1388,
+          "missing": "未然防止",
+          "missing_len": 4,
+          "context": "4. 未然防止原則とは、環境の保全は、環境上の支障が生じてからで",
+          "confidence": "medium"
+        },
+        {
+          "line": 1388,
+          "missing": "然防止原",
+          "missing_len": 4,
+          "context": "4. 未然防止原則とは、環境の保全は、環境上の支障が生じてからでは",
+          "confidence": "medium"
+        },
+        {
+          "line": 1388,
+          "missing": "防止原則",
+          "missing_len": 4,
+          "context": "4. 未然防止原則とは、環境の保全は、環境上の支障が生じてからではな",
+          "confidence": "medium"
+        },
+        {
+          "line": 1389,
+          "missing": "環境問題",
+          "missing_len": 4,
+          "context": "5. 予防的な取組方法とは、環境問題について科学的に不確実であることをもって対策を避ら",
+          "confidence": "medium"
+        },
+        {
+          "line": 1454,
+          "missing": "環境報告",
+          "missing_len": 4,
+          "context": "2. 環境報告とは、企業が事業活動に伴い排出した物質のうち有害で",
+          "confidence": "medium"
+        },
+        {
+          "line": 1454,
+          "missing": "年間排出",
+          "missing_len": 4,
+          "context": "有害であるとして法令で定められたものについて、その年間排出量を国に報告するための任務をいう。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1454,
+          "missing": "間排出量",
+          "missing_len": 4,
+          "context": "害であるとして法令で定められたものについて、その年間排出量を国に報告するための任務をいう。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1455,
+          "missing": "消費段階",
+          "missing_len": 4,
+          "context": "制度とは、一定規模以上の事業者が、商品やサービスの消費段階で排出される温室効果ガスのうち、二酸化炭素の量につ",
+          "confidence": "medium"
+        },
+        {
+          "line": 1456,
+          "missing": "遵法防止",
+          "missing_len": 4,
+          "context": "羅し、企業の事業活動におけるこれらの義務の手続きの遵法防止と確実な履行をサポートするためのシステムをいう。",
+          "confidence": "medium"
+        },
+        {
+          "line": 1485,
+          "missing": "大気汚染",
+          "missing_len": 4,
+          "context": "ものはどれか。なお、環境基準の達成状況については「大気汚染の状況 資料編」（平成26年度版、平成28年度版 ",
+          "confidence": "medium"
+        },
+        {
+          "line": 22,
+          "missing": "英単語",
+          "missing_len": 3,
+          "context": "尺度を表す用語にPQCDSMEがあり、これは7つの英単語の頭文字を並べたものである。次のうち、PQCDSM",
+          "confidence": "low"
+        },
+        {
+          "line": 22,
+          "missing": "意味及",
+          "missing_len": 3,
+          "context": "る。次のうち、PQCDSMEに含まれる頭文字とその意味及び管理指標の例の組合せとして最も適切なものはどれか",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "平均故",
+          "missing_len": 3,
+          "context": "| M | 保全性 | 平均故障間隔 |",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "均故障",
+          "missing_len": 3,
+          "context": "| M | 保全性 | 平均故障間隔 |",
+          "confidence": "low"
+        },
+        {
+          "line": 29,
+          "missing": "故障間",
+          "missing_len": 3,
+          "context": "| M | 保全性 | 平均故障間隔 |",
+          "confidence": "low"
+        },
+        {
+          "line": 35,
+          "missing": "平均故",
+          "missing_len": 3,
+          "context": "4. ④ M - 保全性 - 平均故障間隔",
+          "confidence": "low"
+        },
+        {
+          "line": 35,
+          "missing": "均故障",
+          "missing_len": 3,
+          "context": "4. ④ M - 保全性 - 平均故障間隔",
+          "confidence": "low"
+        },
+        {
+          "line": 35,
+          "missing": "故障間",
+          "missing_len": 3,
+          "context": "4. ④ M - 保全性 - 平均故障間隔",
+          "confidence": "low"
+        },
+        {
+          "line": 104,
+          "missing": "原因因",
+          "missing_len": 3,
+          "context": "特性要因図を、原因が複雑に絡み合った問題に対して、原因因上の因果関係を整理するために用いる。",
+          "confidence": "low"
+        },
+        {
+          "line": 104,
+          "missing": "因因上",
+          "missing_len": 3,
+          "context": "性要因図を、原因が複雑に絡み合った問題に対して、原因因上の因果関係を整理するために用いる。",
+          "confidence": "low"
+        },
+        {
+          "line": 170,
+          "missing": "残存額",
+          "missing_len": 3,
+          "context": "1年目の初めに1,000万円を支払い、5年目の末に残存額100万円で買い戻してもよえる。なお、設置費用及び",
+          "confidence": "low"
+        },
+        {
+          "line": 170,
+          "missing": "既去費",
+          "missing_len": 3,
+          "context": "100万円で買い戻してもよえる。なお、設置費用及び既去費用は無料とする。",
+          "confidence": "low"
+        },
+        {
+          "line": 210,
+          "missing": "費目別",
+          "missing_len": 3,
+          "context": "じめに製品別原価計算、次いで部門別原価計算、最後に費目別原価計算を行う。",
+          "confidence": "low"
+        },
+        {
+          "line": 210,
+          "missing": "目別原",
+          "missing_len": 3,
+          "context": "めに製品別原価計算、次いで部門別原価計算、最後に費目別原価計算を行う。",
+          "confidence": "low"
+        },
+        {
+          "line": 242,
+          "missing": "貸定式",
+          "missing_len": 3,
+          "context": "1. 貸借対照表（貸定式）では、左側に資産の部、右側に負債の部と純資産の部",
+          "confidence": "low"
+        },
+        {
+          "line": 243,
+          "missing": "常損益",
+          "missing_len": 3,
+          "context": "は、はじめに売上総利益を計算し、次いで営業損益、経常損益などを経て、当期純損益の順に損益が計算される。",
+          "confidence": "low"
+        },
+        {
+          "line": 245,
+          "missing": "貸定式",
+          "missing_len": 3,
+          "context": "4. 貸借対照表（貸定式）における流動資産の総額は、同期のキャッシュ・フロ",
+          "confidence": "low"
+        },
+        {
+          "line": 276,
+          "missing": "故障率",
+          "missing_len": 3,
+          "context": "設備の運転時間の経過に対する故障率の推移の特徴を概念的に示す下図のバスタブカーブに関",
+          "confidence": "low"
+        },
+        {
+          "line": 292,
+          "missing": "初期故",
+          "missing_len": 3,
+          "context": "1. A、B、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 292,
+          "missing": "期故障",
+          "missing_len": 3,
+          "context": "1. A、B、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 292,
+          "missing": "故障期",
+          "missing_len": 3,
+          "context": ". A、B、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 292,
+          "missing": "摩耗故",
+          "missing_len": 3,
+          "context": "、Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 292,
+          "missing": "耗故障",
+          "missing_len": 3,
+          "context": "Cの各期間は、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 292,
+          "missing": "偶発故",
+          "missing_len": 3,
+          "context": "、時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 292,
+          "missing": "発故障",
+          "missing_len": 3,
+          "context": "時間経過順にそれぞれ初期故障期間、摩耗故障期間、偶発故障期間と呼ばれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 294,
+          "missing": "故障率",
+          "missing_len": 3,
+          "context": "3. B期間では、設備の故障率はそれまでの実働時間にほとんど依存しない。",
+          "confidence": "low"
+        },
+        {
+          "line": 294,
+          "missing": "実働時",
+          "missing_len": 3,
+          "context": "3. B期間では、設備の故障率はそれまでの実働時間にほとんど依存しない。",
+          "confidence": "low"
+        },
+        {
+          "line": 295,
+          "missing": "材質変",
+          "missing_len": 3,
+          "context": "化して、機械的な障損や疲労、化学的な腐食、経年的な材質変化などに起因する故障が生ずる。",
+          "confidence": "low"
+        },
+        {
+          "line": 295,
+          "missing": "質変化",
+          "missing_len": 3,
+          "context": "して、機械的な障損や疲労、化学的な腐食、経年的な材質変化などに起因する故障が生ずる。",
+          "confidence": "low"
+        },
+        {
+          "line": 296,
+          "missing": "故障率",
+          "missing_len": 3,
+          "context": "5. C期間では、予防保全や改良保全により、故障率の増大傾向を減少させることが有効である。",
+          "confidence": "low"
+        },
+        {
+          "line": 325,
+          "missing": "相当性",
+          "missing_len": 3,
+          "context": "受ける不利益の程度、労働条件の変更の必要性、内容の相当性、労働組合等との交渉の状況が合理的であるある必要が",
+          "confidence": "low"
+        },
+        {
+          "line": 362,
+          "missing": "原則付",
+          "missing_len": 3,
+          "context": "1. 時間外労働の上限が原則付きで法律に規定され、違法反の有無は所定外労働時間の",
+          "confidence": "low"
+        },
+        {
+          "line": 362,
+          "missing": "違法反",
+          "missing_len": 3,
+          "context": "1. 時間外労働の上限が原則付きで法律に規定され、違法反の有無は所定外労働時間の超過時間で判断される。",
+          "confidence": "low"
+        },
+        {
+          "line": 362,
+          "missing": "超過時",
+          "missing_len": 3,
+          "context": "きで法律に規定され、違法反の有無は所定外労働時間の超過時間で判断される。",
+          "confidence": "low"
+        },
+        {
+          "line": 364,
+          "missing": "各種的",
+          "missing_len": 3,
+          "context": "タイムカードによる記録、PC等の使用時間の記録等の各種的な方法や使用者による現認が原則となっている。",
+          "confidence": "low"
+        },
+        {
+          "line": 396,
+          "missing": "常時従",
+          "missing_len": 3,
+          "context": "2. 1つの事業場の常時従業される同種の労働者の過半数が1つの労働協約の適用",
+          "confidence": "low"
+        },
+        {
+          "line": 396,
+          "missing": "時従業",
+          "missing_len": 3,
+          "context": "2. 1つの事業場の常時従業される同種の労働者の過半数が1つの労働協約の適用を",
+          "confidence": "low"
+        },
+        {
+          "line": 397,
+          "missing": "当労行",
+          "missing_len": 3,
+          "context": "の経費の支払いについき管理上の援助を与えることは不当労行為として禁止されているが、最小限の広さの組合事務所",
+          "confidence": "low"
+        },
+        {
+          "line": 397,
+          "missing": "労行為",
+          "missing_len": 3,
+          "context": "経費の支払いについき管理上の援助を与えることは不当労行為として禁止されているが、最小限の広さの組合事務所の",
+          "confidence": "low"
+        },
+        {
+          "line": 399,
+          "missing": "給争当",
+          "missing_len": 3,
+          "context": "5. 労働委員会が行うあっせんは、給争当事者双方の主張のとりなしや団体交渉のとりもちなどを",
+          "confidence": "low"
+        },
+        {
+          "line": 399,
+          "missing": "事者双",
+          "missing_len": 3,
+          "context": "5. 労働委員会が行うあっせんは、給争当事者双方の主張のとりなしや団体交渉のとりもちなどをあっせ",
+          "confidence": "low"
+        },
+        {
+          "line": 399,
+          "missing": "者双方",
+          "missing_len": 3,
+          "context": "5. 労働委員会が行うあっせんは、給争当事者双方の主張のとりなしや団体交渉のとりもちなどをあっせん",
+          "confidence": "low"
+        },
+        {
+          "line": 430,
+          "missing": "後輩間",
+          "missing_len": 3,
+          "context": "には、上司から部下に行われるものだけでなく、先輩・後輩間などの様々な優位性を背景に行われるものも含まれる。",
+          "confidence": "low"
+        },
+        {
+          "line": 432,
+          "missing": "間関係",
+          "missing_len": 3,
+          "context": "トの行為類型として、身体的な攻撃、精神的な攻撃、人間関係からの切り離し、過大な要求、過小な要求などがある。",
+          "confidence": "low"
+        },
+        {
+          "line": 466,
+          "missing": "具体的",
+          "missing_len": 3,
+          "context": "評価してしまいがちである。これを防ぐため、評価者は具体的事実や評価要素に沿った評価を行い、私的感情の除去努",
+          "confidence": "low"
+        },
+        {
+          "line": 466,
+          "missing": "除去努",
+          "missing_len": 3,
+          "context": "具体的事実や評価要素に沿った評価を行い、私的感情の除去努めること等が重要である。",
+          "confidence": "low"
+        },
+        {
+          "line": 468,
+          "missing": "各評価",
+          "missing_len": 3,
+          "context": "4. 各評価項目について、評価者が自身で被評価者の業務を行った",
+          "confidence": "low"
+        },
+        {
+          "line": 469,
+          "missing": "顧客等",
+          "missing_len": 3,
+          "context": "けでなく同僚、後輩、一緒に仕事をした他部門の社員、顧客等からの評価を考慮することでもあり、評価誤差の低減に",
+          "confidence": "low"
+        },
+        {
+          "line": 616,
+          "missing": "出国家",
+          "missing_len": 3,
+          "context": "平成27年4月1日より出国家付が開始された、新しい5タイプの商標に関する次の記",
+          "confidence": "low"
+        },
+        {
+          "line": 616,
+          "missing": "国家付",
+          "missing_len": 3,
+          "context": "平成27年4月1日より出国家付が開始された、新しい5タイプの商標に関する次の記述",
+          "confidence": "low"
+        },
+        {
+          "line": 618,
+          "missing": "錯痕消",
+          "missing_len": 3,
+          "context": "1. 錯痕消費用の湿布薬に付けられた香りなどの、香り商標",
+          "confidence": "low"
+        },
+        {
+          "line": 618,
+          "missing": "痕消費",
+          "missing_len": 3,
+          "context": "1. 錯痕消費用の湿布薬に付けられた香りなどの、香り商標",
+          "confidence": "low"
+        },
+        {
+          "line": 618,
+          "missing": "消費用",
+          "missing_len": 3,
+          "context": "1. 錯痕消費用の湿布薬に付けられた香りなどの、香り商標",
+          "confidence": "low"
+        },
+        {
+          "line": 622,
+          "missing": "置商標",
+          "missing_len": 3,
+          "context": "に付けるロゴが入った赤ラベルの取付け位置などの、位置商標",
+          "confidence": "low"
+        },
+        {
+          "line": 652,
+          "missing": "累積人",
+          "missing_len": 3,
+          "context": "| 得点 | 人数 | 累積人数 |",
+          "confidence": "low"
+        },
+        {
+          "line": 652,
+          "missing": "積人数",
+          "missing_len": 3,
+          "context": "| 得点 | 人数 | 累積人数 |",
+          "confidence": "low"
+        },
+        {
+          "line": 654,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 0点以上9点以下 | 2 | 2 |",
+          "confidence": "low"
+        },
+        {
+          "line": 654,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 0点以上9点以下 | 2 | 2 |",
+          "confidence": "low"
+        },
+        {
+          "line": 655,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 10点以上19点以下 | 7 | 9 |",
+          "confidence": "low"
+        },
+        {
+          "line": 655,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 10点以上19点以下 | 7 | 9 |",
+          "confidence": "low"
+        },
+        {
+          "line": 656,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 20点以上29点以下 | 9 | 18 |",
+          "confidence": "low"
+        },
+        {
+          "line": 656,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 20点以上29点以下 | 9 | 18 |",
+          "confidence": "low"
+        },
+        {
+          "line": 657,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 30点以上39点以下 | 10 | 28 |",
+          "confidence": "low"
+        },
+        {
+          "line": 657,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 30点以上39点以下 | 10 | 28 |",
+          "confidence": "low"
+        },
+        {
+          "line": 658,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 40点以上49点以下 | 13 | 41 |",
+          "confidence": "low"
+        },
+        {
+          "line": 658,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 40点以上49点以下 | 13 | 41 |",
+          "confidence": "low"
+        },
+        {
+          "line": 659,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 50点以上59点以下 | 14 | 55 |",
+          "confidence": "low"
+        },
+        {
+          "line": 659,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 50点以上59点以下 | 14 | 55 |",
+          "confidence": "low"
+        },
+        {
+          "line": 660,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 60点以上69点以下 | 19 | 74 |",
+          "confidence": "low"
+        },
+        {
+          "line": 660,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 60点以上69点以下 | 19 | 74 |",
+          "confidence": "low"
+        },
+        {
+          "line": 661,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 70点以上79点以下 | 21 | 95 |",
+          "confidence": "low"
+        },
+        {
+          "line": 661,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 70点以上79点以下 | 21 | 95 |",
+          "confidence": "low"
+        },
+        {
+          "line": 662,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 80点以上89点以下 | 51 | 146 |",
+          "confidence": "low"
+        },
+        {
+          "line": 662,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 80点以上89点以下 | 51 | 146 |",
+          "confidence": "low"
+        },
+        {
+          "line": 663,
+          "missing": "点以上",
+          "missing_len": 3,
+          "context": "| 90点以上100点以下 | 4 | 150 |",
+          "confidence": "low"
+        },
+        {
+          "line": 663,
+          "missing": "点以下",
+          "missing_len": 3,
+          "context": "| 90点以上100点以下 | 4 | 150 |",
+          "confidence": "low"
+        },
+        {
+          "line": 697,
+          "missing": "事業的",
+          "missing_len": 3,
+          "context": "wsのように、市場で多くの人に受け入れられることで事業的に標準となったものである。",
+          "confidence": "low"
+        },
+        {
+          "line": 699,
+          "missing": "自発的",
+          "missing_len": 3,
+          "context": "、ある特定の標準の策定に関心のある複数の企業などが自発的に集まって結成したフォーラムと呼ばれる組織の合意に",
+          "confidence": "low"
+        },
+        {
+          "line": 810,
+          "missing": "加機能",
+          "missing_len": 3,
+          "context": "加え、ファイルの版管理やアクセス権限の設定などの付加機能を持つものもある。",
+          "confidence": "low"
+        },
+        {
+          "line": 813,
+          "missing": "参加間",
+          "missing_len": 3,
+          "context": "連絡や情報共有のためだけでなく、業務とは切り離した参加間の交流の促進のためにも利用されることがある。",
+          "confidence": "low"
+        },
+        {
+          "line": 848,
+          "missing": "公共無",
+          "missing_len": 3,
+          "context": "4. 公共無線LANを用いてテレワークを行う際に、通信傍受を防",
+          "confidence": "low"
+        },
+        {
+          "line": 848,
+          "missing": "共無線",
+          "missing_len": 3,
+          "context": "4. 公共無線LANを用いてテレワークを行う際に、通信傍受を防ぐ",
+          "confidence": "low"
+        },
+        {
+          "line": 848,
+          "missing": "暗号化",
+          "missing_len": 3,
+          "context": "ワークを行う際に、通信傍受を防ぐため、WPA2より暗号化強度が強い「WEPで保護」と表示されているアクセス",
+          "confidence": "low"
+        },
+        {
+          "line": 849,
+          "missing": "委託先",
+          "missing_len": 3,
+          "context": "5. 委託先から最近のやり取りの内容と全く異なる不自然なメール",
+          "confidence": "low"
+        },
+        {
+          "line": 849,
+          "missing": "的型攻",
+          "missing_len": 3,
+          "context": "りの内容と全く異なる不自然なメールが届いたため、標的型攻撃メールなどを疑い、添付ファイルは開かず、情報管理",
+          "confidence": "low"
+        },
+        {
+          "line": 849,
+          "missing": "型攻撃",
+          "missing_len": 3,
+          "context": "の内容と全く異なる不自然なメールが届いたため、標的型攻撃メールなどを疑い、添付ファイルは開かず、情報管理者",
+          "confidence": "low"
+        },
+        {
+          "line": 898,
+          "missing": "向上策",
+          "missing_len": 3,
+          "context": "**生産性向上策の事例**",
+          "confidence": "low"
+        },
+        {
+          "line": 906,
+          "missing": "自動化",
+          "missing_len": 3,
+          "context": "影し、その映像や測量データに基づき設計をAIにより自動化することで、測量と設計・施工計画の業務を一体化する",
+          "confidence": "low"
+        },
+        {
+          "line": 944,
+          "missing": "直接交",
+          "missing_len": 3,
+          "context": "クを実施した事業者は、医師等から労働者の検査結果を直接交付し確認して適切な就労上の措置を講じた後に、労働者",
+          "confidence": "low"
+        },
+        {
+          "line": 944,
+          "missing": "接交付",
+          "missing_len": 3,
+          "context": "を実施した事業者は、医師等から労働者の検査結果を直接交付し確認して適切な就労上の措置を講じた後に、労働者に",
+          "confidence": "low"
+        },
+        {
+          "line": 945,
+          "missing": "的負担",
+          "missing_len": 3,
+          "context": "る疾病、過労死は労災補償の対象とされているが、心理的負担による精神障害などについては、因果関係の特定が因難",
+          "confidence": "low"
+        },
+        {
+          "line": 974,
+          "missing": "諸法律",
+          "missing_len": 3,
+          "context": "危機管理に関する諸法律における避難等に関する次の記述のうち、最も適切なも",
+          "confidence": "low"
+        },
+        {
+          "line": 974,
+          "missing": "対象本",
+          "missing_len": 3,
+          "context": "どれか。法の名称には通常を含む。なお、以下における対象本部長、ある いは政府対策本部長は、通常は内閣総理大",
+          "confidence": "low"
+        },
+        {
+          "line": 974,
+          "missing": "象本部",
+          "missing_len": 3,
+          "context": "れか。法の名称には通常を含む。なお、以下における対象本部長、ある いは政府対策本部長は、通常は内閣総理大臣",
+          "confidence": "low"
+        },
+        {
+          "line": 977,
+          "missing": "村長及",
+          "missing_len": 3,
+          "context": "：原子力規制委員会は、原子力緊急事態を宣言し、市町村長及び都道府県知事に対し、屋内への退避の勧告や指示を行",
+          "confidence": "low"
+        },
+        {
+          "line": 978,
+          "missing": "対象本",
+          "missing_len": 3,
+          "context": "3. 国民保護法：対象本部長は、武力攻撃から国民の生命、身体又は財産を保護",
+          "confidence": "low"
+        },
+        {
+          "line": 978,
+          "missing": "象本部",
+          "missing_len": 3,
+          "context": "3. 国民保護法：対象本部長は、武力攻撃から国民の生命、身体又は財産を保護す",
+          "confidence": "low"
+        },
+        {
+          "line": 979,
+          "missing": "等緊急",
+          "missing_len": 3,
+          "context": "策特別措置法：政府対策本部長は、新型インフルエンザ等緊急事態において、特定の都道府県の住民に対して、感染を",
+          "confidence": "low"
+        },
+        {
+          "line": 980,
+          "missing": "高潮及",
+          "missing_len": 3,
+          "context": "場合には、気象庁の報告に基づき、気象、地象、津波、高潮及び波浪についての特別警報を発する。",
+          "confidence": "low"
+        },
+        {
+          "line": 1014,
+          "missing": "警戒宣",
+          "missing_len": 3,
+          "context": "度が高い地震の予測が可能となっていることを踏まえ、警戒宣言による地震発生前の避難や各種規制措置が、主たる対",
+          "confidence": "low"
+        },
+        {
+          "line": 1014,
+          "missing": "戒宣言",
+          "missing_len": 3,
+          "context": "が高い地震の予測が可能となっていることを踏まえ、警戒宣言による地震発生前の避難や各種規制措置が、主たる対策",
+          "confidence": "low"
+        },
+        {
+          "line": 1047,
+          "missing": "特別教",
+          "missing_len": 3,
+          "context": "ネス型」のものを用いて業務を行う労働者は、安全衛生特別教育が免除される。",
+          "confidence": "low"
+        },
+        {
+          "line": 1047,
+          "missing": "別教育",
+          "missing_len": 3,
+          "context": "ス型」のものを用いて業務を行う労働者は、安全衛生特別教育が免除される。",
+          "confidence": "low"
+        },
+        {
+          "line": 1135,
+          "missing": "維続的",
+          "missing_len": 3,
+          "context": "、及びステークホルダーとの対話を行うために、組織が維続的に及び繰り返し行うプロセスである。",
+          "confidence": "low"
+        },
+        {
+          "line": 1168,
+          "missing": "故障等",
+          "missing_len": 3,
+          "context": "を犯す人間要因）、Machine（機械設備の欠陥・故障等の物的要因）、Media（作業情報、作業方法、環境",
+          "confidence": "low"
+        },
+        {
+          "line": 1172,
+          "missing": "運転特",
+          "missing_len": 3,
+          "context": "は、ガードや保護装置を使用しないで、機械の設計又は運転特性を変更することによって、危険源を除去する又は危険",
+          "confidence": "low"
+        },
+        {
+          "line": 1172,
+          "missing": "転特性",
+          "missing_len": 3,
+          "context": "、ガードや保護装置を使用しないで、機械の設計又は運転特性を変更することによって、危険源を除去する又は危険源",
+          "confidence": "low"
+        },
+        {
+          "line": 1202,
+          "missing": "事象間",
+          "missing_len": 3,
+          "context": "のうち、必ずTが生起するものはどれか。なお、各原因事象間には特段の因果関係は無いものとする。",
+          "confidence": "low"
+        },
+        {
+          "line": 1282,
+          "missing": "済効率",
+          "missing_len": 3,
+          "context": "安全性を前提に、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、",
+          "confidence": "low"
+        },
+        {
+          "line": 1282,
+          "missing": "効率性",
+          "missing_len": 3,
+          "context": "全性を前提に、エネルギーの安定供給を第一とし、経済効率性の向上による低コストでのエネルギー供給を実現し、同",
+          "confidence": "low"
+        },
+        {
+          "line": 1283,
+          "missing": "多層的",
+          "missing_len": 3,
+          "context": "ギー源によって適切に補完されるような組合せを持つ、多層的な供給構造を実現することが必要である。",
+          "confidence": "low"
+        },
+        {
+          "line": 1284,
+          "missing": "互参入",
+          "missing_len": 3,
+          "context": "競争の活性化のためには、既存のエネルギー事業者の相互参入や異業種からの新規参入、さらに地域単位でエネルギー",
+          "confidence": "low"
+        },
+        {
+          "line": 1284,
+          "missing": "備給管",
+          "missing_len": 3,
+          "context": "や異業種からの新規参入、さらに地域単位でエネルギー備給管理サービスを行う自治体や非営利法人等がエネルギー供",
+          "confidence": "low"
+        },
+        {
+          "line": 1285,
+          "missing": "般水力",
+          "missing_len": 3,
+          "context": "、「ミドル電源」、「ピーク電源」に分類した場合、一般水力（流れ込み方式）、原子力、石油はベースロード電源の",
+          "confidence": "low"
+        },
+        {
+          "line": 1286,
+          "missing": "中心的",
+          "missing_len": 3,
+          "context": "ことから、将来の二次エネルギーで、電気、熱に加え、中心的な役割を担うことが期待される。",
+          "confidence": "low"
+        },
+        {
+          "line": 1348,
+          "missing": "水質及",
+          "missing_len": 3,
+          "context": "最も適切なものはどれか。なお、以下において、湖沼の水質及び底質については、環境省が実施している水環境に関す",
+          "confidence": "low"
+        },
+        {
+          "line": 1348,
+          "missing": "検出下",
+          "missing_len": 3,
+          "context": "する県のうち福島県以外の県といい、放射性セシウムの検出下限値は、水質が1Bq/L、底質が10Bq/kgであ",
+          "confidence": "low"
+        },
+        {
+          "line": 1348,
+          "missing": "出下限",
+          "missing_len": 3,
+          "context": "る県のうち福島県以外の県といい、放射性セシウムの検出下限値は、水質が1Bq/L、底質が10Bq/kgである",
+          "confidence": "low"
+        },
+        {
+          "line": 1350,
+          "missing": "染実績",
+          "missing_len": 3,
+          "context": "1. 土壌等の除染は除染実績が進められてきており、帰還困難区域を除けば、当該計",
+          "confidence": "low"
+        },
+        {
+          "line": 1350,
+          "missing": "度完了",
+          "missing_len": 3,
+          "context": "域を除けば、当該計画に従う面的除染はおおむね7割程度完了している。",
+          "confidence": "low"
+        },
+        {
+          "line": 1386,
+          "missing": "各段階",
+          "missing_len": 3,
+          "context": "主体が政策を行う場合には、政策の企画、立案、実行の各段階において、政策に関する民間の各主体の参加を得て行わ",
+          "confidence": "low"
+        },
+        {
+          "line": 1387,
+          "missing": "広域的",
+          "missing_len": 3,
+          "context": "3. 補完性原則とは、環境施策の処理はできる限り広域的な行政単位が担い、それにならじまない事情に関わって",
+          "confidence": "low"
+        },
+        {
+          "line": 1388,
+          "missing": "然防止",
+          "missing_len": 3,
+          "context": "4. 未然防止原則とは、環境の保全は、環境上の支障が生じてからで",
+          "confidence": "low"
+        },
+        {
+          "line": 1388,
+          "missing": "防止原",
+          "missing_len": 3,
+          "context": "4. 未然防止原則とは、環境の保全は、環境上の支障が生じてからでは",
+          "confidence": "low"
+        },
+        {
+          "line": 1388,
+          "missing": "止原則",
+          "missing_len": 3,
+          "context": "4. 未然防止原則とは、環境の保全は、環境上の支障が生じてからではな",
+          "confidence": "low"
+        },
+        {
+          "line": 1389,
+          "missing": "環境問",
+          "missing_len": 3,
+          "context": "5. 予防的な取組方法とは、環境問題について科学的に不確実であることをもって対策を避",
+          "confidence": "low"
+        },
+        {
+          "line": 1389,
+          "missing": "境問題",
+          "missing_len": 3,
+          "context": "5. 予防的な取組方法とは、環境問題について科学的に不確実であることをもって対策を避ら",
+          "confidence": "low"
+        },
+        {
+          "line": 1454,
+          "missing": "環境報",
+          "missing_len": 3,
+          "context": "2. 環境報告とは、企業が事業活動に伴い排出した物質のうち有害",
+          "confidence": "low"
+        },
+        {
+          "line": 1454,
+          "missing": "年間排",
+          "missing_len": 3,
+          "context": "有害であるとして法令で定められたものについて、その年間排出量を国に報告するための任務をいう。",
+          "confidence": "low"
+        },
+        {
+          "line": 1454,
+          "missing": "間排出",
+          "missing_len": 3,
+          "context": "害であるとして法令で定められたものについて、その年間排出量を国に報告するための任務をいう。",
+          "confidence": "low"
+        },
+        {
+          "line": 1455,
+          "missing": "消費段",
+          "missing_len": 3,
+          "context": "制度とは、一定規模以上の事業者が、商品やサービスの消費段階で排出される温室効果ガスのうち、二酸化炭素の量に",
+          "confidence": "low"
+        },
+        {
+          "line": 1455,
+          "missing": "費段階",
+          "missing_len": 3,
+          "context": "度とは、一定規模以上の事業者が、商品やサービスの消費段階で排出される温室効果ガスのうち、二酸化炭素の量につ",
+          "confidence": "low"
+        },
+        {
+          "line": 1456,
+          "missing": "遵法防",
+          "missing_len": 3,
+          "context": "羅し、企業の事業活動におけるこれらの義務の手続きの遵法防止と確実な履行をサポートするためのシステムをいう。",
+          "confidence": "low"
+        },
+        {
+          "line": 1456,
+          "missing": "法防止",
+          "missing_len": 3,
+          "context": "し、企業の事業活動におけるこれらの義務の手続きの遵法防止と確実な履行をサポートするためのシステムをいう。",
+          "confidence": "low"
+        },
+        {
+          "line": 1485,
+          "missing": "気汚染",
+          "missing_len": 3,
+          "context": "のはどれか。なお、環境基準の達成状況については「大気汚染の状況 資料編」（平成26年度版、平成28年度版 ",
+          "confidence": "low"
+        }
+      ]
+    },
+    {
+      "year": "R01",
+      "kind": "secondary",
+      "pdf": "docs/textbook/技術士（総監）/過去問/R01/R01_試験問題_記述式.pdf",
+      "mdx": ".local/r2/posts/pe-comprehensive-management/r01-secondary/article.mdx",
+      "ocr_text_len": 2019,
+      "mdx_text_lines": 58,
+      "ocr_kanji_ngrams": 359,
+      "mismatch_total": 257,
+      "mismatch_by_confidence": {
+        "high": 20,
+        "medium": 76,
+        "low": 161
+      },
+      "ocr_figure_captions": [],
+      "ocr_figure_caption_count": 0,
+      "candidates": [
+        {
+          "line": 20,
+          "missing": "総監記述式",
+          "missing_len": 5,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）** ",
+          "confidence": "high"
+        },
+        {
+          "line": 20,
+          "missing": "作問委員任",
+          "missing_len": 5,
+          "context": "降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは",
+          "confidence": "high"
+        },
+        {
+          "line": 20,
+          "missing": "問委員任期",
+          "missing_len": 5,
+          "context": "の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは ",
+          "confidence": "high"
+        },
+        {
+          "line": 76,
+          "missing": "記述式試験",
+          "missing_len": 5,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年度",
+          "confidence": "high"
+        },
+        {
+          "line": 76,
+          "missing": "模範論文例",
+          "missing_len": 5,
+          "context": "「三層構造」を、令和元年度の問題文に当てはめた例。模範論文例を読む前に、**(1) → (2) がどう因果でつ",
+          "confidence": "high"
+        },
+        {
+          "line": 104,
+          "missing": "再発防止策",
+          "missing_len": 5,
+          "context": " | ヒューマンエラー事例が具体的か、原因・対応・再発防止策が区別されているか |",
+          "confidence": "high"
+        },
+        {
+          "line": 114,
+          "missing": "再発防止策",
+          "missing_len": 5,
+          "context": "例は「内容・影響 → 原因 → 取られた対応 → 再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・",
+          "confidence": "high"
+        },
+        {
+          "line": 114,
+          "missing": "暗黙知依存",
+          "missing_len": 5,
+          "context": "」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示",
+          "confidence": "high"
+        },
+        {
+          "line": 114,
+          "missing": "列車運行下",
+          "missing_len": 5,
+          "context": "事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段で提示する施",
+          "confidence": "high"
+        },
+        {
+          "line": 121,
+          "missing": "空間的制約",
+          "missing_len": 5,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "high"
+        },
+        {
+          "line": 122,
+          "missing": "議事録共有",
+          "missing_len": 5,
+          "context": "- チェックリスト・5W1H の徹底・議事録共有 → 情報管理による経路の明確化",
+          "confidence": "high"
+        },
+        {
+          "line": 123,
+          "missing": "熟練者不足",
+          "missing_len": 5,
+          "context": " ナレッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "high"
+        },
+        {
+          "line": 125,
+          "missing": "信頼性担保",
+          "missing_len": 5,
+          "context": "向けた課題や障害（導入コスト・教育負荷・システムの信頼性担保）を必ずセットで記述する。",
+          "confidence": "high"
+        },
+        {
+          "line": 129,
+          "missing": "経験的要素",
+          "missing_len": 5,
+          "context": "するリスク（ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜",
+          "confidence": "high"
+        },
+        {
+          "line": 129,
+          "missing": "代替手段喪",
+          "missing_len": 5,
+          "context": "ル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象として示す。",
+          "confidence": "high"
+        },
+        {
+          "line": 129,
+          "missing": "替手段喪失",
+          "missing_len": 5,
+          "context": "空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象として示す。",
+          "confidence": "high"
+        },
+        {
+          "line": 134,
+          "missing": "模範解答例",
+          "missing_len": 5,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは「",
+          "confidence": "high"
+        },
+        {
+          "line": 242,
+          "missing": "模範解答例",
+          "missing_len": 5,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テーマは「ヒュー",
+          "confidence": "high"
+        },
+        {
+          "line": 338,
+          "missing": "模範解答例",
+          "missing_len": 5,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テー",
+          "confidence": "high"
+        },
+        {
+          "line": 433,
+          "missing": "模範解答例",
+          "missing_len": 5,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テーマ",
+          "confidence": "high"
+        },
+        {
+          "line": 20,
+          "missing": "総監記述",
+          "missing_len": 4,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）**",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "監記述式",
+          "missing_len": 4,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）** ",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "出題形式",
+          "missing_len": 4,
+          "context": "属し、現在（R03 以降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "作問委員",
+          "missing_len": 4,
+          "context": "降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まず",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "問委員任",
+          "missing_len": 4,
+          "context": "の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "委員任期",
+          "missing_len": 4,
+          "context": " **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは ",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "形式変化",
+          "missing_len": 4,
+          "context": "が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "解答戦略",
+          "missing_len": 4,
+          "context": " 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "三層構造",
+          "missing_len": 4,
+          "context": "年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度 記述式 ",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "論点抽出",
+          "missing_len": 4,
+          "context": "分） と 令和 7 年度 記述式 を学習してから、論点抽出の素材として本ページを参照することを推奨します。",
+          "confidence": "medium"
+        },
+        {
+          "line": 31,
+          "missing": "成果物等",
+          "missing_len": 4,
+          "context": "」という。）を1つ取り上げ，その目的や創出している成果物等を踏まえ，ヒューマンエラーに関して総合技術監理の視",
+          "confidence": "medium"
+        },
+        {
+          "line": 76,
+          "missing": "記述式試",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年",
+          "confidence": "medium"
+        },
+        {
+          "line": 76,
+          "missing": "述式試験",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年度",
+          "confidence": "medium"
+        },
+        {
+          "line": 76,
+          "missing": "解答戦略",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年度の問題文に",
+          "confidence": "medium"
+        },
+        {
+          "line": 76,
+          "missing": "三層構造",
+          "missing_len": 4,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年度の問題文に当てはめた例。模範論文例",
+          "confidence": "medium"
+        },
+        {
+          "line": 76,
+          "missing": "模範論文",
+          "missing_len": 4,
+          "context": "「三層構造」を、令和元年度の問題文に当てはめた例。模範論文例を読む前に、**(1) → (2) がどう因果で",
+          "confidence": "medium"
+        },
+        {
+          "line": 76,
+          "missing": "範論文例",
+          "missing_len": 4,
+          "context": "三層構造」を、令和元年度の問題文に当てはめた例。模範論文例を読む前に、**(1) → (2) がどう因果でつ",
+          "confidence": "medium"
+        },
+        {
+          "line": 76,
+          "missing": "模範解答",
+          "missing_len": 4,
+          "context": "つながっているか** を確認しておくと、4 例ある模範解答の共通構造が理解しやすい。",
+          "confidence": "medium"
+        },
+        {
+          "line": 76,
+          "missing": "共通構造",
+          "missing_len": 4,
+          "context": "いるか** を確認しておくと、4 例ある模範解答の共通構造が理解しやすい。",
+          "confidence": "medium"
+        },
+        {
+          "line": 81,
+          "missing": "発生原因",
+          "missing_len": 4,
+          "context": "**ヒューマンエラー** と、その発生原因および対策。",
+          "confidence": "medium"
+        },
+        {
+          "line": 86,
+          "missing": "発生要因",
+          "missing_len": 4,
+          "context": "- **発生要因**: 思い込み、勘違い、不注意、慣れなど",
+          "confidence": "medium"
+        },
+        {
+          "line": 87,
+          "missing": "発生範囲",
+          "missing_len": 4,
+          "context": "- **発生範囲**: 業種・職種を問わず存在",
+          "confidence": "medium"
+        },
+        {
+          "line": 88,
+          "missing": "基本認識",
+          "missing_len": 4,
+          "context": "- **管理の基本認識**: 完全排除は困難だが、対応を誤ると重大な問題",
+          "confidence": "medium"
+        },
+        {
+          "line": 88,
+          "missing": "完全排除",
+          "missing_len": 4,
+          "context": "- **管理の基本認識**: 完全排除は困難だが、対応を誤ると重大な問題・被害が発生する",
+          "confidence": "medium"
+        },
+        {
+          "line": 92,
+          "missing": "要求事項",
+          "missing_len": 4,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 101,
+          "missing": "評価項目",
+          "missing_len": 4,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "medium"
+        },
+        {
+          "line": 104,
+          "missing": "発防止策",
+          "missing_len": 4,
+          "context": "| ヒューマンエラー事例が具体的か、原因・対応・再発防止策が区別されているか |",
+          "confidence": "medium"
+        },
+        {
+          "line": 105,
+          "missing": "今後予想",
+          "missing_len": 4,
+          "context": "| 論理的なつながり | 過去の事例 → 今後予想されるエラー → 新技術での防止策、が自然につなが",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "発防止策",
+          "missing_len": 4,
+          "context": "は「内容・影響 → 原因 → 取られた対応 → 再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "事業特性",
+          "missing_len": 4,
+          "context": " 取られた対応 → 再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "閉鎖空間",
+          "missing_len": 4,
+          "context": "対応 → 再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業な",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "危険環境",
+          "missing_len": 4,
+          "context": "再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "暗黙知依",
+          "missing_len": 4,
+          "context": "」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "黙知依存",
+          "missing_len": 4,
+          "context": "の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "列車運行",
+          "missing_len": 4,
+          "context": "事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段で提示する",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "車運行下",
+          "missing_len": 4,
+          "context": "業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段で提示する施",
+          "confidence": "medium"
+        },
+        {
+          "line": 114,
+          "missing": "前提条件",
+          "missing_len": 4,
+          "context": "環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段で提示する施策がなぜ有効かを正当化",
+          "confidence": "medium"
+        },
+        {
+          "line": 118,
+          "missing": "事業特性",
+          "missing_len": 4,
+          "context": "(1) で示した事業特性のもとで、今後さらに発生しうる重大なヒューマンエラ",
+          "confidence": "medium"
+        },
+        {
+          "line": 118,
+          "missing": "影響軽減",
+          "missing_len": 4,
+          "context": "なヒューマンエラーを 1 つ取り上げ、それを防止・影響軽減できる新たな技術・方策を提示する。具体例:",
+          "confidence": "medium"
+        },
+        {
+          "line": 121,
+          "missing": "安全教育",
+          "missing_len": 4,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "medium"
+        },
+        {
+          "line": 121,
+          "missing": "空間的制",
+          "missing_len": 4,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "medium"
+        },
+        {
+          "line": 121,
+          "missing": "間的制約",
+          "missing_len": 4,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "medium"
+        },
+        {
+          "line": 122,
+          "missing": "議事録共",
+          "missing_len": 4,
+          "context": "- チェックリスト・5W1H の徹底・議事録共有 → 情報管理による経路の明確化",
+          "confidence": "medium"
+        },
+        {
+          "line": 122,
+          "missing": "事録共有",
+          "missing_len": 4,
+          "context": "- チェックリスト・5W1H の徹底・議事録共有 → 情報管理による経路の明確化",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "形式知化",
+          "missing_len": 4,
+          "context": "- ナレッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "熟練者不",
+          "missing_len": 4,
+          "context": " ナレッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "medium"
+        },
+        {
+          "line": 123,
+          "missing": "練者不足",
+          "missing_len": 4,
+          "context": "ナレッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "medium"
+        },
+        {
+          "line": 125,
+          "missing": "教育負荷",
+          "missing_len": 4,
+          "context": "果だけでなく、実現に向けた課題や障害（導入コスト・教育負荷・システムの信頼性担保）を必ずセットで記述する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 125,
+          "missing": "信頼性担",
+          "missing_len": 4,
+          "context": "向けた課題や障害（導入コスト・教育負荷・システムの信頼性担保）を必ずセットで記述する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 125,
+          "missing": "頼性担保",
+          "missing_len": 4,
+          "context": "けた課題や障害（導入コスト・教育負荷・システムの信頼性担保）を必ずセットで記述する。",
+          "confidence": "medium"
+        },
+        {
+          "line": 127,
+          "missing": "延長線上",
+          "missing_len": 4,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**",
+          "confidence": "medium"
+        },
+        {
+          "line": 127,
+          "missing": "将来展望",
+          "missing_len": 4,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "階層構造",
+          "missing_len": 4,
+          "context": "本問題は設問が (1)(2) の 2 階層構造だが、(2)(b) の「乗り越えなければならない課",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "将来展望",
+          "missing_len": 4,
+          "context": "「乗り越えなければならない課題や障害」が実質的に「将来展望と最大リスク」を問うている。(2)(a) のエラー",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "経験的要",
+          "missing_len": 4,
+          "context": "するリスク（ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "験的要素",
+          "missing_len": 4,
+          "context": "るリスク（ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "継承断絶",
+          "missing_len": 4,
+          "context": "ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理に",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "誤作動時",
+          "missing_len": 4,
+          "context": "化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "代替手段",
+          "missing_len": 4,
+          "context": "ル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象として示す",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "替手段喪",
+          "missing_len": 4,
+          "context": "空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象として示す。",
+          "confidence": "medium"
+        },
+        {
+          "line": 129,
+          "missing": "手段喪失",
+          "missing_len": 4,
+          "context": "洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象として示す。",
+          "confidence": "medium"
+        },
+        {
+          "line": 134,
+          "missing": "模範解答",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは",
+          "confidence": "medium"
+        },
+        {
+          "line": 134,
+          "missing": "範解答例",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは「",
+          "confidence": "medium"
+        },
+        {
+          "line": 134,
+          "missing": "選択科目",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは「ヒューマンエ",
+          "confidence": "medium"
+        },
+        {
+          "line": 134,
+          "missing": "上下水道",
+          "missing_len": 4,
+          "context": "2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは「ヒューマンエラーとその防止",
+          "confidence": "medium"
+        },
+        {
+          "line": 242,
+          "missing": "模範解答",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テーマは「ヒュ",
+          "confidence": "medium"
+        },
+        {
+          "line": 242,
+          "missing": "範解答例",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テーマは「ヒュー",
+          "confidence": "medium"
+        },
+        {
+          "line": 242,
+          "missing": "選択科目",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テーマは「ヒューマンエラーと",
+          "confidence": "medium"
+        },
+        {
+          "line": 338,
+          "missing": "模範解答",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テ",
+          "confidence": "medium"
+        },
+        {
+          "line": 338,
+          "missing": "範解答例",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テー",
+          "confidence": "medium"
+        },
+        {
+          "line": 338,
+          "missing": "選択科目",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テーマは「ヒュー",
+          "confidence": "medium"
+        },
+        {
+          "line": 338,
+          "missing": "地方計画",
+          "missing_len": 4,
+          "context": "記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テーマは「ヒューマンエラーとその防止策」です",
+          "confidence": "medium"
+        },
+        {
+          "line": 433,
+          "missing": "模範解答",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テー",
+          "confidence": "medium"
+        },
+        {
+          "line": 433,
+          "missing": "範解答例",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テーマ",
+          "confidence": "medium"
+        },
+        {
+          "line": 433,
+          "missing": "選択科目",
+          "missing_len": 4,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テーマは「ヒューマ",
+          "confidence": "medium"
+        },
+        {
+          "line": 433,
+          "missing": "精密機器",
+          "missing_len": 4,
+          "context": "）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テーマは「ヒューマンエラーとその防止策」です",
+          "confidence": "medium"
+        },
+        {
+          "line": 20,
+          "missing": "総監記",
+          "missing_len": 3,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）*",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "監記述",
+          "missing_len": 3,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）**",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）** ",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "転換期",
+          "missing_len": 3,
+          "context": "この年度は総監記述式の **第 2 期（転換期、H28〜R02）** に属し、現在（R03 以降",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "出題形",
+          "missing_len": 3,
+          "context": "属し、現在（R03 以降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "題形式",
+          "missing_len": 3,
+          "context": "し、現在（R03 以降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "作問委",
+          "missing_len": 3,
+          "context": "降の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。ま",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "問委員",
+          "missing_len": 3,
+          "context": "の **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まず",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "委員任",
+          "missing_len": 3,
+          "context": " **第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "員任期",
+          "missing_len": 3,
+          "context": "**第 3 期**）と出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは ",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "年周期",
+          "missing_len": 3,
+          "context": "出題形式が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "形式変",
+          "missing_len": 3,
+          "context": "が異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 ",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "式変化",
+          "missing_len": 3,
+          "context": "異なります（作問委員任期による 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "解答戦",
+          "missing_len": 3,
+          "context": " 3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "答戦略",
+          "missing_len": 3,
+          "context": "3〜5 年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "三層構",
+          "missing_len": 3,
+          "context": "年周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度 記述式",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "層構造",
+          "missing_len": 3,
+          "context": "周期の形式変化のため）。まずは 最新の解答戦略（三層構造・5 枚×30 分） と 令和 7 年度 記述式 ",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "論点抽",
+          "missing_len": 3,
+          "context": "分） と 令和 7 年度 記述式 を学習してから、論点抽出の素材として本ページを参照することを推奨します。",
+          "confidence": "low"
+        },
+        {
+          "line": 20,
+          "missing": "点抽出",
+          "missing_len": 3,
+          "context": "） と 令和 7 年度 記述式 を学習してから、論点抽出の素材として本ページを参照することを推奨します。",
+          "confidence": "low"
+        },
+        {
+          "line": 31,
+          "missing": "果物等",
+          "missing_len": 3,
+          "context": "という。）を1つ取り上げ，その目的や創出している成果物等を踏まえ，ヒューマンエラーに関して総合技術監理の視",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "述式試",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "式試験",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年度",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "解答戦",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年度の問題文",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "答戦略",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年度の問題文に",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "三層構",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年度の問題文に当てはめた例。模範論文",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "層構造",
+          "missing_len": 3,
+          "context": "記述式試験の解答戦略 で論じている「三層構造」を、令和元年度の問題文に当てはめた例。模範論文例",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "問題文",
+          "missing_len": 3,
+          "context": "解答戦略 で論じている「三層構造」を、令和元年度の問題文に当てはめた例。模範論文例を読む前に、**(1) ",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "模範論",
+          "missing_len": 3,
+          "context": "「三層構造」を、令和元年度の問題文に当てはめた例。模範論文例を読む前に、**(1) → (2) がどう因果",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "範論文",
+          "missing_len": 3,
+          "context": "三層構造」を、令和元年度の問題文に当てはめた例。模範論文例を読む前に、**(1) → (2) がどう因果で",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "論文例",
+          "missing_len": 3,
+          "context": "層構造」を、令和元年度の問題文に当てはめた例。模範論文例を読む前に、**(1) → (2) がどう因果でつ",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "模範解",
+          "missing_len": 3,
+          "context": "つながっているか** を確認しておくと、4 例ある模範解答の共通構造が理解しやすい。",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "範解答",
+          "missing_len": 3,
+          "context": "ながっているか** を確認しておくと、4 例ある模範解答の共通構造が理解しやすい。",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "共通構",
+          "missing_len": 3,
+          "context": "いるか** を確認しておくと、4 例ある模範解答の共通構造が理解しやすい。",
+          "confidence": "low"
+        },
+        {
+          "line": 76,
+          "missing": "通構造",
+          "missing_len": 3,
+          "context": "るか** を確認しておくと、4 例ある模範解答の共通構造が理解しやすい。",
+          "confidence": "low"
+        },
+        {
+          "line": 81,
+          "missing": "発生原",
+          "missing_len": 3,
+          "context": "**ヒューマンエラー** と、その発生原因および対策。",
+          "confidence": "low"
+        },
+        {
+          "line": 81,
+          "missing": "生原因",
+          "missing_len": 3,
+          "context": "**ヒューマンエラー** と、その発生原因および対策。",
+          "confidence": "low"
+        },
+        {
+          "line": 86,
+          "missing": "発生要",
+          "missing_len": 3,
+          "context": "- **発生要因**: 思い込み、勘違い、不注意、慣れなど",
+          "confidence": "low"
+        },
+        {
+          "line": 86,
+          "missing": "生要因",
+          "missing_len": 3,
+          "context": "- **発生要因**: 思い込み、勘違い、不注意、慣れなど",
+          "confidence": "low"
+        },
+        {
+          "line": 87,
+          "missing": "発生範",
+          "missing_len": 3,
+          "context": "- **発生範囲**: 業種・職種を問わず存在",
+          "confidence": "low"
+        },
+        {
+          "line": 87,
+          "missing": "生範囲",
+          "missing_len": 3,
+          "context": "- **発生範囲**: 業種・職種を問わず存在",
+          "confidence": "low"
+        },
+        {
+          "line": 88,
+          "missing": "基本認",
+          "missing_len": 3,
+          "context": "- **管理の基本認識**: 完全排除は困難だが、対応を誤ると重大な問",
+          "confidence": "low"
+        },
+        {
+          "line": 88,
+          "missing": "本認識",
+          "missing_len": 3,
+          "context": "- **管理の基本認識**: 完全排除は困難だが、対応を誤ると重大な問題",
+          "confidence": "low"
+        },
+        {
+          "line": 88,
+          "missing": "完全排",
+          "missing_len": 3,
+          "context": "- **管理の基本認識**: 完全排除は困難だが、対応を誤ると重大な問題・被害が発生す",
+          "confidence": "low"
+        },
+        {
+          "line": 88,
+          "missing": "全排除",
+          "missing_len": 3,
+          "context": "- **管理の基本認識**: 完全排除は困難だが、対応を誤ると重大な問題・被害が発生する",
+          "confidence": "low"
+        },
+        {
+          "line": 92,
+          "missing": "要求事",
+          "missing_len": 3,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "low"
+        },
+        {
+          "line": 92,
+          "missing": "求事項",
+          "missing_len": 3,
+          "context": "| 要求事項 | 内容 |",
+          "confidence": "low"
+        },
+        {
+          "line": 101,
+          "missing": "評価項",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 101,
+          "missing": "価項目",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 101,
+          "missing": "着眼点",
+          "missing_len": 3,
+          "context": "| 評価項目 | 着眼点 |",
+          "confidence": "low"
+        },
+        {
+          "line": 104,
+          "missing": "防止策",
+          "missing_len": 3,
+          "context": " ヒューマンエラー事例が具体的か、原因・対応・再発防止策が区別されているか |",
+          "confidence": "low"
+        },
+        {
+          "line": 105,
+          "missing": "今後予",
+          "missing_len": 3,
+          "context": "| 論理的なつながり | 過去の事例 → 今後予想されるエラー → 新技術での防止策、が自然につな",
+          "confidence": "low"
+        },
+        {
+          "line": 105,
+          "missing": "後予想",
+          "missing_len": 3,
+          "context": "| 論理的なつながり | 過去の事例 → 今後予想されるエラー → 新技術での防止策、が自然につなが",
+          "confidence": "low"
+        },
+        {
+          "line": 105,
+          "missing": "新技術",
+          "missing_len": 3,
+          "context": "り | 過去の事例 → 今後予想されるエラー → 新技術での防止策、が自然につながるか |",
+          "confidence": "low"
+        },
+        {
+          "line": 105,
+          "missing": "防止策",
+          "missing_len": 3,
+          "context": "去の事例 → 今後予想されるエラー → 新技術での防止策、が自然につながるか |",
+          "confidence": "low"
+        },
+        {
+          "line": 106,
+          "missing": "一貫性",
+          "missing_len": 3,
+          "context": "とまり | 計画段階と実施段階の 2 事例を通じた一貫性があるか |",
+          "confidence": "low"
+        },
+        {
+          "line": 112,
+          "missing": "設計図",
+          "missing_len": 3,
+          "context": "**(1) 設計図として置くべき前提**",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "各事例",
+          "missing_len": 3,
+          "context": "れぞれで実際に発生したヒューマンエラー事例を置く。各事例は「内容・影響 → 原因 → 取られた対応 → 再",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "防止策",
+          "missing_len": 3,
+          "context": "「内容・影響 → 原因 → 取られた対応 → 再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "事業特",
+          "missing_len": 3,
+          "context": " 取られた対応 → 再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "業特性",
+          "missing_len": 3,
+          "context": "取られた対応 → 再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "閉鎖空",
+          "missing_len": 3,
+          "context": "対応 → 再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "鎖空間",
+          "missing_len": 3,
+          "context": "応 → 再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業な",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "危険環",
+          "missing_len": 3,
+          "context": "再発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "険環境",
+          "missing_len": 3,
+          "context": "発防止策」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "暗黙知",
+          "missing_len": 3,
+          "context": "」の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件とし",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "黙知依",
+          "missing_len": 3,
+          "context": "の 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "知依存",
+          "missing_len": 3,
+          "context": " 4 点セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "短工期",
+          "missing_len": 3,
+          "context": "セット。事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "列車運",
+          "missing_len": 3,
+          "context": "事業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段で提示す",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "車運行",
+          "missing_len": 3,
+          "context": "業特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段で提示する",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "運行下",
+          "missing_len": 3,
+          "context": "特性（閉鎖空間・危険環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段で提示する施",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "前提条",
+          "missing_len": 3,
+          "context": "環境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段で提示する施策がなぜ有効かを正当",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "提条件",
+          "missing_len": 3,
+          "context": "境・暗黙知依存・短工期・列車運行下の作業など）を前提条件として示し、後段で提示する施策がなぜ有効かを正当化",
+          "confidence": "low"
+        },
+        {
+          "line": 114,
+          "missing": "正当化",
+          "missing_len": 3,
+          "context": "提条件として示し、後段で提示する施策がなぜ有効かを正当化する。",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "事業特",
+          "missing_len": 3,
+          "context": "(1) で示した事業特性のもとで、今後さらに発生しうる重大なヒューマンエ",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "業特性",
+          "missing_len": 3,
+          "context": "(1) で示した事業特性のもとで、今後さらに発生しうる重大なヒューマンエラ",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "影響軽",
+          "missing_len": 3,
+          "context": "なヒューマンエラーを 1 つ取り上げ、それを防止・影響軽減できる新たな技術・方策を提示する。具体例:",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "響軽減",
+          "missing_len": 3,
+          "context": "ヒューマンエラーを 1 つ取り上げ、それを防止・影響軽減できる新たな技術・方策を提示する。具体例:",
+          "confidence": "low"
+        },
+        {
+          "line": 118,
+          "missing": "具体例",
+          "missing_len": 3,
+          "context": "を防止・影響軽減できる新たな技術・方策を提示する。具体例:",
+          "confidence": "low"
+        },
+        {
+          "line": 120,
+          "missing": "省人化",
+          "missing_len": 3,
+          "context": "- ICT 調査（ドローン・IC タグ）による省人化 → 経済性↔安全・人的資源のトレードオフ",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "安全教",
+          "missing_len": 3,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "全教育",
+          "missing_len": 3,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "時間的",
+          "missing_len": 3,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "空間的",
+          "missing_len": 3,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "間的制",
+          "missing_len": 3,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "low"
+        },
+        {
+          "line": 121,
+          "missing": "的制約",
+          "missing_len": 3,
+          "context": "- VR を用いた安全教育・訓練 → 時間的・空間的制約の解消",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "議事録",
+          "missing_len": 3,
+          "context": "- チェックリスト・5W1H の徹底・議事録共有 → 情報管理による経路の明確化",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "事録共",
+          "missing_len": 3,
+          "context": "- チェックリスト・5W1H の徹底・議事録共有 → 情報管理による経路の明確化",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "録共有",
+          "missing_len": 3,
+          "context": "- チェックリスト・5W1H の徹底・議事録共有 → 情報管理による経路の明確化",
+          "confidence": "low"
+        },
+        {
+          "line": 122,
+          "missing": "明確化",
+          "missing_len": 3,
+          "context": "1H の徹底・議事録共有 → 情報管理による経路の明確化",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "暗黙知",
+          "missing_len": 3,
+          "context": "- ナレッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "形式知",
+          "missing_len": 3,
+          "context": "- ナレッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "式知化",
+          "missing_len": 3,
+          "context": "- ナレッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "熟練者",
+          "missing_len": 3,
+          "context": " ナレッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "練者不",
+          "missing_len": 3,
+          "context": "ナレッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "low"
+        },
+        {
+          "line": 123,
+          "missing": "者不足",
+          "missing_len": 3,
+          "context": "レッジマネジメントによる暗黙知の形式知化 → 熟練者不足への対応",
+          "confidence": "low"
+        },
+        {
+          "line": 125,
+          "missing": "教育負",
+          "missing_len": 3,
+          "context": "果だけでなく、実現に向けた課題や障害（導入コスト・教育負荷・システムの信頼性担保）を必ずセットで記述する。",
+          "confidence": "low"
+        },
+        {
+          "line": 125,
+          "missing": "育負荷",
+          "missing_len": 3,
+          "context": "だけでなく、実現に向けた課題や障害（導入コスト・教育負荷・システムの信頼性担保）を必ずセットで記述する。",
+          "confidence": "low"
+        },
+        {
+          "line": 125,
+          "missing": "頼性担",
+          "missing_len": 3,
+          "context": "けた課題や障害（導入コスト・教育負荷・システムの信頼性担保）を必ずセットで記述する。",
+          "confidence": "low"
+        },
+        {
+          "line": 125,
+          "missing": "性担保",
+          "missing_len": 3,
+          "context": "た課題や障害（導入コスト・教育負荷・システムの信頼性担保）を必ずセットで記述する。",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "延長線",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "長線上",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "将来展",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**",
+          "confidence": "low"
+        },
+        {
+          "line": 127,
+          "missing": "来展望",
+          "missing_len": 3,
+          "context": "**(3) (2) の延長線上の将来展望と最大リスク**",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "本問題",
+          "missing_len": 3,
+          "context": "本問題は設問が (1)(2) の 2 階層構造だが、(2",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "階層構",
+          "missing_len": 3,
+          "context": "本問題は設問が (1)(2) の 2 階層構造だが、(2)(b) の「乗り越えなければならない",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "層構造",
+          "missing_len": 3,
+          "context": "本問題は設問が (1)(2) の 2 階層構造だが、(2)(b) の「乗り越えなければならない課",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "実質的",
+          "missing_len": 3,
+          "context": "(b) の「乗り越えなければならない課題や障害」が実質的に「将来展望と最大リスク」を問うている。(2)(a",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "将来展",
+          "missing_len": 3,
+          "context": "「乗り越えなければならない課題や障害」が実質的に「将来展望と最大リスク」を問うている。(2)(a) のエラ",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "来展望",
+          "missing_len": 3,
+          "context": "乗り越えなければならない課題や障害」が実質的に「将来展望と最大リスク」を問うている。(2)(a) のエラー",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "新技術",
+          "missing_len": 3,
+          "context": "リスク」を問うている。(2)(a) のエラーを防ぐ新技術を導入した結果、次に顕在化するリスク（ICT ツー",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "顕在化",
+          "missing_len": 3,
+          "context": ")(a) のエラーを防ぐ新技術を導入した結果、次に顕在化するリスク（ICT ツール依存化でのスキル空洞化、",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "依存化",
+          "missing_len": 3,
+          "context": "導入した結果、次に顕在化するリスク（ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "空洞化",
+          "missing_len": 3,
+          "context": "に顕在化するリスク（ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "経験的",
+          "missing_len": 3,
+          "context": "するリスク（ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "験的要",
+          "missing_len": 3,
+          "context": "るリスク（ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "的要素",
+          "missing_len": 3,
+          "context": "リスク（ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "継承断",
+          "missing_len": 3,
+          "context": "ICT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "承断絶",
+          "missing_len": 3,
+          "context": "CT ツール依存化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理に",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "誤作動",
+          "missing_len": 3,
+          "context": "化でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "作動時",
+          "missing_len": 3,
+          "context": "でのスキル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "代替手",
+          "missing_len": 3,
+          "context": "ル空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象として示",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "替手段",
+          "missing_len": 3,
+          "context": "空洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象として示す",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "手段喪",
+          "missing_len": 3,
+          "context": "洞化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象として示す。",
+          "confidence": "low"
+        },
+        {
+          "line": 129,
+          "missing": "段喪失",
+          "missing_len": 3,
+          "context": "化、経験的要素の継承断絶、システム誤作動時の代替手段喪失）を見抜き、管理によって制御する対象として示す。",
+          "confidence": "low"
+        },
+        {
+          "line": 134,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**",
+          "confidence": "low"
+        },
+        {
+          "line": 134,
+          "missing": "模範解",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマ",
+          "confidence": "low"
+        },
+        {
+          "line": 134,
+          "missing": "範解答",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは",
+          "confidence": "low"
+        },
+        {
+          "line": 134,
+          "missing": "解答例",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは「",
+          "confidence": "low"
+        },
+        {
+          "line": 134,
+          "missing": "選択科",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは「ヒューマン",
+          "confidence": "low"
+        },
+        {
+          "line": 134,
+          "missing": "択科目",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは「ヒューマンエ",
+          "confidence": "low"
+        },
+        {
+          "line": 134,
+          "missing": "上下水",
+          "missing_len": 3,
+          "context": "2019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは「ヒューマンエラーとその防",
+          "confidence": "low"
+        },
+        {
+          "line": 134,
+          "missing": "下水道",
+          "missing_len": 3,
+          "context": "019年度）記述式の模範解答例①。選択科目は**上下水道－下水道**、テーマは「ヒューマンエラーとその防止",
+          "confidence": "low"
+        },
+        {
+          "line": 134,
+          "missing": "防止策",
+          "missing_len": 3,
+          "context": "水道－下水道**、テーマは「ヒューマンエラーとその防止策」です。",
+          "confidence": "low"
+        },
+        {
+          "line": 242,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テー",
+          "confidence": "low"
+        },
+        {
+          "line": 242,
+          "missing": "模範解",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テーマは「ヒ",
+          "confidence": "low"
+        },
+        {
+          "line": 242,
+          "missing": "範解答",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テーマは「ヒュ",
+          "confidence": "low"
+        },
+        {
+          "line": 242,
+          "missing": "解答例",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テーマは「ヒュー",
+          "confidence": "low"
+        },
+        {
+          "line": 242,
+          "missing": "選択科",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テーマは「ヒューマンエラー",
+          "confidence": "low"
+        },
+        {
+          "line": 242,
+          "missing": "択科目",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例②。選択科目は**建設－鉄道**、テーマは「ヒューマンエラーと",
+          "confidence": "low"
+        },
+        {
+          "line": 242,
+          "missing": "防止策",
+          "missing_len": 3,
+          "context": "*建設－鉄道**、テーマは「ヒューマンエラーとその防止策」です。",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "模範解",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "範解答",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テ",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "解答例",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テー",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "選択科",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テーマは「ヒュ",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "択科目",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テーマは「ヒュー",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "都市及",
+          "missing_len": 3,
+          "context": "9年度）記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テーマは「ヒューマンエラーとその防",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "地方計",
+          "missing_len": 3,
+          "context": "記述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テーマは「ヒューマンエラーとその防止策」で",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "方計画",
+          "missing_len": 3,
+          "context": "述式の模範解答例③。選択科目は**建設－都市及び地方計画**、テーマは「ヒューマンエラーとその防止策」です",
+          "confidence": "low"
+        },
+        {
+          "line": 338,
+          "missing": "防止策",
+          "missing_len": 3,
+          "context": "及び地方計画**、テーマは「ヒューマンエラーとその防止策」です。",
+          "confidence": "low"
+        },
+        {
+          "line": 433,
+          "missing": "記述式",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器",
+          "confidence": "low"
+        },
+        {
+          "line": 433,
+          "missing": "模範解",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テ",
+          "confidence": "low"
+        },
+        {
+          "line": 433,
+          "missing": "範解答",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テー",
+          "confidence": "low"
+        },
+        {
+          "line": 433,
+          "missing": "解答例",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テーマ",
+          "confidence": "low"
+        },
+        {
+          "line": 433,
+          "missing": "選択科",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テーマは「ヒュー",
+          "confidence": "low"
+        },
+        {
+          "line": 433,
+          "missing": "択科目",
+          "missing_len": 3,
+          "context": "令和元年度（2019年度）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テーマは「ヒューマ",
+          "confidence": "low"
+        },
+        {
+          "line": 433,
+          "missing": "精密機",
+          "missing_len": 3,
+          "context": "）記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テーマは「ヒューマンエラーとその防止策」で",
+          "confidence": "low"
+        },
+        {
+          "line": 433,
+          "missing": "密機器",
+          "missing_len": 3,
+          "context": "記述式の模範解答例④。選択科目は**機械－情報・精密機器**、テーマは「ヒューマンエラーとその防止策」です",
+          "confidence": "low"
+        },
+        {
+          "line": 433,
+          "missing": "防止策",
+          "missing_len": 3,
+          "context": "報・精密機器**、テーマは「ヒューマンエラーとその防止策」です。",
+          "confidence": "low"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Issue #128 Phase 3 — 総監過去問 R01-R07 全 7 年分（択一式 + 記述式 = 14 PDF, 197 ページ）を Tesseract jpn で OCR、MDX と差分突合する `audit-pdf-vs-mdx.mjs` を実装し初回実行。

## なぜ重要か

ユーザー指摘: 「全年度を PDF と照合すべき」「図が復元されていないものもあるのでは」。前回の Phase 1+2 (PR #142) は MDX 内部整合性のみで、本文に「下図」と書いてないのに PDF には図がある、という未検出ケースを構造的に拾えなかった。本 PR で **PDF 側の OCR 結果と MDX 漢字 n-gram の差分** を取ることで、Phase 1+2 の盲点を埋める。

## 実行結果

| Year/Kind | High | Med | Low | Total |
|---|---|---|---|---|
| R07/primary | 51 | 96 | 133 | 280 |
| R07/secondary | 6 | 9 | 8 | 23 |
| R06/primary | 64 | 95 | 114 | 273 |
| R06/secondary | 5 | 14 | 22 | 41 |
| R05/primary | 44 | 75 | 99 | 218 |
| R05/secondary | 3 | 5 | 9 | 17 |
| R04/primary | 69 | 101 | 121 | 291 |
| R04/secondary | 20 | 57 | 105 | 182 |
| R03/primary | 41 | 80 | 118 | 239 |
| R03/secondary | 15 | 42 | 79 | 136 |
| R02/primary | 63 | 96 | 115 | 274 |
| R02/secondary | 17 | 59 | 118 | 194 |
| R01/primary | 39 | 74 | 135 | 248 |
| R01/secondary | 20 | 76 | 161 | 257 |

**合計**: HIGH **457 件** / HIGH+MEDIUM **1336 件**

## R07 primary サンプル確認 (51 件 high)

- L26 「取機的手象」 ← 既知の誤読、高信頼で正常検出 ✓
- L378 「労働基準監督官」 ← 真の誤読の疑い（要原典確認）
- L540 「用事可否格付」 ← 文脈不明、誤読確実
- L819 「絶修復時間」 ← 「総修復時間」のはず
- L162 「修理作業等」 ← Tesseract 側の誤読（false positive）

high 候補の **約半分が真の OCR 誤読、半分が Tesseract 側ノイズ** と推定。実質 ~250 件の人手レビュー対象。

## 構造的補足

`<details>...</details>` (運営者執筆の解答解説) と JSX prop 配列内の文字列は MDX 抽出から除外済（除外しないと candidate 数 7 倍に膨れ上がってノイズまみれになる、初回実行で確認）。

## OCR キャッシュ

`.tmp/ocr-cache/{year}-{kind}/page-XXX.png|txt` と `{year}-{kind}-fullocr.txt` を保存（gitignore）。`--skip-ocr` フラグで再実行高速化。次回以降の同年度は OCR スキップ可能。

## Test plan

- [x] R07 primary で既知誤読「取機的手象」の検出を確認（high で出る）
- [x] 全 14 PDF を完走（5-6 分）
- [x] JSON 出力 (782 KB)
- [ ] high 候補 457 件を手動レビュー（後続 PR）

## 関連

- Issue #128 (元の audit issue)
- PR #142 (Phase 1+2 — MDX 内部整合性チェック)

🤖 Generated with [Claude Code](https://claude.com/claude-code)