### PR TITLE
deploy: revert LCP Wave 2 (#84)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,14 +20,11 @@ const inter = Inter({
   preload: true,
 });
 
-// Wave 2 (#84): preload: false に変更。日本語サブセット指定のない Noto Sans JP は
-// mobile で巨大ペイロードを critical path に乗せ LCP の主要ボトルネックとなっていた。
-// preload off + display:swap で system font フォールバックによる早期描画を狙う（FOUT 許容）。
 const notoSansJP = Noto_Sans_JP({
   subsets: ["latin"],
   variable: "--font-noto-sans-jp",
   display: "swap",
-  preload: false,
+  preload: true,
 });
 
 // Serif/Mincho フォント（2026-04-22 追加）: 本文フォント切替の基盤として導入。


### PR DESCRIPTION
## デプロイ内容

LCP Wave 2 (Noto Sans JP preload off) のロールバック反映。

## 含まれる PR
- #146: revert(lcp): Wave 2 をロールバック (#84)

## 経緯
- Wave 2 反映後の PSI mobile LCP: 6968ms → **7955ms (+987ms 悪化、3連続同値)**
- Tailwind の font-sans に日本語 system font fallback がない可能性で、preload off は逆効果
- Wave 3 で根本対応予定

## 検証
- [x] PR #146 build 成功
- [ ] Cloudflare Pages 自動デプロイ
- [ ] PSI 再計測で 7955ms → 6968ms 台に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)