### PR TITLE
ci(metrics): GSC+GA4 fetch を土曜 08:00 JST に移動

### DIFF
--- a/.github/workflows/fetch-metrics.yml
+++ b/.github/workflows/fetch-metrics.yml
@@ -2,7 +2,7 @@ name: Fetch SEO metrics (GSC + GA4)
 
 on:
   schedule:
-    - cron: "0 11 * * 0" # JST 20:00 Sunday (UTC 11:00)
+    - cron: "0 23 * * 5" # JST 08:00 Saturday (UTC 23:00 Friday)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

`fetch-metrics.yml` の cron schedule を変更:
- **Before**: `0 11 * * 0` = 日曜 20:00 JST
- **After**: `0 23 * * 5` = **土曜 08:00 JST**

## なぜ土曜朝か

- GSC は 2-3 日遅れデータ → 土曜朝取得で木曜分まで見える
- 土曜中にレビュー → 日/月で改善着手という週次サイクルが回る
- 現状の日曜 20:00 だと月曜にしかレビューできず、サイクルが詰まる

## 影響範囲

- `fetch-metrics`: 日曜 → 土曜（週1のまま、曜日のみ変更）
- `psi-audit`: **変更なし**（毎日 02:00 JST、CWV 連続監視）
- `uptime-ping`: **変更なし**（毎日 08/14/20 JST、死活監視）

## 注意事項

merge 後、次の発火タイミングは:
- 旧スケジュール (日曜 20:00 JST): 発火しない
- 新スケジュール (土曜 08:00 JST): 直近の土曜から有効

`workflow_dispatch` は手動トリガーで継続利用可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)