### PR TITLE
revert(lcp): Wave 2 (Noto Sans JP preload off) をロールバック (#84)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,14 +20,11 @@ const inter = Inter({
   preload: true,
 });
 
-// Wave 2 (#84): preload: false に変更。日本語サブセット指定のない Noto Sans JP は
-// mobile で巨大ペイロードを critical path に乗せ LCP の主要ボトルネックとなっていた。
-// preload off + display:swap で system font フォールバックによる早期描画を狙う（FOUT 許容）。
 const notoSansJP = Noto_Sans_JP({
   subsets: ["latin"],
   variable: "--font-noto-sans-jp",
   display: "swap",
-  preload: false,
+  preload: true,
 });
 
 // Serif/Mincho フォント（2026-04-22 追加）: 本文フォント切替の基盤として導入。


### PR DESCRIPTION
## ロールバック理由

Wave 2 (PR #143/#144) デプロイ後の PSI 計測で **LCP が悪化**したため即時ロールバック。

## 計測結果（3 連続同値で安定）

| Metric | Before (Wave 1 後) | After (Wave 2) | Δ |
|---|---|---|---|
| LCP | 6968 ms | **7955 ms** | **+987 ms ❌** |
| Performance | 64 | 60 | -4 ❌ |
| FCP | 4765 ms | 5289 ms | +524 ms ❌ |
| TBT | 66 ms | 113 ms | +47 ms ❌ |

## 原因仮説

- preload off → Noto Sans JP の読込遅延 → h1（LCP element）の最終描画遅延
- `display: swap` のはずだが Tailwind の `font-sans` に日本語 system font fallback が含まれず、フォント読込まで描画が待たされている可能性

## 次の打ち手 (Wave 3)

1. **bundle-analyzer 導入** で chunk 内訳可視化
2. **Hero の LCP element 直接特定**（Chrome DevTools mobile emulation または Lighthouse Treemap）
3. **Tailwind font fallback 修正**（日本語 system font を fallback に追加）
4. **KaTeX CSS の docs 限定読込**

Refs: #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)