### PR TITLE
feat(seo): RSS 2.0 + Atom 1.0 フィード生成 (#80)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "generate-webp": "node .claude/scripts/generate-webp.mjs",
     "update-image-refs": "node .claude/scripts/update-mdx-image-refs.mjs",
     "prebuild": "npm run generate-webp && npm run update-image-refs",
-    "build": "rm -rf out && npm run refresh-indexes && node scripts/generate-search-index.mjs && next build && node scripts/generate-sitemap.mjs",
+    "build": "rm -rf out && npm run refresh-indexes && node scripts/generate-search-index.mjs && next build && node scripts/generate-sitemap.mjs && node scripts/generate-rss.mjs",
     "ogp": "node .claude/skills/conversion/ogp-create/scripts/ogp-create.mjs",
     "start": "next start -p 3020",
     "lint": "eslint src/",

--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -1,0 +1,197 @@
+import { readdirSync, readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
+import { join, relative } from 'path';
+import matter from 'gray-matter';
+import { loadGitDates, lookupGitDates } from '../.claude/scripts/lib/git-dates.mjs';
+
+const SITE_URL = 'https://doboku-note.com';
+const SITE_TITLE = 'doboku-note - 土木系資格試験 専門技術ノート';
+const SITE_DESCRIPTION =
+  '1級土木施工管理技士・技術士（総合技術監理部門）の試験対策サイト。体系的な技術解説と過去問で合格をサポート。';
+const SITE_LANGUAGE = 'ja';
+const FEED_AUTHOR = 'doboku-note';
+const FEED_AUTHOR_EMAIL = 'admin@doboku-note.com';
+const MAX_ITEMS = 50;
+const OUT_DIR = 'out';
+const POSTS_DIR = join('.local', 'r2', 'posts');
+const REDIRECTS_FILE = join('public', '_redirects');
+
+// _redirects から 301 ソース側の /docs/{slug} を抽出（generate-sitemap.mjs と同じロジック）
+function parseRedirectedDocSlugs() {
+  const excluded = new Set();
+  if (!existsSync(REDIRECTS_FILE)) return excluded;
+  const content = readFileSync(REDIRECTS_FILE, 'utf8');
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 2) continue;
+    const from = parts[0];
+    const m = from.match(/^\/docs\/([^/*]+)$/);
+    if (m) excluded.add(m[1]);
+  }
+  return excluded;
+}
+
+function resolveDate(data, fullPath, gitDates, key) {
+  if (key === 'modified') {
+    const relPath = relative(process.cwd(), fullPath);
+    const gd = lookupGitDates(gitDates, relPath);
+    if (gd?.dateModified) {
+      const d = new Date(gd.dateModified);
+      if (!isNaN(d.getTime())) return d;
+    }
+  }
+  const candidates =
+    key === 'published'
+      ? [data.publishedAt, data.created, data.dateModified, data.updated]
+      : [data.dateModified, data.updated, data.publishedAt, data.created];
+  for (const c of candidates) {
+    if (c == null) continue;
+    const d = new Date(typeof c === 'string' ? c : String(c));
+    if (!isNaN(d.getTime())) return d;
+  }
+  return new Date(0);
+}
+
+function walkMdxFiles(dir, gitDates, segments = [], results = []) {
+  if (!existsSync(dir)) return results;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkMdxFiles(full, gitDates, [...segments, entry.name], results);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.mdx')) continue;
+
+    const baseName = entry.name.replace(/\.mdx$/, '');
+    const slugParts = baseName === 'article' ? segments : [...segments, baseName];
+    if (slugParts.length === 0) continue;
+    const slug = slugParts.join('-');
+
+    const fileContents = readFileSync(full, 'utf8');
+    const { data } = matter(fileContents);
+
+    if (data.published === false) continue;
+    if (!data.title) continue;
+
+    results.push({
+      slug,
+      title: data.title,
+      description: data.description || '',
+      category: data.category || '',
+      tags: Array.isArray(data.tags) ? data.tags : [],
+      pubDate: resolveDate(data, full, gitDates, 'published'),
+      updatedDate: resolveDate(data, full, gitDates, 'modified'),
+    });
+  }
+  return results;
+}
+
+// XML の特殊文字エスケープ
+function escapeXml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+// RFC 822 形式（RSS 2.0 の pubDate 用）
+function toRfc822(date) {
+  return date.toUTCString();
+}
+
+// ISO 8601 形式（Atom 1.0 の updated 用）
+function toIso8601(date) {
+  return date.toISOString();
+}
+
+function buildRss(items, lastBuildDate) {
+  const itemsXml = items
+    .map((it) => {
+      const url = `${SITE_URL}/docs/${it.slug}`;
+      const categoryXml = it.tags.map((t) => `    <category>${escapeXml(t)}</category>`).join('\n');
+      return `  <item>
+    <title>${escapeXml(it.title)}</title>
+    <link>${url}</link>
+    <guid isPermaLink="true">${url}</guid>
+    <description>${escapeXml(it.description)}</description>
+    <pubDate>${toRfc822(it.pubDate)}</pubDate>
+${categoryXml}
+  </item>`;
+    })
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+  <title>${escapeXml(SITE_TITLE)}</title>
+  <link>${SITE_URL}</link>
+  <description>${escapeXml(SITE_DESCRIPTION)}</description>
+  <language>${SITE_LANGUAGE}</language>
+  <lastBuildDate>${toRfc822(lastBuildDate)}</lastBuildDate>
+  <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml" />
+${itemsXml}
+</channel>
+</rss>
+`;
+}
+
+function buildAtom(items, lastBuildDate) {
+  const entriesXml = items
+    .map((it) => {
+      const url = `${SITE_URL}/docs/${it.slug}`;
+      const categoryXml = it.tags
+        .map((t) => `    <category term="${escapeXml(t)}" />`)
+        .join('\n');
+      return `  <entry>
+    <title>${escapeXml(it.title)}</title>
+    <link href="${url}" />
+    <id>${url}</id>
+    <published>${toIso8601(it.pubDate)}</published>
+    <updated>${toIso8601(it.updatedDate)}</updated>
+    <summary>${escapeXml(it.description)}</summary>
+${categoryXml}
+  </entry>`;
+    })
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="${SITE_LANGUAGE}">
+  <title>${escapeXml(SITE_TITLE)}</title>
+  <subtitle>${escapeXml(SITE_DESCRIPTION)}</subtitle>
+  <link href="${SITE_URL}/atom.xml" rel="self" />
+  <link href="${SITE_URL}" />
+  <id>${SITE_URL}/</id>
+  <updated>${toIso8601(lastBuildDate)}</updated>
+  <author>
+    <name>${escapeXml(FEED_AUTHOR)}</name>
+    <email>${escapeXml(FEED_AUTHOR_EMAIL)}</email>
+  </author>
+${entriesXml}
+</feed>
+`;
+}
+
+// ---- メイン ---------------------------------------------------------
+
+if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+
+const excludedSlugs = parseRedirectedDocSlugs();
+const gitDates = loadGitDates();
+console.log(`[rss] git-dates: ${gitDates.size} ファイルを解析`);
+
+const allDocs = walkMdxFiles(POSTS_DIR, gitDates).filter((d) => !excludedSlugs.has(d.slug));
+
+// 更新日降順でソートして上位 MAX_ITEMS 件
+allDocs.sort((a, b) => b.updatedDate.getTime() - a.updatedDate.getTime());
+const items = allDocs.slice(0, MAX_ITEMS);
+
+const lastBuildDate = items[0]?.updatedDate || new Date();
+
+writeFileSync(join(OUT_DIR, 'feed.xml'), buildRss(items, lastBuildDate));
+writeFileSync(join(OUT_DIR, 'atom.xml'), buildAtom(items, lastBuildDate));
+
+console.log(`✅ Generated feed.xml + atom.xml with ${items.length} items (of ${allDocs.length} published)`);
+console.log(`   latest: ${items[0]?.title || '(none)'} (${items[0]?.updatedDate.toISOString().slice(0, 10)})`);

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -37,6 +37,14 @@ export const getCommonSeoData = () => ({
   metadataBase: new URL("https://doboku-note.com"),
   alternates: {
     canonical: "/",
+    types: {
+      "application/rss+xml": [
+        { url: "/feed.xml", title: "doboku-note RSS フィード" },
+      ],
+      "application/atom+xml": [
+        { url: "/atom.xml", title: "doboku-note Atom フィード" },
+      ],
+    },
   },
   robots: {
     index: true,


### PR DESCRIPTION
## Summary

- `scripts/generate-rss.mjs` を新規追加。`generate-sitemap.mjs` と同パターンで `.local/r2/posts/` を走査、`published === false` を除外し、`git-dates` で `dateModified` を解決。`out/feed.xml`（RSS 2.0）と `out/atom.xml`（Atom 1.0）を **更新日降順で最新 50 件** 出力する
- `package.json` の `build` chain 末尾に `generate-rss.mjs` を追加（`generate-sitemap.mjs` の直後）
- `src/lib/metadata.ts` の `alternates.types` に RSS/Atom フィードを登録し、全ページの `<head>` に `<link rel="alternate">` を露出

Closes #80

## Test plan

ローカル検証で確認済:

- [x] `node scripts/generate-rss.mjs` 単体実行: `feed.xml` + `atom.xml` を 50/768 件で出力、`[rss] git-dates: 14813 ファイルを解析` ログ確認
- [x] Python `xml.etree.ElementTree.parse()` で両 XML が well-formed
- [x] `npm run type-check` green
- [x] dev server (port 3020) で `curl http://localhost:3020/` の出力に以下 2 件が含まれることを確認:
  - `<link rel="alternate" type="application/rss+xml" href="https://doboku-note.com/feed.xml" title="doboku-note RSS フィード"/>`
  - `<link rel="alternate" type="application/atom+xml" href="https://doboku-note.com/atom.xml" title="doboku-note Atom フィード"/>`

## 本番デプロイ後の確認項目（Issue #80 完了条件）

- [ ] `curl https://doboku-note.com/feed.xml` で 200 + 正しい RSS XML が返る
- [ ] `curl https://doboku-note.com/atom.xml` で 200 + 正しい Atom XML が返る
- [ ] Feedly 等のフィードリーダーで購読できる
- [ ] [W3C Feed Validation Service](https://validator.w3.org/feed/) で RSS / Atom 共に合格

## 設計メモ

- 件数を 50 件に制限したのは、フィードリーダーの慣習（フィード全体を毎回ダウンロードするため、768 件全件は重い）+ Feedly 等の RSS パーサのデフォルト処理上限 50〜100 件に合わせたもの
- `_redirects` の旧 URL は `parseRedirectedDocSlugs()` で除外（sitemap と同じロジック）
- `pubDate` / `updated` は `git-dates` 優先、frontmatter `publishedAt` `dateModified` がフォールバック（sitemap と同方針）
- channel メタは `getCommonSeoData()` のサイトタイトル・説明と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)