### PR TITLE
feat(seo): FAQPage 構造化データの出力基盤 (#78)

### DIFF
--- a/.claude/reference/content-authoring.md
+++ b/.claude/reference/content-authoring.md
@@ -196,6 +196,27 @@ published: true                      # false なら下書き・非表示
 - `past-questions` — 過去問
 - `keyword` — キーワード解説
 
+## FAQ オプション（任意）
+
+ガイドページやキーワード解説ページに FAQ セクションを持たせる場合、frontmatter に `faqs` を追加すると `<StructuredData>` が `@type: FAQPage` を出力する。Google の Rich Results で SERP 占有面積拡大が狙える。
+
+```yaml
+faqs:
+  - q: "1級土木施工管理技士の合格率はどれくらい？"
+    a: "第1次試験 約60%、第2次試験 約30%（過去5年平均）。"
+  - q: "学習期間の目安は？"
+    a: "実務2年以上の受験者で、第1次は3〜4ヶ月、第2次は4〜6ヶ月が目安。"
+```
+
+**ルール**:
+- `q` / `a` は **プレーンテキスト**（HTML タグや Markdown は書かない）。Schema.org 仕様上 HTML も許容されるが、Google のリッチリザルト表示でエスケープされるケースがあるため避ける
+- `q` は質問形（疑問符で終える）、`a` は 1〜3 文程度で簡潔に
+- 1 ページあたり **3〜10 件** が目安。多すぎると Google から spam 判定の懸念
+- frontmatter の FAQ と本文の FAQ セクション（`## よくある質問` 等）は内容を一致させる
+- 配列が空 / 不正な形（`q` か `a` が文字列でない等）の場合は FAQPage スキーマを出力しない
+
+実装は `src/components/seo/StructuredData.tsx` の `generateFAQSchema()`。
+
 ## 複数試験対応コンテンツ
 
 frontmatter に複数カテゴリを参照する方法（要検討）:

--- a/src/components/seo/StructuredData.tsx
+++ b/src/components/seo/StructuredData.tsx
@@ -100,6 +100,38 @@ function getExamName(category: string | undefined): string {
   }
 }
 
+type FAQEntry = { q: string; a: string };
+
+function getFAQs(meta: DocMeta | PostData): FAQEntry[] {
+  const raw = (meta as any).faqs;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (item): item is FAQEntry =>
+      item != null &&
+      typeof item === "object" &&
+      typeof item.q === "string" &&
+      typeof item.a === "string" &&
+      item.q.trim().length > 0 &&
+      item.a.trim().length > 0
+  );
+}
+
+function generateFAQSchema(faqs: FAQEntry[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((entry) => ({
+      "@type": "Question",
+      name: entry.q,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: entry.a,
+      },
+    })),
+    inLanguage: "ja-JP",
+  };
+}
+
 function generateQuizSchema(meta: DocMeta | PostData, baseUrl: string) {
   const slug = "id" in meta ? meta.id : meta.slug;
   return {
@@ -255,6 +287,9 @@ export default function StructuredData({ type, post, docMeta }: StructuredDataPr
       ? generateBreadcrumbSchema(meta as DocMeta | PostData, baseUrl)
       : null;
 
+  const faqEntries = meta ? getFAQs(meta as DocMeta | PostData) : [];
+  const faqData = faqEntries.length > 0 ? generateFAQSchema(faqEntries) : null;
+
   return (
     <>
       <script
@@ -284,6 +319,14 @@ export default function StructuredData({ type, post, docMeta }: StructuredDataPr
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(breadcrumbData, null, 2),
+          }}
+        />
+      )}
+      {faqData && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(faqData, null, 2),
           }}
         />
       )}


### PR DESCRIPTION
## Summary

Issue #78（P7 FAQPage スキーマ導入）のうち、**インフラ部分のみ**を実装。frontmatter に `faqs: [{q, a}, ...]` を書くと `<StructuredData>` が `@type: FAQPage` の JSON-LD を自動出力するようになる。

実際の FAQ 本文を持つページはまだ存在しないため、本 PR をマージしても site の出力は変化しない（faqs を持つページが追加された時点から発火）。

## 実装内容

- `src/components/seo/StructuredData.tsx`
  - `getFAQs(meta)` — frontmatter の `faqs` を検証して `{q, a}[]` を返す（空 / 不正値は除外）
  - `generateFAQSchema(faqs)` — Schema.org の `FAQPage` JSON-LD を生成
  - 既存の Quiz / DefinedTerm / Breadcrumb と同じく条件付き `<script>` レンダリング
- `.claude/reference/content-authoring.md`
  - frontmatter 仕様、Q/A の書き方ルール、推奨件数（3〜10）、本文セクションとの整合ルールを追記

## なぜインフラだけ分離したか

Issue は「FAQ セクションを持つ既存ページに導入」を想定しているが、リポジトリ全体を grep した結果 **既存 MDX で `## よくある質問` / `## FAQ` セクションを持つページは 0 件**。よって 5–10 ページ分の FAQ 本文執筆は editorial 判断を伴う別タスクとして follow-up Issue 化する。

## Test plan

- [x] `npm run type-check` 通過
- [x] `npm run build` 通過（779 静的ページ生成、エラーなし）
- [x] faqs 未指定の既存ページの出力は変化しない（条件付きレンダリングなので）
- [ ] 執筆 follow-up Issue で実際の FAQ ページを 1 本追加した後、本番デプロイ → [Google Rich Results Test](https://search.google.com/test/rich-results) で `FAQPage` 検出を確認（本 PR では検証不可）
- [ ] Search Console 拡張レポートでエラーゼロ（同上、follow-up）

## Refs

- Issue: #78
- Umbrella: #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)