### PR TITLE
perf(lcp): Hero の blur orb 3 つを削除 (#84 Wave 3)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,13 +16,9 @@ export default async function HomePage() {
 
       <main className="flex-grow">
         {/* Hero Section */}
+        {/* Issue #84 Wave 3: 装飾用 blur orb 3 つを削除して mobile GPU 負荷を低減。
+            背景グラデーション (bg-gradient-to-br) は維持。視覚影響は最小、LCP 改善が目的。 */}
         <section className="relative overflow-hidden bg-gradient-to-br from-primary-50 via-white to-cyan-50 dark:from-primary-950 dark:via-gray-900 dark:to-cyan-950 py-20 lg:py-32">
-          <div className="absolute inset-0 opacity-10 dark:opacity-20">
-            <div className="absolute top-0 left-0 w-32 h-32 bg-primary-400 rounded blur-3xl"></div>
-            <div className="absolute top-1/2 right-0 w-24 h-24 bg-cyan-400 rounded blur-2xl"></div>
-            <div className="absolute bottom-0 left-1/3 w-20 h-20 bg-primary-300 rounded blur-2xl"></div>
-          </div>
-
           <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-gray-900 dark:text-gray-100 mb-6 leading-tight">
               土木系資格試験


### PR DESCRIPTION
## Summary

mobile LCP 改善 **Wave 3**。Hero セクションの装飾用 blur orb 3 つを削除。

## Wave 1/2 失敗からの転換

| Wave | 変更 | 結果 |
|---|---|---|
| Wave 1 | GA4 lazyOnload | hydration 副作用でサイトクラッシュ → revert |
| Wave 2 | Noto Sans JP preload: false | font fallback 不在で +986ms 悪化 → revert |
| **Wave 3** | **Hero blur orb 削除** | **DOM 表層のみ、副作用ゼロ前提** |

## 実測ベース診断

Playwright + PerformanceObserver で LCP 要素を実測:
- LCP element: H1 「土木系資格試験対策サイト」(size 25488 px²)
- LCP renderTime: 592ms (Playwright fast network)
- mobile PSI 計測: 8524ms / Performance 53

Hero セクションには `opacity-10 dark:opacity-20` で 3 つの blur orb (`blur-3xl`/`blur-2xl`) が配置されていた。mobile GPU で blur filter は重い演算を要求し、LCP テキストの paint を遅らせていた。

## 変更内容

`src/app/page.tsx` の Hero セクションから以下の 3 つの絶対配置 div を削除:

```diff
-          <div className="absolute inset-0 opacity-10 dark:opacity-20">
-            <div className="absolute top-0 left-0 w-32 h-32 bg-primary-400 rounded blur-3xl"></div>
-            <div className="absolute top-1/2 right-0 w-24 h-24 bg-cyan-400 rounded blur-2xl"></div>
-            <div className="absolute bottom-0 left-1/3 w-20 h-20 bg-primary-300 rounded blur-2xl"></div>
-          </div>
```

背景 `bg-gradient-to-br from-primary-50 via-white to-cyan-50` は維持。

## 期待効果

- mobile LCP: 8524ms → 5000ms 台
- mobile Performance: 53 → 65 以上
- 副作用: 視覚的にはほぼ気付かないレベル (opacity-10 だった装飾)

## 検証

- [x] `npm run type-check` 通過
- [x] `npm run build` 通過 (779 ページ SSG)
- [ ] develop merge → main deploy
- [ ] Playwright で視覚確認 (Hero 崩れがないこと)
- [ ] PSI mobile 再計測

## 関連

- Issue #84
- PR #133/#137 (Wave 1 + revert)
- PR #143/#147 (Wave 2 + revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)