### PR TITLE
content(svg): Issue #64 Tier 2 P2/P6 解消 + detector 改善 + npm run audit-svg

### DIFF
--- a/.claude/skills/quality/check-mdx/scripts/rules/svg/detect.mjs
+++ b/.claude/skills/quality/check-mdx/scripts/rules/svg/detect.mjs
@@ -265,8 +265,11 @@ export function detectSvgIssues(svg) {
   }
 
   // P2: テキスト同士の重なり
+  // 回転テキスト（軸ラベル等）は textBBox が rotation を考慮しないため、
+  // 水平に展開した phantom bbox と他テキストの偽陽性を避ける（P1 と同じ理由）
   for (let i = 0; i < bboxes.length; i++) {
     for (let j = i + 1; j < bboxes.length; j++) {
+      if (svg.texts[i].isRotated || svg.texts[j].isRotated) continue;
       if (bboxesOverlap(bboxes[i], bboxes[j])) {
         findings.push({
           pattern: "P2-text-overlap",

--- a/.claude/state/svg-audit.json
+++ b/.claude/state/svg-audit.json
@@ -1,19 +1,3942 @@
 {
   "meta": {
-    "generated_at": "2026-04-28T03:33:37.954Z",
+    "generated_at": "2026-04-30T04:50:08.626Z",
     "path": ".local/r2/posts/**/img/*.svg",
-    "file": "C:/Users/m004195/doboku-note/.local/r2/posts/pe-comprehensive-management/personal-communication/img/push-pull-communication.svg"
+    "file": null
   },
   "summary": {
-    "scanned_files": 1,
-    "files_with_issues": 0,
-    "total_findings": 0,
+    "scanned_files": 117,
+    "files_with_issues": 62,
+    "total_findings": 567,
     "by_severity": {
       "HIGH": 0,
-      "MEDIUM": 0,
-      "LOW": 0
+      "MEDIUM": 50,
+      "LOW": 517
     },
-    "by_pattern": {}
+    "by_pattern": {
+      "P5-wide-viewbox": 50,
+      "P4-tiny-font": 517
+    }
   },
-  "findings": []
+  "findings": [
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\work-planning\\img\\standard-time-tree.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 500px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\system-reliability\\img\\series-parallel-formulas.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "a₁",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\system-reliability\\img\\series-parallel-formulas.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "a₂",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\system-reliability\\img\\series-parallel-configuration.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 420px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\system-reliability\\img\\series-parallel-configuration.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（信頼度 R₁）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\system-reliability\\img\\series-parallel-configuration.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（信頼度 R₂）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\system-reliability\\img\\series-parallel-configuration.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（信頼度 R₃）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\system-reliability\\img\\series-parallel-configuration.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（信頼度 R₄）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\system-reliability\\img\\series-parallel-configuration.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "入力",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\system-reliability\\img\\series-parallel-configuration.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "出力",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 560px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "デジタルトランスフォーメーション",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "新たな商品・サービス提供やビジネスモデルの変革",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "デジタル技術の",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "利用・活用と",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "DXの境界",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "・DXは社会制度や組織文化なども変革する取組み",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "・ビジネスやプロセスの変革が本質",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "・「現在または直近に変革の着手が見えているもの」",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "明確ではないものはDXとは位置付けない",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "DXの取組と",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "推進計画",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "①取組の概要と変革の内容（過去〜現在）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "②DX推進計画の概要（タスクフォース・スケジュール）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "記述の明確さ、5つの管理の視点",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r04-secondary\\img\\figure-4-40.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "論文全体のまとまり ★、トレードオフへの対応",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 560px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "①日常業務の意思決定でのビッグデータ活用",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "②AI、IoT、ナレッジマネジメント等のデジタルツール",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "幅広いレベル",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "でのデータの",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "利活用",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "従来にない形のデータ収集・解析・利活用",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "現在のデータ利活用状況と今後の可能性",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "近い将来（5〜10年後）の新たな利活用",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "総合技術監理の視点（5管理）でのデータ利活用課題",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r03-secondary\\img\\figure-4-36.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "トレードオフへの対応",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 560px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "将来の自然",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "災害リスク",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "事業場の将来の自然災害リスクに対する対策の検討",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "事業場",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "異常な",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "自然現象",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "・1つ以上の事業場（工場、支店、農場等）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "・異常な自然現象：暴風、豪雨、洪水、高潮、地震等",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "・被害：直接受ける物理的被害や業務上の障害を含む",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（A、B、Cのラベルを付す）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "対策の",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "実施計画",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（i）既にとられている対策　（ii）今後追加する対策",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "追加対策の優先順位とその理由・実施計画",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r02-secondary\\img\\figure-4-33.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "記述の明確さ、5つの管理の視点、論文全体のまとまり ★",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 560px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "人為的過誤や失敗など、目標から逸脱した人の判断や行動。",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "JIS Z 8115:2019「人間が実施する行為と要求行為との相違」",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ヒューマンエラーを完全に排除することは困難",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "総合技術監理の立場として業務全体を把握し、",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "事業・プロジェクト等を取り上げ5つの管理の観点から分析",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "対象：よく知っている事業・プロジェクト等（1つ）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ヒューマン",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "エラー分析",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "過去発生したHEの分析と今後の予防対策",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "将来発生可能性のあるHEと新技術による防止策",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（a）過去 （b）将来",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "考察における視点の広さ、記述の明確さ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\r01-secondary\\img\\figure-4-30.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "論理的なつながり、論文全体のまとまり ★",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 460px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "着工",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "完了予定",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "現在",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "(計画値)",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "(実コスト)",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "(出来高)",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "SV",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "(&lt; 0: 遅延)",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "CV",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "(&lt; 0: 超過)",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "SV = EV − PV",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "CV = EV − AC",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "SPI = EV / PV",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\evm-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "CPI = EV / AC",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 440px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "100",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "50",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "着工",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "竣工",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "現在",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "上方許容限界",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "下方許容限界",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "予定",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\progress-management\\img\\banana-curve.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "実績",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\process-capability-index\\img\\normal-distribution-3sigma.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 480px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\process-capability-index\\img\\normal-distribution-3sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "N(μ, σ²) における標準偏差基準の包含確率",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\occupational-accident-prevention-plan\\img\\unskilled-worker-accident-types.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "※動作の反動等 49.0% / 全未熟練 35.9% / 未熟練労働者 39.0",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\occupational-accident-prevention-plan\\img\\unskilled-worker-accident-types.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "出典：厚生労働省・安全衛生教育マニュアル（平成 25 年）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 440px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "−3σ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "−2σ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "−σ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "σ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2σ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "3σ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "68.3%",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "95.4%",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "99.7%",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "寸法規格を",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\npv-net-present-value\\img\\normal-distribution-sigma.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "満さない範囲",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 445px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "働き方",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "DX投資",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "リスク",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "環境コスト",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "人事DX",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "労働安全",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "多様性",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "セキュリティ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "倫理",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\management-tradeoffs\\img\\tradeoff-frequency-matrix.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "防災×景観",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "O",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "1",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "3",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "4",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "1",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "3",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "4",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "5",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "3x₁+x₂=9",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "x₁+2x₂=8",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "z=6",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "z=12",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "z 増加",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "(3, 0)",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "(0, 4)",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\linear-programming\\img\\lp-graphical-method.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "(2, 3)",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\jit-production\\img\\kanban-two-types-flow.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 500px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\jit-production\\img\\kanban-two-types-flow.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（後工程が取りに来る指示）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\jit-production\\img\\kanban-two-types-flow.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（前工程に「作れ」指示）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\jit-production\\img\\kanban-two-types-flow.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "実線: 部品（物）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\jit-production\\img\\kanban-two-types-flow.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "破線: かんばん（情報）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\iso-26000\\img\\iso-26000-7-core-subjects.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 580px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\iso-26000\\img\\iso-26000-7-core-subjects.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Organizational",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\iso-26000\\img\\iso-26000-7-core-subjects.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Governance",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\iso-26000\\img\\iso-26000-7-core-subjects.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Human Rights",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\iso-26000\\img\\iso-26000-7-core-subjects.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Labour Practices",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\iso-26000\\img\\iso-26000-7-core-subjects.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Environment",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\iso-26000\\img\\iso-26000-7-core-subjects.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Fair Operating",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\iso-26000\\img\\iso-26000-7-core-subjects.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Consumer Issues",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\iso-26000\\img\\iso-26000-7-core-subjects.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Community",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\income-statement\\img\\breakeven-point.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "固定費",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\income-statement\\img\\breakeven-point.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "総費用",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\income-statement\\img\\breakeven-point.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "売上高",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\income-statement\\img\\breakeven-point.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "BEP",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\income-statement\\img\\breakeven-point.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "利益",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\income-statement\\img\\breakeven-point.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "損失",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 560px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "a) 事例の内容　b) 変化　c) 働き方の変化",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（答案用紙3枚以内）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "a) 背景　b) 背景の具体的な影響　c) 背景",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "a) 背景　b) 背景の具体的な影響　c) 背景",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "a) 具体的な技術や方策",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "b) 実現するために乗り越えなければならない障害",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "c) 実現した場合の働き方への具体的な効果",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "d) 付随して生じる留意すべき影響",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-09.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "→ 答案用紙2枚以内にまとめること",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-08.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 540px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-04.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 560px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h30-secondary\\img\\figure-4-03.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 560px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 680px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "起因事象",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "早期漏洩検知",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "緊急遮断",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "着火",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "初期消火",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "最終事象",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "可燃性液体",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "漏洩 0.01/年",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "成功 0.9999",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "失敗 0.0001",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "成功 0.999",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "失敗 0.001",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小規模漏洩",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "不着火 0.9",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "着火 0.1",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "大規模漏洩",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "成功 0.7",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "失敗 0.3",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小規模火災",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "中規模火災",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "不着火 0.9",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "着火 0.1",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "大規模漏洩",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "成功 0.7",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "失敗 0.3",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "中規模火災",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "大規模火災",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "P1 = 0.01 x (0.0001 x 0.1 x 0.3 + 0.9999",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h26-primary\\img\\event-tree-i-1-32.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "検知失敗10倍: P2 &#x2248; 6.0 x 10&#x207B;&#x",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h25-primary\\img\\fault-tree-i-1-27.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 520px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h25-primary\\img\\fault-tree-i-1-27.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "AND",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h25-primary\\img\\fault-tree-i-1-27.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "OR",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h25-primary\\img\\fault-tree-i-1-27.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "AND",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h25-primary\\img\\fault-tree-i-1-27.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.03",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h25-primary\\img\\fault-tree-i-1-27.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.10",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h25-primary\\img\\fault-tree-i-1-27.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.05",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h25-primary\\img\\fault-tree-i-1-27.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.05",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h25-primary\\img\\fault-tree-i-1-27.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.05",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 680px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "D マグレガー",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "D マグレガー",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "仕事嫌い、命令・強制されなければ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "働かない。責任回避、指示待ち、",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "安全志向",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "仕事は自然。自己実現のために",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "自発的に働く。責任を求め、",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "創造性・想像力を発揮できる",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "命令・統制・強制によって",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "組織の目標を達成させる",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "アメとムチ型の管理",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "自己統制・自己指示によって",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "目標を達成させる。参加型管理",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "目標による管理",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "命令・統制・強制により部下を",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "管理する。懲罰・賞金などを使用",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "し、部下の服従を強制する",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "アメとムチによる管理",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "部下との信頼関係を築きながら",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "コーチングやリーダーシップを発揮",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "自律性を促し、動機付けを行う",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（4）発電士の",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "管理階層は解消",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "中央集権的な階層型組織",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "④上司の指示に従って業務を行う",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "①〜③の前目標は解消できない",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "分権的・フラットな組織",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "目標管理・自己実現を重視",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "参加型・コンサルティブな意思決定",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "受動的に目標に従い行動する",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "少しの野心も持たない",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "安全を求める",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "自己目標を設定し、積極的に働く",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "創意工夫・想像力を発揮",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "目標達成への高い動機付け",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "＊動機付け手段",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "X理論：アメとムチ（報酬と罰）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Y理論：自己実現・達成感・成長",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "＊2 この人間観管理の仕組みと効果",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\xy-theory-ii-1-9.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "＊目標による管理の定義的的意味説明",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\voc-regulation-ii-1-37.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 680px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\voc-regulation-ii-1-37.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "酢酸エチル、酢酸ビニル、アセトアルデヒド、",
+      "detail": "font-size 9.5px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\voc-regulation-ii-1-37.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "エタノール、イソプロピルアルコール",
+      "detail": "font-size 9.5px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\voc-regulation-ii-1-37.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "住宅の内装・外壁塗料",
+      "detail": "font-size 9.5px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\voc-regulation-ii-1-37.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "大気汚染防止法の排出抑制制度により、VOCの排出施設（塗装、洗浄、接着、印刷等）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\voc-regulation-ii-1-37.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "排出基準は施設の種類・規模に応じて設定（大気汚染防止法第17条の3〜第17条の1",
+      "detail": "font-size 9.5px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 760px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（安衛令2条）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "林業、鉱業、建設業、",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "運送業、清掃業",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "製造業、電気業、ガス業、熱供給業、水道業、",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "通信業、各種商品卸売業、家具・建具・じゅう器等",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "その他の業種（業種1・2以外）",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（金融業、保険業など）",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（安衛法10条、",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "安衛令2条）",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（安衛法11条、",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "安衛令3条）",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（安衛法12条、",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "安衛令4条）",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（安衛法13条、",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "安衛令5条）",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（安衛法17条、",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "安衛令8条、安衛令21条）",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "注（注1）「安全委員会」は、労働安全衛生法の規定に基づいて安全委員会を設置しなけ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "衛生委員会（安衛法18条、安衛令21条）は、衛生管理者を選任すべき事業場（安衛法",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\safety-org-structure-ii-1-29.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "安全衛生委員会（安衛法19条）は、安全委員会及び衛生委員会を設置しなければならな",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\pdpc-diagram-ii-1-3.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 500px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 680px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（調停委員会）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "及ぼす関係等での当事者",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（当事者申請）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "協議に基づく一方申請",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "協議に基づく一方申請",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（公益委員三者構成）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "で構成",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "公益委員",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（双事者委員で構成）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "あっせん：労働者代表と使用者の間で締結する。調停・仲裁：労働組合員に関する争議の",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\labor-dispute-resolution-ii-1-15.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "＊労働委員会があっせんを開始するのは申請があった場合等に、労使の申請を受けて非公",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\kj-method-ii-1-3.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 700px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\kj-method-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループA",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\kj-method-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループB",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\kj-method-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループC",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\kj-method-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループD",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\kj-method-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループA",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\kj-method-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループB",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\kj-method-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループC（統合テーマ）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\interrelation-diagram-ii-1-3.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 500px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\interrelation-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（テーマ）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\flextime-ii-1-11.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 580px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\flextime-ii-1-11.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（法定労働時間の総枠）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\flextime-ii-1-11.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "の総枠",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\flextime-ii-1-11.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（40時間×31÷7）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\flextime-ii-1-11.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（40時間×31÷7）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\flextime-ii-1-11.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（40時間×30÷7）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\flextime-ii-1-11.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "6カ月経過日から起算して、当該初日以後の1年間においては、有給休暇",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\flextime-ii-1-11.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "全労働者の8割以上出勤したその者に対して、10労働日の有給休暇を与えなければなら",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\flextime-ii-1-11.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（雇入れの日から、6カ月を起算して1年ごとに、前年の日数の区分に応じた継続勤務し",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\eia-procedure-ii-1-38.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 560px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\eia-procedure-ii-1-38.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（スクリーニング）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\eia-procedure-ii-1-38.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（環境保全計画の策定）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\eia-procedure-ii-1-38.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "準備書",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\eia-procedure-ii-1-38.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（環境影響評価の実施）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\eia-procedure-ii-1-38.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "環境影響評価法のフロー（概略）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\eia-procedure-ii-1-38.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "第一種事業：必ず環境影響評価を実施　第二種事業：スクリーニングにより要否を判定",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\eia-procedure-ii-1-38.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "方法書→準備書→評価書の順で手続きを進め、各段階で知事・市町村長・住民の意見を聴",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 600px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（特性）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小要因",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小要因",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小要因",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小要因",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小要因",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小要因",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小要因",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\cause-effect-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "小要因",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 580px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "1",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "3",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "4",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "5",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "6",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "7",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "8",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "今後30年以内に地震が発生する確率（%）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "1000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2500",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "3000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "4000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "5000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2.20%",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-unknown-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "↑現在（2530年）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 580px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "確率密度",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.001",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.0008",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.0006",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.0004",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.0002",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "1000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2500",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "3000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "4000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "5000",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "面積A",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "面積B",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2500年　2530年",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\bpt-distribution-known-ii-1-28.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "↑現在",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 480px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードA",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードB",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードC",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードD",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "見出しカード",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードE",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードF",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードG",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "見出しカード",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードH",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードI",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードJ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "カードK",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "見出しカード",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループ1",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループ2",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "グループ3",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\h24-primary\\img\\affinity-diagram-ii-1-3.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "まとめカード",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\four-e-countermeasures\\img\\four-e-overview.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 420px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\four-e-countermeasures\\img\\four-e-overview.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "4 つの観点を補完的に組み合わせて運用する",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "必要・不要を区別し",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "不要なものを除くこと",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "決められた場所に",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "置くこと",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "常に清潔にして",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "わかる状態を保つ",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "整理・整頓・清掃の",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "3Sを維持すること",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "決められたことを",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\five-s\\img\\5s-quality-map.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "守る習慣をつける",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\exam-application-guide\\img\\figure-2-4.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 600px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\exam-application-guide\\img\\figure-2-4.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "改善案に",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\exam-application-guide\\img\\figure-2-4.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "トレードオフ",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\exam-application-guide\\img\\figure-2-4.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "の解消を",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\exam-application-guide\\img\\figure-2-1.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 720px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\exam-application-guide\\img\\figure-2-1.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "経歴票がそのまま質問ベースに",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "早期発見",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "計器発見",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "検査発見",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "着火しない",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "成功",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.9",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "失敗",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.1",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "成功",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.9",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "失敗",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.1",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "成功",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.9",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "失敗",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.1",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "成功",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.5",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "失敗",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0.5",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\eta\\img\\eta-gas-leak-example.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（4 層のセーフガードがすべて失敗した場合のみ事故）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\essay-exam-strategy\\img\\figure-4-15-three-layer-structure.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 560px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\essay-exam-strategy\\img\\figure-4-02.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 500px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 640px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（高速・国道・林道）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（新幹線・軌道）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（ダム・堰・放水路",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "湖沼開発）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "水力・火力・地熱",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "原子力",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "太陽電池・風力",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（原子力はすべて）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "最終処分場",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "30ha 以上が",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "第一種事業",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "※ 宅地には工場用地なども含む",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\environmental-impact-assessment\\img\\eia-target-categories.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "第一種/第二種の規模基準（面積・延長・出力等）は環境省パンフレット参照",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\design-thinking\\img\\5-steps-iterative-flow.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 600px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\csr\\img\\csr-csv-evolution.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 600px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\csr\\img\\csr-csv-evolution.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ポーター（2011）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\correlation-analysis\\img\\regression-line.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "u",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\correlation-analysis\\img\\regression-line.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "プロットとモデル関数の二乗の和を最小にする f(x)",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\correlation-analysis\\img\\regression-line.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "← 回帰直線 →",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\correlation-analysis\\img\\correlation-scatter-patterns.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 500px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\correlation-analysis\\img\\correlation-scatter-patterns.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "右肩上がり",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\correlation-analysis\\img\\correlation-scatter-patterns.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "相関係数 ≈ 1 に近い",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\correlation-analysis\\img\\correlation-scatter-patterns.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "相関係数 ≈ 0",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\correlation-analysis\\img\\correlation-scatter-patterns.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "右肩下がり",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\correlation-analysis\\img\\correlation-scatter-patterns.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "相関係数 ≈ −1 に近い",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 500px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "200",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "400",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "600",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "1975",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "1985",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "1995",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2005",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2015",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "2021",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "気象庁",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（回）発生件数（年間）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "500",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "400",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "図　1時間降水量50mm以上の年間発生回数の経年変化（1976〜2021年）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\climate-change-decarbonization\\img\\heavy-rainfall-trend.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "棒グラフ＝各年の発生件数／直線＝5 年移動平均／黒線＝比較期間の平均トレンド",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\citizen-participation\\img\\arnstein-ladder.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 460px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\citizen-participation\\img\\arnstein-ladder.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "Arnstein (1969) \"A Ladder of Citizen Par",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\cause-and-effect-diagram\\img\\fishbone-4m.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 460px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\cause-and-effect-diagram\\img\\fishbone-4m.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "技能・経験",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\cause-and-effect-diagram\\img\\fishbone-4m.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "教育",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\cause-and-effect-diagram\\img\\fishbone-4m.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "作業手順",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\cause-and-effect-diagram\\img\\fishbone-4m.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "工程設計",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\cause-and-effect-diagram\\img\\fishbone-4m.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "保守状況",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\cause-and-effect-diagram\\img\\fishbone-4m.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "経年劣化",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\cause-and-effect-diagram\\img\\fishbone-4m.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "品質",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\cause-and-effect-diagram\\img\\fishbone-4m.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "規格",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\break-even-point\\img\\break-even-chart.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 420px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\break-even-point\\img\\break-even-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "0",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\break-even-point\\img\\break-even-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "損益分岐点",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\break-even-point\\img\\break-even-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "売上高",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\break-even-point\\img\\break-even-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "総費用",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\break-even-point\\img\\break-even-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "固定費",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\break-even-point\\img\\break-even-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "変動費",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\break-even-point\\img\\break-even-chart.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "固定費",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\break-even-point\\img\\bep-formulas.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 440px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 440px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "設置",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "故障率",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "初期故障期間",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "偶発故障期間",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "摩耗故障期間",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "部品交換",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "部分更新",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "更新",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "部品交換による",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "故障率の低減・",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-maintenance-effect.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "耐用年数の延長",
+      "detail": "font-size 8px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-curve-phases.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 420px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-curve-phases.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "初期故障期間",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-curve-phases.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "偶発故障期間",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\bathtub-curve\\img\\bathtub-curve-phases.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "摩耗故障期間",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\alert-levels\\img\\alert-levels-5stage.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "既に災害発生／命を守る最善の行動",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\alert-levels\\img\\alert-levels-5stage.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "危険な場所から全員避難",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\alert-levels\\img\\alert-levels-5stage.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "高齢者・要配慮者は立退き避難",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\alert-levels\\img\\alert-levels-5stage.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ハザードマップ等で避難経路を再確認",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\alert-levels\\img\\alert-levels-5stage.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "最新の防災気象情報に注意",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\activity-abc\\img\\abc-two-stage-allocation.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 520px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\activity-abc\\img\\abc-two-stage-allocation.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "人件費・設備費等",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\activity-abc\\img\\abc-two-stage-allocation.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "検査・段取・運搬",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\activity-abc\\img\\abc-two-stage-allocation.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "A・B・C 品番",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\activity-abc\\img\\abc-two-stage-allocation.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "各活動の資源消費量",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\activity-abc\\img\\abc-two-stage-allocation.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（例: 人時・稼働時間）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\activity-abc\\img\\abc-two-stage-allocation.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "各製品の活動利用量",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\pe-comprehensive-management\\activity-abc\\img\\abc-two-stage-allocation.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（例: 検査回数・段取回数）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "バック",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ホゥ",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ショベル",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（油圧）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ローディング",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ショベル",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "クラムシェル",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（油圧）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "クラムシェル",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（機械式）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ドラグライン",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ショベル",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（機械式）",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "油圧ショベル",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "油圧ショベル",
+      "detail": "font-size 9px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "油圧式",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "機械式",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "派生機械",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "基本分類",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-8.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "油圧式／機械式は作業動力の伝達方式による分類",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "定格荷重表示銘板",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "落下防止バルブ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "アーム角度センサ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ブーム角度センサ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "荷重検出用圧力センサ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "過負荷警報装置",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "水準器",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "クレーンモード",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "外部表示灯",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "格納型フック",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "安全装置",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "センサ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ブーム",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "アーム",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-13.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "バケット",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-10.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ブームシリンダ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-10.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "アームシリンダ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-10.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "バケットシリンダ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-10.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "ブーム",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-10.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "アーム",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-10.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "バケット",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-10.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "シリンダ",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-shovel-excavator\\img\\figure-2-10.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "本体",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-schedule-overview\\img\\cost-duration-curve.svg",
+      "pattern": "P5-wide-viewbox",
+      "severity": "MEDIUM",
+      "detail": "viewBox 幅 420px > 400px（モバイル視認性）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-port-regulations\\img\\figure-7-6.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（優先）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-port-regulations\\img\\figure-7-6.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "待機船",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-port-regulations\\img\\figure-7-6.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "入港船",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-port-regulations\\img\\figure-7-6.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "（防波堤の外で待機→右側航行）",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-port-regulations\\img\\figure-7-6.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "引船",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    },
+    {
+      "file": ".local\\r2\\posts\\civil-construction-1\\textbook-port-regulations\\img\\figure-7-6.svg",
+      "pattern": "P4-tiny-font",
+      "severity": "LOW",
+      "text": "被えい航物件",
+      "detail": "font-size 10px < 11px（モバイル視認性下限）"
+    }
+  ]
 }

--- a/.local/r2/posts/civil-construction-1/textbook-distance-angle/img/error-cancellation.svg
+++ b/.local/r2/posts/civil-construction-1/textbook-distance-angle/img/error-cancellation.svg
@@ -13,7 +13,7 @@
 
     <!-- Ideal sight (straight up) -->
     <line x1="100" y1="200" x2="100" y2="80" stroke="#8a8a8a" stroke-width="1.5" stroke-dasharray="3 2"/>
-    <text x="108" y="95" font-family="sans-serif" font-size="11" fill="#8a8a8a">理想視準</text>
+    <text x="92" y="95" text-anchor="end" font-family="sans-serif" font-size="11" fill="#8a8a8a">理想視準</text>
 
     <!-- Actual sight (tilted right by error) -->
     <line x1="100" y1="200" x2="130" y2="80" stroke="#b22234" stroke-width="2"/>

--- a/.local/r2/posts/civil-construction-1/textbook-distance-angle/img/error-cancellation.svg
+++ b/.local/r2/posts/civil-construction-1/textbook-distance-angle/img/error-cancellation.svg
@@ -47,6 +47,6 @@
   </g>
 
   <!-- Bottom equation -->
-  <rect x="60" y="248" width="280" height="28" fill="#f5f7fa" stroke="#2e6da4" stroke-width="1"/>
+  <rect x="60" y="248" width="280" height="28" fill="#f5f5f5" stroke="#2e6da4" stroke-width="1"/>
   <text x="200" y="267" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#1a3a5c">平均 = （+e − e）／2 = 0 → 視準軸誤差は消える</text>
 </svg>

--- a/.local/r2/posts/civil-construction-1/textbook-schedule-overview/img/cost-duration-curve.svg
+++ b/.local/r2/posts/civil-construction-1/textbook-schedule-overview/img/cost-duration-curve.svg
@@ -35,5 +35,5 @@
   <text x="220" y="305" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="bold" fill="#3a7d44">最適工期</text>
 
   <!-- 底の注釈 -->
-  <text x="210" y="125" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#3a7d44">（直接＋間接の合計 最小）</text>
+  <text x="210" y="140" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#3a7d44">（直接＋間接の合計 最小）</text>
 </svg>

--- a/.local/r2/posts/pe-comprehensive-management/balance-sheet/img/bs-structure.svg
+++ b/.local/r2/posts/pe-comprehensive-management/balance-sheet/img/bs-structure.svg
@@ -17,14 +17,14 @@
 
   <!-- Right top: 負債 (warn) -->
   <rect x="205" y="60" width="180" height="54" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5"/> <!-- warn-fill / warn -->
-  <text x="295" y="91" text-anchor="middle" font-size="14" font-weight="bold" fill="#6b5015">流動負債</text> <!-- warn deep (legibility) -->
+  <text x="295" y="91" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">流動負債</text> <!-- warn deep (legibility) -->
 
   <rect x="205" y="114" width="180" height="36" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5"/>
-  <text x="295" y="136" text-anchor="middle" font-size="14" font-weight="bold" fill="#6b5015">固定負債</text>
+  <text x="295" y="136" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a3a5c">固定負債</text>
 
   <!-- Right bottom: 純資産 (positive) -->
   <rect x="205" y="150" width="180" height="90" fill="#d0e8d0" stroke="#3a7d44" stroke-width="1.5"/> <!-- positive-fill / positive -->
-  <text x="295" y="199" text-anchor="middle" font-size="14" font-weight="bold" fill="#1e4d27">純資産（自己資本）</text> <!-- positive deep -->
+  <text x="295" y="199" text-anchor="middle" font-size="14" font-weight="bold" fill="#3a7d44">純資産（自己資本）</text> <!-- positive deep -->
 
   <!-- Equation -->
   <text x="200" y="265" text-anchor="middle" font-size="12" fill="#555">資産合計 ＝ 負債合計 ＋ 純資産合計</text>

--- a/.local/r2/posts/pe-comprehensive-management/break-even-point/img/break-even-chart.svg
+++ b/.local/r2/posts/pe-comprehensive-management/break-even-point/img/break-even-chart.svg
@@ -16,7 +16,7 @@
   <line x1="60" y1="170" x2="340" y2="170" stroke="#d7d7d7" stroke-width="1" stroke-dasharray="5,4"/>
 
   <!-- 総費用ライン: (60,170)→(340,110) -->
-  <line x1="60" y1="170" x2="340" y2="110" stroke="#e74c3c" stroke-width="2"/>
+  <line x1="60" y1="170" x2="340" y2="110" stroke="#b22234" stroke-width="2"/>
 
   <!-- 売上高ライン: (60,250)→(340,40) -->
   <line x1="60" y1="250" x2="340" y2="40" stroke="#2e6da4" stroke-width="2.5"/>
@@ -28,14 +28,14 @@
 
   <!-- ライン凡例（右端、十分な間隔） -->
   <text x="343" y="42" fill="#2e6da4" font-size="10" font-weight="bold">売上高</text>
-  <text x="343" y="113" fill="#e74c3c" font-size="10" font-weight="bold">総費用</text>
+  <text x="343" y="113" fill="#b22234" font-size="10" font-weight="bold">総費用</text>
   <text x="343" y="174" fill="#8a8a8a" font-size="10">固定費</text>
 
   <!-- 利益ラベル: BEP右側、売上高線と総費用線の間 -->
   <text x="270" y="108" fill="#2e6da4" font-size="13" font-weight="bold">利益</text>
 
   <!-- 損失ラベル: BEP左側、総費用線と売上高線の間 -->
-  <text x="125" y="178" fill="#e74c3c" font-size="13" font-weight="bold">損失</text>
+  <text x="125" y="178" fill="#b22234" font-size="13" font-weight="bold">損失</text>
 
   <!-- 費用構成ラベル: 総費用線の内訳 -->
   <text x="295" y="147" fill="#8a8a8a" font-size="9">変動費</text>

--- a/.local/r2/posts/pe-comprehensive-management/citizen-participation/img/arnstein-ladder.svg
+++ b/.local/r2/posts/pe-comprehensive-management/citizen-participation/img/arnstein-ladder.svg
@@ -36,31 +36,31 @@
 
   <!-- ============ Rung 5: 懐柔 ============ -->
   <g>
-    <rect x="30" y="215" width="350" height="46" fill="#fff3cd" stroke="#ca8a04" stroke-width="2" rx="6"/>
-    <circle cx="58" cy="238" r="16" fill="#ca8a04"/>
+    <rect x="30" y="215" width="350" height="46" fill="#fff3cd" stroke="#d4a017" stroke-width="2" rx="6"/>
+    <circle cx="58" cy="238" r="16" fill="#d4a017"/>
     <text x="58" y="243" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">5</text>
-    <text x="85" y="243" font-size="14" font-weight="bold" fill="#713f12">懐柔</text>
+    <text x="85" y="243" font-size="14" font-weight="bold" fill="#1a3a5c">懐柔</text>
   </g>
 
   <!-- Rung 4: 協議 -->
   <g>
-    <rect x="30" y="265" width="350" height="46" fill="#fff3cd" stroke="#ca8a04" stroke-width="2" rx="6"/>
-    <circle cx="58" cy="288" r="16" fill="#ca8a04"/>
+    <rect x="30" y="265" width="350" height="46" fill="#fff3cd" stroke="#d4a017" stroke-width="2" rx="6"/>
+    <circle cx="58" cy="288" r="16" fill="#d4a017"/>
     <text x="58" y="293" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">4</text>
-    <text x="85" y="293" font-size="14" font-weight="bold" fill="#713f12">協議</text>
+    <text x="85" y="293" font-size="14" font-weight="bold" fill="#1a3a5c">協議</text>
   </g>
 
   <!-- Rung 3: 情報提供 -->
   <g>
-    <rect x="30" y="315" width="350" height="46" fill="#fff3cd" stroke="#ca8a04" stroke-width="2" rx="6"/>
-    <circle cx="58" cy="338" r="16" fill="#ca8a04"/>
+    <rect x="30" y="315" width="350" height="46" fill="#fff3cd" stroke="#d4a017" stroke-width="2" rx="6"/>
+    <circle cx="58" cy="338" r="16" fill="#d4a017"/>
     <text x="58" y="343" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">3</text>
-    <text x="85" y="343" font-size="14" font-weight="bold" fill="#713f12">情報提供</text>
+    <text x="85" y="343" font-size="14" font-weight="bold" fill="#1a3a5c">情報提供</text>
   </g>
 
   <!-- Category label: 形式的参加 -->
-  <text x="420" y="284" text-anchor="middle" font-size="12" font-weight="bold" fill="#713f12">形式的</text>
-  <text x="420" y="300" text-anchor="middle" font-size="12" font-weight="bold" fill="#713f12">参加</text>
+  <text x="420" y="284" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a3a5c">形式的</text>
+  <text x="420" y="300" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a3a5c">参加</text>
 
   <!-- Divider line -->
   <line x1="30" y1="369" x2="380" y2="369" stroke="#8a8a8a" stroke-width="1" stroke-dasharray="4,3"/>
@@ -70,7 +70,7 @@
     <rect x="30" y="375" width="350" height="46" fill="#f8d7da" stroke="#b22234" stroke-width="2" rx="6"/>
     <circle cx="58" cy="398" r="16" fill="#b22234"/>
     <text x="58" y="403" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">2</text>
-    <text x="85" y="403" font-size="14" font-weight="bold" fill="#7f1d1d">セラピー</text>
+    <text x="85" y="403" font-size="14" font-weight="bold" fill="#b22234">セラピー</text>
   </g>
 
   <!-- Rung 1: 操作 -->
@@ -78,12 +78,12 @@
     <rect x="30" y="425" width="350" height="46" fill="#f8d7da" stroke="#b22234" stroke-width="2" rx="6"/>
     <circle cx="58" cy="448" r="16" fill="#b22234"/>
     <text x="58" y="453" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">1</text>
-    <text x="85" y="453" font-size="14" font-weight="bold" fill="#7f1d1d">操作</text>
+    <text x="85" y="453" font-size="14" font-weight="bold" fill="#b22234">操作</text>
   </g>
 
   <!-- Category label: 非参加 -->
-  <text x="420" y="420" text-anchor="middle" font-size="12" font-weight="bold" fill="#7f1d1d">非</text>
-  <text x="420" y="436" text-anchor="middle" font-size="12" font-weight="bold" fill="#7f1d1d">参加</text>
+  <text x="420" y="420" text-anchor="middle" font-size="12" font-weight="bold" fill="#b22234">非</text>
+  <text x="420" y="436" text-anchor="middle" font-size="12" font-weight="bold" fill="#b22234">参加</text>
 
   <!-- Source note -->
   <text x="230" y="495" text-anchor="middle" font-size="10" fill="#8a8a8a">Arnstein (1969) "A Ladder of Citizen Participation" より</text>

--- a/.local/r2/posts/pe-comprehensive-management/correlation-analysis/img/regression-line.svg
+++ b/.local/r2/posts/pe-comprehensive-management/correlation-analysis/img/regression-line.svg
@@ -25,8 +25,6 @@
     <line x1="160" y1="80"  x2="160" y2="93"  stroke="#8a8a8a" stroke-width="1" stroke-dasharray="3,2"/>
     <!-- ラベル -->
     <text x="110" y="122" fill="#555" font-size="9">u</text>
-    <text x="60"  y="188" text-anchor="middle" fill="#555" font-size="9">プロットとモデル関数の</text>
-    <text x="150" y="188" text-anchor="middle" fill="#555" font-size="9">二乗の和を最小にする</text>
-    <text x="220" y="188" text-anchor="middle" fill="#555" font-size="9">f(x)を求める</text>
-    <text x="145" y="197" text-anchor="middle" fill="#555" font-size="9">← 回帰直線 →</text>
+    <text x="140" y="188" text-anchor="middle" fill="#555" font-size="9">プロットとモデル関数の二乗の和を最小にする f(x)</text>
+    <text x="140" y="197" text-anchor="middle" fill="#555" font-size="9">← 回帰直線 →</text>
   </svg>

--- a/.local/r2/posts/pe-comprehensive-management/design-thinking/img/5-steps-iterative-flow.svg
+++ b/.local/r2/posts/pe-comprehensive-management/design-thinking/img/5-steps-iterative-flow.svg
@@ -1,7 +1,7 @@
 <svg width="600" height="200" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 200" font-family="sans-serif" style="max-width:600px;width:100%" role="img" aria-label="デザイン思考の5ステップとイテレーティブフロー">
   <defs>
     <marker id="arrowSolid" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M0,0 L10,5 L0,10 Z" fill="#374151"/>
+      <path d="M0,0 L10,5 L0,10 Z" fill="#555"/>
     </marker>
     <marker id="arrowDash" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0,0 L10,5 L0,10 Z" fill="#8a8a8a"/>
@@ -30,22 +30,22 @@
     <text x="425" y="142" text-anchor="middle" font-size="11" fill="#2e6da4">Prototype</text>
   </g>
   <g>
-    <rect x="495" y="95" width="100" height="65" rx="8" fill="#fff3cd" stroke="#d97706" stroke-width="2"/>
-    <text x="545" y="120" text-anchor="middle" font-size="15" font-weight="bold" fill="#78350f">⑤ 検証</text>
-    <text x="545" y="142" text-anchor="middle" font-size="11" fill="#92400e">Test</text>
+    <rect x="495" y="95" width="100" height="65" rx="8" fill="#fff3cd" stroke="#d4a017" stroke-width="2"/>
+    <text x="545" y="120" text-anchor="middle" font-size="15" font-weight="bold" fill="#1a3a5c">⑤ 検証</text>
+    <text x="545" y="142" text-anchor="middle" font-size="11" fill="#d4a017">Test</text>
   </g>
 
   <!-- Forward solid arrows -->
-  <line x1="115" y1="127.5" x2="133" y2="127.5" stroke="#374151" stroke-width="2" marker-end="url(#arrowSolid)"/>
-  <line x1="235" y1="127.5" x2="253" y2="127.5" stroke="#374151" stroke-width="2" marker-end="url(#arrowSolid)"/>
-  <line x1="355" y1="127.5" x2="373" y2="127.5" stroke="#374151" stroke-width="2" marker-end="url(#arrowSolid)"/>
-  <line x1="475" y1="127.5" x2="493" y2="127.5" stroke="#374151" stroke-width="2" marker-end="url(#arrowSolid)"/>
+  <line x1="115" y1="127.5" x2="133" y2="127.5" stroke="#555" stroke-width="2" marker-end="url(#arrowSolid)"/>
+  <line x1="235" y1="127.5" x2="253" y2="127.5" stroke="#555" stroke-width="2" marker-end="url(#arrowSolid)"/>
+  <line x1="355" y1="127.5" x2="373" y2="127.5" stroke="#555" stroke-width="2" marker-end="url(#arrowSolid)"/>
+  <line x1="475" y1="127.5" x2="493" y2="127.5" stroke="#555" stroke-width="2" marker-end="url(#arrowSolid)"/>
 
   <!-- Dashed return arrow: from Test top, curving up and over, to Empathize top -->
   <path d="M 545 95 C 545 20, 65 20, 65 93" fill="none" stroke="#8a8a8a" stroke-width="2" stroke-dasharray="6,4" marker-end="url(#arrowDash)"/>
 
   <!-- Label for return arrow -->
-  <text x="305" y="30" text-anchor="middle" font-size="12" font-weight="bold" fill="#4b5563">問題発見時は前段階に戻る（反復）</text>
+  <text x="305" y="30" text-anchor="middle" font-size="12" font-weight="bold" fill="#555">問題発見時は前段階に戻る（反復）</text>
 
   <!-- Caption below boxes -->
   <text x="300" y="185" text-anchor="middle" font-size="11" fill="#555">5段階は直線ではなく、検証での気づきを前段階に還流する反復プロセス</text>

--- a/.local/r2/posts/pe-comprehensive-management/environmental-impact-assessment/img/eia-target-categories.svg
+++ b/.local/r2/posts/pe-comprehensive-management/environmental-impact-assessment/img/eia-target-categories.svg
@@ -17,32 +17,32 @@
   <text x="35" y="196" font-size="11" fill="#555">4. 飛行場</text>
 
   <!-- 河川・水 -->
-  <rect x="180" y="56" width="150" height="160" fill="#e3f0f7" stroke="#2b6cb0" stroke-width="1.5" rx="4"/>
-  <text x="255" y="78" text-anchor="middle" font-size="13" font-weight="bold" fill="#2b6cb0">河川・水</text>
-  <line x1="200" y1="88" x2="310" y2="88" stroke="#2b6cb0" stroke-width="0.8"/>
+  <rect x="180" y="56" width="150" height="160" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5" rx="4"/>
+  <text x="255" y="78" text-anchor="middle" font-size="13" font-weight="bold" fill="#2e6da4">河川・水</text>
+  <line x1="200" y1="88" x2="310" y2="88" stroke="#2e6da4" stroke-width="0.8"/>
   <text x="195" y="112" font-size="11" fill="#555">2. 河川</text>
   <text x="205" y="130" font-size="10" fill="#555">（ダム・堰・放水路</text>
   <text x="205" y="146" font-size="10" fill="#555">　湖沼開発）</text>
   <text x="195" y="176" font-size="11" fill="#555">7. 埋立て・干拓</text>
 
   <!-- エネルギー -->
-  <rect x="340" y="56" width="150" height="160" fill="#fdf0e4" stroke="#d4a017" stroke-width="1.5" rx="4"/>
+  <rect x="340" y="56" width="150" height="160" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5" rx="4"/>
   <text x="415" y="78" text-anchor="middle" font-size="13" font-weight="bold" fill="#d4a017">エネルギー</text>
   <line x1="360" y1="88" x2="470" y2="88" stroke="#d4a017" stroke-width="0.8"/>
   <text x="355" y="112" font-size="11" fill="#555">5. 発電所</text>
   <text x="365" y="130" font-size="10" fill="#555">水力・火力・地熱</text>
   <text x="365" y="146" font-size="10" fill="#555">原子力</text>
   <text x="365" y="162" font-size="10" fill="#555">太陽電池・風力</text>
-  <text x="355" y="196" font-size="10" fill="#555555" font-style="italic">（原子力はすべて）</text>
+  <text x="355" y="196" font-size="10" fill="#555" font-style="italic">（原子力はすべて）</text>
 
   <!-- 廃棄物 -->
-  <rect x="500" y="56" width="120" height="160" fill="#f5f5f5" stroke="#555555" stroke-width="1.5" rx="4"/>
+  <rect x="500" y="56" width="120" height="160" fill="#f5f5f5" stroke="#555" stroke-width="1.5" rx="4"/>
   <text x="560" y="78" text-anchor="middle" font-size="13" font-weight="bold" fill="#222">廃棄物</text>
-  <line x1="515" y1="88" x2="605" y2="88" stroke="#555555" stroke-width="0.8"/>
+  <line x1="515" y1="88" x2="605" y2="88" stroke="#555" stroke-width="0.8"/>
   <text x="512" y="115" font-size="11" fill="#555">6. 廃棄物</text>
   <text x="522" y="133" font-size="10" fill="#555">最終処分場</text>
-  <text x="512" y="165" font-size="10" fill="#555555" font-style="italic">30ha 以上が</text>
-  <text x="512" y="181" font-size="10" fill="#555555" font-style="italic">第一種事業</text>
+  <text x="512" y="165" font-size="10" fill="#555" font-style="italic">30ha 以上が</text>
+  <text x="512" y="181" font-size="10" fill="#555" font-style="italic">第一種事業</text>
 
   <!-- Row 2: full-width 面的開発 -->
   <rect x="20" y="236" width="600" height="160" fill="#d0e8d0" stroke="#3a7d44" stroke-width="1.5" rx="4"/>
@@ -59,7 +59,7 @@
   <text x="330" y="322" font-size="12" fill="#555">12. 流通業務団地造成事業</text>
   <text x="330" y="350" font-size="12" fill="#555">13. 宅地の造成の事業</text>
 
-  <text x="320" y="380" text-anchor="middle" font-size="10" fill="#555555" font-style="italic">※ 宅地には工場用地なども含む</text>
+  <text x="320" y="380" text-anchor="middle" font-size="10" fill="#555" font-style="italic">※ 宅地には工場用地なども含む</text>
 
   <!-- Footer legend -->
   <text x="320" y="420" text-anchor="middle" font-size="10" fill="#8a8a8a">第一種/第二種の規模基準（面積・延長・出力等）は環境省パンフレット参照</text>

--- a/.local/r2/posts/pe-comprehensive-management/exam-application-guide/img/figure-2-1.svg
+++ b/.local/r2/posts/pe-comprehensive-management/exam-application-guide/img/figure-2-1.svg
@@ -13,17 +13,17 @@
 
   <!-- 業務経歴 sub-box -->
   <rect x="185" y="30" width="155" height="55" rx="6" fill="#d0e8d0" stroke="#3a7d44" stroke-width="1.5"/>
-  <text x="262" y="53" text-anchor="middle" font-size="13" font-weight="bold" fill="#1a5a1a">業務経歴</text>
+  <text x="262" y="53" text-anchor="middle" font-size="13" font-weight="bold" fill="#3a7d44">業務経歴</text>
   <text x="262" y="73" text-anchor="middle" font-size="11" fill="#3a7d44">（業務内容の概要）</text>
 
   <!-- 業務内容の詳細 sub-box -->
   <rect x="185" y="140" width="155" height="55" rx="6" fill="#d0e8d0" stroke="#3a7d44" stroke-width="1.5"/>
-  <text x="262" y="163" text-anchor="middle" font-size="13" font-weight="bold" fill="#1a5a1a">業務内容の詳細</text>
+  <text x="262" y="163" text-anchor="middle" font-size="13" font-weight="bold" fill="#3a7d44">業務内容の詳細</text>
   <text x="262" y="183" text-anchor="middle" font-size="11" fill="#3a7d44">（論文の骨子）</text>
 
   <!-- 経験のアピール sub-box -->
   <rect x="185" y="250" width="155" height="55" rx="6" fill="#d0e8d0" stroke="#3a7d44" stroke-width="1.5"/>
-  <text x="262" y="278" text-anchor="middle" font-size="13" font-weight="bold" fill="#1a5a1a">経験のアピール</text>
+  <text x="262" y="278" text-anchor="middle" font-size="13" font-weight="bold" fill="#3a7d44">経験のアピール</text>
   <text x="262" y="296" text-anchor="middle" font-size="11" fill="#3a7d44">（成長ストーリー）</text>
 
   <!-- arrows from 出願 to sub-boxes -->
@@ -33,22 +33,22 @@
 
   <!-- 筆記試験 box -->
   <rect x="390" y="30" width="150" height="195" rx="8" fill="#fff3cd" stroke="#d4a017" stroke-width="2"/>
-  <text x="465" y="58" text-anchor="middle" font-size="15" font-weight="bold" fill="#5a4a00">筆記試験</text>
+  <text x="465" y="58" text-anchor="middle" font-size="15" font-weight="bold" fill="#1a3a5c">筆記試験</text>
   <text x="465" y="78" text-anchor="middle" font-size="11" fill="#d4a017">（記述式問題）</text>
   <!-- inside: 設問1 -->
   <rect x="405" y="90" width="120" height="40" rx="4" fill="#fff3cd" stroke="#d4a017" stroke-width="1"/>
-  <text x="465" y="115" text-anchor="middle" font-size="12" fill="#3a2a00">設問1（必須）</text>
+  <text x="465" y="115" text-anchor="middle" font-size="12" fill="#1a3a5c">設問1（必須）</text>
   <!-- inside: 設問2以降 -->
   <rect x="405" y="140" width="120" height="70" rx="4" fill="#fff3cd" stroke="#d4a017" stroke-width="1"/>
-  <text x="465" y="170" text-anchor="middle" font-size="12" fill="#3a2a00">設問2以降</text>
-  <text x="465" y="190" text-anchor="middle" font-size="11" fill="#5a4a00">（択一含む）</text>
+  <text x="465" y="170" text-anchor="middle" font-size="12" fill="#1a3a5c">設問2以降</text>
+  <text x="465" y="190" text-anchor="middle" font-size="11" fill="#1a3a5c">（択一含む）</text>
 
   <!-- 口頭試験 box -->
-  <rect x="590" y="100" width="110" height="140" rx="8" fill="#f8d7da" stroke="#a94442" stroke-width="2"/>
-  <text x="645" y="155" text-anchor="middle" font-size="15" font-weight="bold" fill="#6b1c1c">口頭試験</text>
-  <text x="645" y="178" text-anchor="middle" font-size="11" fill="#8b3c3c">経歴・詳細を</text>
-  <text x="645" y="195" text-anchor="middle" font-size="11" fill="#8b3c3c">深掘りされる</text>
-  <text x="645" y="225" text-anchor="middle" font-size="11" font-weight="bold" fill="#a94442">最重要</text>
+  <rect x="590" y="100" width="110" height="140" rx="8" fill="#f8d7da" stroke="#b22234" stroke-width="2"/>
+  <text x="645" y="155" text-anchor="middle" font-size="15" font-weight="bold" fill="#b22234">口頭試験</text>
+  <text x="645" y="178" text-anchor="middle" font-size="11" fill="#b22234">経歴・詳細を</text>
+  <text x="645" y="195" text-anchor="middle" font-size="11" fill="#b22234">深掘りされる</text>
+  <text x="645" y="225" text-anchor="middle" font-size="11" font-weight="bold" fill="#b22234">最重要</text>
 
   <!-- arrows from sub-boxes to 筆記試験 -->
   <line x1="340" y1="57" x2="388" y2="110" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
@@ -59,11 +59,11 @@
   <line x1="540" y1="170" x2="588" y2="170" stroke="#555" stroke-width="2" marker-end="url(#arr)"/>
 
   <!-- dashed arrow from 業務経歴 directly to 口頭試験 -->
-  <path d="M340,57 Q520,10 640,98" fill="none" stroke="#a94442" stroke-width="1.5" stroke-dasharray="6,3" marker-end="url(#arr)"/>
-  <text x="500" y="22" text-anchor="middle" font-size="10" fill="#a94442">経歴票がそのまま質問ベースに</text>
+  <path d="M340,57 Q520,10 640,98" fill="none" stroke="#b22234" stroke-width="1.5" stroke-dasharray="6,3" marker-end="url(#arr)"/>
+  <text x="500" y="22" text-anchor="middle" font-size="10" fill="#b22234">経歴票がそのまま質問ベースに</text>
 
   <!-- dashed arrow from 業務内容の詳細 to 口頭試験 -->
-  <path d="M340,167 Q530,140 640,140" fill="none" stroke="#a94442" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <path d="M340,167 Q530,140 640,140" fill="none" stroke="#b22234" stroke-width="1.5" stroke-dasharray="6,3"/>
 
   <!-- bottom label -->
   <text x="360" y="330" text-anchor="middle" font-size="12" fill="#222" font-weight="bold">図表2.1　出願と筆記試験・口頭試験との関連性</text>

--- a/.local/r2/posts/pe-comprehensive-management/exam-application-guide/img/figure-2-4.svg
+++ b/.local/r2/posts/pe-comprehensive-management/exam-application-guide/img/figure-2-4.svg
@@ -11,38 +11,38 @@
 
   <!-- Row 1: Two boxes side by side -->
   <!-- Box 1: 総監の背景を踏まえた業務 -->
-  <rect x="20" y="75" width="265" height="60" rx="6" fill="#d0e8f8" stroke="#2e6da4" stroke-width="1.5"/>
-  <text x="152" y="98" text-anchor="middle" font-size="13" fill="#1a3a6b" font-weight="bold">総監の背景を踏まえた業務</text>
+  <rect x="20" y="75" width="265" height="60" rx="6" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5"/>
+  <text x="152" y="98" text-anchor="middle" font-size="13" fill="#1a3a5c" font-weight="bold">総監の背景を踏まえた業務</text>
   <text x="152" y="118" text-anchor="middle" font-size="11" fill="#2e6da4">5つの管理の視点で記述した業務内容</text>
 
   <!-- Box 2: 最重点管理項目 -->
-  <rect x="315" y="75" width="265" height="60" rx="6" fill="#fde8cc" stroke="#e07820" stroke-width="1.5"/>
-  <text x="447" y="98" text-anchor="middle" font-size="13" fill="#7a3a00" font-weight="bold">最重点管理項目</text>
-  <text x="447" y="118" text-anchor="middle" font-size="11" fill="#a05a20">5つの管理の中で最も重視した管理</text>
+  <rect x="315" y="75" width="265" height="60" rx="6" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5"/>
+  <text x="447" y="98" text-anchor="middle" font-size="13" fill="#1a3a5c" font-weight="bold">最重点管理項目</text>
+  <text x="447" y="118" text-anchor="middle" font-size="11" fill="#d4a017">5つの管理の中で最も重視した管理</text>
 
   <!-- Arrows down from Row 1 -->
   <line x1="152" y1="135" x2="152" y2="155" stroke="#2e6da4" stroke-width="2" marker-end="url(#arr4)"/>
   <line x1="447" y1="135" x2="447" y2="155" stroke="#2e6da4" stroke-width="2" marker-end="url(#arr4)"/>
 
   <!-- Row 2: トレードオフ (wide) -->
-  <rect x="60" y="158" width="480" height="55" rx="6" fill="#e8f5e8" stroke="#3a7d44" stroke-width="1.5"/>
-  <text x="300" y="182" text-anchor="middle" font-size="13" fill="#1a4a1a" font-weight="bold">管理間のトレードオフ</text>
+  <rect x="60" y="158" width="480" height="55" rx="6" fill="#d0e8d0" stroke="#3a7d44" stroke-width="1.5"/>
+  <text x="300" y="182" text-anchor="middle" font-size="13" fill="#1a3a5c" font-weight="bold">管理間のトレードオフ</text>
   <text x="300" y="202" text-anchor="middle" font-size="11" fill="#3a7d44">5つの管理のうち、2つの管理間の対立・調整（経済性管理同士は除外）</text>
 
   <!-- Arrow down -->
   <line x1="300" y1="213" x2="300" y2="238" stroke="#2e6da4" stroke-width="2" marker-end="url(#arr4)"/>
 
   <!-- Row 3: 改善案・解決策 -->
-  <rect x="60" y="240" width="480" height="50" rx="6" fill="#f0e8f8" stroke="#7030a0" stroke-width="1.5"/>
-  <text x="300" y="262" text-anchor="middle" font-size="13" fill="#4a1a6a" font-weight="bold">改善案・解決策</text>
-  <text x="300" y="280" text-anchor="middle" font-size="11" fill="#6a3a8a">トレードオフの調整方法、管理技術の適用</text>
+  <rect x="60" y="240" width="480" height="50" rx="6" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5"/>
+  <text x="300" y="262" text-anchor="middle" font-size="13" fill="#1a3a5c" font-weight="bold">改善案・解決策</text>
+  <text x="300" y="280" text-anchor="middle" font-size="11" fill="#2e6da4">トレードオフの調整方法、管理技術の適用</text>
 
   <!-- Arrow down -->
   <line x1="300" y1="290" x2="300" y2="310" stroke="#2e6da4" stroke-width="2" marker-end="url(#arr4)"/>
 
   <!-- Row 4: 成果 (highlighted) -->
-  <rect x="40" y="313" width="520" height="50" rx="6" fill="#fff3cd" stroke="#b08000" stroke-width="2"/>
-  <text x="300" y="335" text-anchor="middle" font-size="13" fill="#5a4000" font-weight="bold">成果</text>
+  <rect x="40" y="313" width="520" height="50" rx="6" fill="#fff3cd" stroke="#d4a017" stroke-width="2"/>
+  <text x="300" y="335" text-anchor="middle" font-size="13" fill="#1a3a5c" font-weight="bold">成果</text>
   <text x="300" y="353" text-anchor="middle" font-size="11" fill="#d4a017">プロジェクト完遂・効果的な仕組みの構築・担当技術者のスキル向上 等</text>
 
   <!-- Side note -->

--- a/.local/r2/posts/pe-comprehensive-management/four-e-countermeasures/img/four-e-overview.svg
+++ b/.local/r2/posts/pe-comprehensive-management/four-e-countermeasures/img/four-e-overview.svg
@@ -3,7 +3,7 @@
   <desc id="desc4e">Education(教育)・Engineering(技術)・Enforcement(徹底)・Example(模範)の4つの観点を2×2グリッドで配置した図。各観点はカード形式で表示され、英名・日本語訳・具体例を含む。</desc>
 
   <!-- Title -->
-  <text x="210" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#1e293b">事故の4E対策</text>
+  <text x="210" y="22" text-anchor="middle" font-size="16" font-weight="bold" fill="#222">事故の4E対策</text>
 
   <!-- Card 1: Education (top-left) -->
   <rect x="10" y="40" width="200" height="150" rx="10" fill="#e8f0fe" stroke="#2e6da4" stroke-width="2"/>
@@ -11,44 +11,44 @@
   <text x="42" y="83" text-anchor="middle" font-size="24" font-weight="bold" fill="#ffffff">E</text>
   <text x="72" y="73" font-size="16" font-weight="bold" fill="#1a3a5c">Education</text>
   <text x="72" y="91" font-size="13" fill="#1a3a5c">教育</text>
-  <text x="22" y="122" font-size="12" font-weight="bold" fill="#334155">安全教育・訓練の実施</text>
-  <text x="22" y="144" font-size="11" fill="#475569">・新人教育・KYT</text>
-  <text x="22" y="162" font-size="11" fill="#475569">・資格取得支援</text>
-  <text x="22" y="180" font-size="11" fill="#475569">・危険予知活動</text>
+  <text x="22" y="122" font-size="12" font-weight="bold" fill="#555">安全教育・訓練の実施</text>
+  <text x="22" y="144" font-size="11" fill="#555">・新人教育・KYT</text>
+  <text x="22" y="162" font-size="11" fill="#555">・資格取得支援</text>
+  <text x="22" y="180" font-size="11" fill="#555">・危険予知活動</text>
 
   <!-- Card 2: Engineering (top-right) -->
-  <rect x="210" y="40" width="200" height="150" rx="10" fill="#d1fae5" stroke="#3a7d44" stroke-width="2"/>
+  <rect x="210" y="40" width="200" height="150" rx="10" fill="#d0e8d0" stroke="#3a7d44" stroke-width="2"/>
   <rect x="222" y="55" width="40" height="40" rx="6" fill="#3a7d44"/>
   <text x="242" y="83" text-anchor="middle" font-size="24" font-weight="bold" fill="#ffffff">E</text>
   <text x="272" y="73" font-size="16" font-weight="bold" fill="#3a7d44">Engineering</text>
   <text x="272" y="91" font-size="13" fill="#3a7d44">技術</text>
-  <text x="222" y="122" font-size="12" font-weight="bold" fill="#334155">設備・技術的対策</text>
-  <text x="222" y="144" font-size="11" fill="#475569">・安全装置の設置</text>
-  <text x="222" y="162" font-size="11" fill="#475569">・作業環境の改善</text>
-  <text x="222" y="180" font-size="11" fill="#475569">・本質安全設計</text>
+  <text x="222" y="122" font-size="12" font-weight="bold" fill="#555">設備・技術的対策</text>
+  <text x="222" y="144" font-size="11" fill="#555">・安全装置の設置</text>
+  <text x="222" y="162" font-size="11" fill="#555">・作業環境の改善</text>
+  <text x="222" y="180" font-size="11" fill="#555">・本質安全設計</text>
 
   <!-- Card 3: Enforcement (bottom-left) -->
-  <rect x="10" y="200" width="200" height="150" rx="10" fill="#fed7aa" stroke="#b22234" stroke-width="2"/>
+  <rect x="10" y="200" width="200" height="150" rx="10" fill="#fff3cd" stroke="#b22234" stroke-width="2"/>
   <rect x="22" y="215" width="40" height="40" rx="6" fill="#f8d7da" stroke="#b22234" stroke-width="2"/>
   <text x="42" y="243" text-anchor="middle" font-size="24" font-weight="bold" fill="#b22234">E</text>
-  <text x="72" y="233" font-size="16" font-weight="bold" fill="#7c2d12">Enforcement</text>
-  <text x="72" y="251" font-size="13" fill="#7c2d12">徹底</text>
-  <text x="22" y="282" font-size="12" font-weight="bold" fill="#334155">規則遵守と管理強化</text>
-  <text x="22" y="304" font-size="11" fill="#475569">・安全規則の制定</text>
-  <text x="22" y="322" font-size="11" fill="#475569">・安全パトロール</text>
-  <text x="22" y="340" font-size="11" fill="#475569">・違反時の指導</text>
+  <text x="72" y="233" font-size="16" font-weight="bold" fill="#1a3a5c">Enforcement</text>
+  <text x="72" y="251" font-size="13" fill="#1a3a5c">徹底</text>
+  <text x="22" y="282" font-size="12" font-weight="bold" fill="#555">規則遵守と管理強化</text>
+  <text x="22" y="304" font-size="11" fill="#555">・安全規則の制定</text>
+  <text x="22" y="322" font-size="11" fill="#555">・安全パトロール</text>
+  <text x="22" y="340" font-size="11" fill="#555">・違反時の指導</text>
 
   <!-- Card 4: Example (bottom-right) -->
-  <rect x="210" y="200" width="200" height="150" rx="10" fill="#fce7f3" stroke="#db2777" stroke-width="2"/>
-  <rect x="222" y="215" width="40" height="40" rx="6" fill="#db2777"/>
-  <text x="242" y="243" text-anchor="middle" font-size="24" font-weight="bold" fill="#ffffff">E</text>
-  <text x="272" y="233" font-size="16" font-weight="bold" fill="#831843">Example</text>
-  <text x="272" y="251" font-size="13" fill="#831843">模範</text>
-  <text x="222" y="282" font-size="12" font-weight="bold" fill="#334155">管理者の率先垂範</text>
-  <text x="222" y="304" font-size="11" fill="#475569">・管理者自身の</text>
-  <text x="222" y="322" font-size="11" fill="#475569">　安全行動の実践</text>
-  <text x="222" y="340" font-size="11" fill="#475569">・組織風土の醸成</text>
+  <rect x="210" y="200" width="200" height="150" rx="10" fill="#f8d7da" stroke="#b22234" stroke-width="2"/>
+  <rect x="222" y="215" width="40" height="40" rx="6" fill="#fff" stroke="#b22234" stroke-width="2"/>
+  <text x="242" y="243" text-anchor="middle" font-size="24" font-weight="bold" fill="#b22234">E</text>
+  <text x="272" y="233" font-size="16" font-weight="bold" fill="#1a3a5c">Example</text>
+  <text x="272" y="251" font-size="13" fill="#1a3a5c">模範</text>
+  <text x="222" y="282" font-size="12" font-weight="bold" fill="#555">管理者の率先垂範</text>
+  <text x="222" y="304" font-size="11" fill="#555">・管理者自身の</text>
+  <text x="222" y="322" font-size="11" fill="#555">　安全行動の実践</text>
+  <text x="222" y="340" font-size="11" fill="#555">・組織風土の醸成</text>
 
   <!-- Footer note -->
-  <text x="210" y="372" text-anchor="middle" font-size="10" fill="#64748b">4 つの観点を補完的に組み合わせて運用する</text>
+  <text x="210" y="372" text-anchor="middle" font-size="10" fill="#8a8a8a">4 つの観点を補完的に組み合わせて運用する</text>
 </svg>

--- a/.local/r2/posts/pe-comprehensive-management/h24-primary/img/bpt-distribution-known-ii-1-28.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h24-primary/img/bpt-distribution-known-ii-1-28.svg
@@ -10,7 +10,7 @@
   <line x1="60" y1="230" x2="60" y2="20" stroke="#222" stroke-width="1.5" marker-end="url(#arq)"/>
 
   <!-- Y-axis label -->
-  <text x="12" y="130" font-size="10" transform="rotate(-90,12,130)" text-anchor="middle">確率密度</text>
+  <text x="4" y="130" font-size="10" transform="rotate(-90,4,130)" text-anchor="middle">確率密度</text>
   <text x="14" y="85" font-size="9">0.001</text>
   <text x="14" y="105" font-size="9">0.0008</text>
   <text x="14" y="130" font-size="9">0.0006</text>

--- a/.local/r2/posts/pe-comprehensive-management/h24-primary/img/bpt-distribution-known-ii-1-28.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h24-primary/img/bpt-distribution-known-ii-1-28.svg
@@ -37,12 +37,12 @@
   <path d="M 60,228 C 80,226 100,222 120,215 150,204 180,185 210,155 230,125 250,60 270,40 280,35 290,38 310,55 330,90 350,130 370,165 400,195 430,212 460,220 500,226 530,228" fill="none" stroke="#2e6da4" stroke-width="2"/>
 
   <!-- Shade area A: from 2500 to "now" (2530) -->
-  <path d="M 250,60 C 260,45 270,40 280,35 290,38 295,40 298,43 L 298,230 L 250,230 Z" fill="#ffaaaa" fill-opacity="0.5" stroke="none"/>
+  <path d="M 250,60 C 260,45 270,40 280,35 290,38 295,40 298,43 L 298,230 L 250,230 Z" fill="#f8d7da" fill-opacity="0.5" stroke="none"/>
   <text x="268" y="200" font-size="10" fill="#b22234">面積A</text>
 
   <!-- Shade area B: from "now" to right tail -->
-  <path d="M 298,43 C 305,50 310,55 330,90 350,130 370,165 400,195 430,212 460,220 500,226 530,228 L 530,230 L 298,230 Z" fill="#aaaaff" fill-opacity="0.4" stroke="none"/>
-  <text x="390" y="200" font-size="10" fill="#2222cc">面積B</text>
+  <path d="M 298,43 C 305,50 310,55 330,90 350,130 370,165 400,195 430,212 460,220 500,226 530,228 L 530,230 L 298,230 Z" fill="#e8f0fe" fill-opacity="0.4" stroke="none"/>
+  <text x="390" y="200" font-size="10" fill="#2e6da4">面積B</text>
 
   <!-- "Now" marker at 2530 year -->
   <line x1="298" y1="30" x2="298" y2="230" stroke="#b22234" stroke-width="1.5" stroke-dasharray="5,3"/>

--- a/.local/r2/posts/pe-comprehensive-management/h24-primary/img/bpt-distribution-unknown-ii-1-28.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h24-primary/img/bpt-distribution-unknown-ii-1-28.svg
@@ -22,7 +22,7 @@
   <text x="45" y="85"  text-anchor="end" font-size="10">6</text>
   <text x="45" y="63"  text-anchor="end" font-size="10">7</text>
   <text x="45" y="42"  text-anchor="end" font-size="10">8</text>
-  <text x="14" y="130" font-size="9" transform="rotate(-90,14,130)" text-anchor="middle">今後30年以内に地震が発生する確率（%）</text>
+  <text x="6" y="130" font-size="9" transform="rotate(-90,6,130)" text-anchor="middle">今後30年以内に地震が発生する確率（%）</text>
 
   <!-- X-axis labels -->
   <text x="60"  y="235" text-anchor="middle" font-size="10">1000</text>
@@ -39,5 +39,5 @@
   <!-- 2.20% annotation -->
   <line x1="298" y1="30" x2="298" y2="220" stroke="#b22234" stroke-width="1.5" stroke-dasharray="5,3"/>
   <text x="310" y="60" font-size="10" fill="#b22234">2.20%</text>
-  <text x="240" y="235" text-anchor="middle" font-size="10" fill="#b22234">↑現在（2530年）</text>
+  <text x="298" y="260" text-anchor="middle" font-size="10" fill="#b22234">↑現在（2530年）</text>
 </svg>

--- a/.local/r2/posts/pe-comprehensive-management/h24-primary/img/cause-effect-diagram-ii-1-3.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h24-primary/img/cause-effect-diagram-ii-1-3.svg
@@ -2,7 +2,7 @@
   <!-- Spine -->
   <line x1="60" y1="140" x2="510" y2="140" stroke="#222" stroke-width="2.5"/>
   <!-- Head (effect) -->
-  <rect x="510" y="110" width="80" height="60" fill="#fff3cd" stroke="#cc8800" stroke-width="2" rx="5"/>
+  <rect x="510" y="110" width="80" height="60" fill="#fff3cd" stroke="#d4a017" stroke-width="2" rx="5"/>
   <text x="550" y="138" text-anchor="middle" font-weight="bold" font-size="12">結果</text>
   <text x="550" y="155" text-anchor="middle" font-size="10">（特性）</text>
   <!-- Arrow to head -->

--- a/.local/r2/posts/pe-comprehensive-management/h24-primary/img/eia-procedure-ii-1-38.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h24-primary/img/eia-procedure-ii-1-38.svg
@@ -44,7 +44,7 @@
   <line x1="115" y1="234" x2="115" y2="256" stroke="#222" stroke-width="1.5" marker-end="url(#arEia)"/>
 
   <!-- Box 5: 準備書 -->
-  <rect x="25" y="256" width="180" height="36" fill="#aad4ff" stroke="#2266aa" stroke-width="2" rx="4"/>
+  <rect x="25" y="256" width="180" height="36" fill="#e8f0fe" stroke="#2e6da4" stroke-width="2" rx="4"/>
   <text x="115" y="276" text-anchor="middle" font-weight="bold">準備書</text>
 
   <!-- Arrow down from 準備書 -->
@@ -75,12 +75,12 @@
   <line x1="115" y1="466" x2="115" y2="488" stroke="#222" stroke-width="1.5" marker-end="url(#arEia)"/>
 
   <!-- Box 9: 事後調査等の実施 -->
-  <rect x="25" y="488" width="180" height="36" fill="#fff3cd" stroke="#ccaa44" stroke-width="1.5" rx="4"/>
+  <rect x="25" y="488" width="180" height="36" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5" rx="4"/>
   <text x="115" y="508" text-anchor="middle">事後調査等の実施</text>
 
   <!-- Right side flow -->
   <!-- 環境影響評価 right boxes -->
-  <rect x="310" y="82" width="220" height="36" fill="#fff3cd" stroke="#cc8844" stroke-width="1.5" rx="4"/>
+  <rect x="310" y="82" width="220" height="36" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5" rx="4"/>
   <text x="420" y="100" text-anchor="middle" font-weight="bold">環境影響評価</text>
   <text x="420" y="113" text-anchor="middle" font-size="9">（環境影響評価の実施）</text>
 

--- a/.local/r2/posts/pe-comprehensive-management/h24-primary/img/flextime-ii-1-11.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h24-primary/img/flextime-ii-1-11.svg
@@ -8,37 +8,37 @@
   <text x="290" y="20" text-anchor="middle" font-weight="bold" font-size="12">変形労働時間制の概要</text>
 
   <!-- Header -->
-  <rect x="10" y="30" width="160" height="35" fill="#e8f0fe" stroke="#4466aa" stroke-width="1.5"/>
+  <rect x="10" y="30" width="160" height="35" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5"/>
   <text x="90" y="52" text-anchor="middle" font-weight="bold">変形期間が1カ月以内</text>
   <rect x="180" y="30" width="100" height="35" fill="#d0e8d0" stroke="#3a7d44" stroke-width="1.5"/>
   <text x="230" y="52" text-anchor="middle" font-weight="bold">例</text>
-  <rect x="290" y="30" width="140" height="35" fill="#fff3cd" stroke="#aaaa44" stroke-width="1.5"/>
+  <rect x="290" y="30" width="140" height="35" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5"/>
   <text x="360" y="44" text-anchor="middle" font-weight="bold">変形期間の日数</text>
   <text x="360" y="58" text-anchor="middle" font-size="10">（法定労働時間の総枠）</text>
-  <rect x="440" y="30" width="130" height="35" fill="#ffccaa" stroke="#aa6644" stroke-width="1.5"/>
+  <rect x="440" y="30" width="130" height="35" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5"/>
   <text x="505" y="44" text-anchor="middle" font-weight="bold">法定労働時間</text>
   <text x="505" y="58" text-anchor="middle" font-size="10">の総枠</text>
 
   <!-- Data rows -->
-  <rect x="10" y="65" width="160" height="40" fill="#e8f0fe" stroke="#aaaacc"/>
+  <rect x="10" y="65" width="160" height="40" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="90" y="90" text-anchor="middle">変形期間が1カ月以内</text>
-  <rect x="180" y="65" width="100" height="40" fill="#d0e8d0" stroke="#aaccaa"/>
+  <rect x="180" y="65" width="100" height="40" fill="#d0e8d0" stroke="#d7d7d7"/>
   <text x="230" y="90" text-anchor="middle">31日</text>
-  <rect x="290" y="65" width="140" height="40" fill="#fff3cd" stroke="#ccccaa"/>
+  <rect x="290" y="65" width="140" height="40" fill="#fff3cd" stroke="#d7d7d7"/>
   <text x="360" y="83" text-anchor="middle">177時間　8分</text>
   <text x="360" y="98" text-anchor="middle" font-size="10">（40時間×31÷7）</text>
-  <rect x="440" y="65" width="130" height="40" fill="#fff3cd" stroke="#ccaaaa"/>
+  <rect x="440" y="65" width="130" height="40" fill="#fff3cd" stroke="#d7d7d7"/>
   <text x="505" y="83" text-anchor="middle">171時間　25分</text>
   <text x="505" y="98" text-anchor="middle" font-size="10">（40時間×31÷7）</text>
 
-  <rect x="10" y="105" width="160" height="40" fill="#e8f0fe" stroke="#aaaacc"/>
+  <rect x="10" y="105" width="160" height="40" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="90" y="130" text-anchor="middle">変形期間が1カ月以内</text>
-  <rect x="180" y="105" width="100" height="40" fill="#d0e8d0" stroke="#aaccaa"/>
+  <rect x="180" y="105" width="100" height="40" fill="#d0e8d0" stroke="#d7d7d7"/>
   <text x="230" y="130" text-anchor="middle">30日</text>
-  <rect x="290" y="105" width="140" height="40" fill="#fff3cd" stroke="#ccccaa"/>
+  <rect x="290" y="105" width="140" height="40" fill="#fff3cd" stroke="#d7d7d7"/>
   <text x="360" y="123" text-anchor="middle">171時間 26分</text>
   <text x="360" y="138" text-anchor="middle" font-size="10">（40時間×30÷7）</text>
-  <rect x="440" y="105" width="130" height="40" fill="#fff3cd" stroke="#ccaaaa"/>
+  <rect x="440" y="105" width="130" height="40" fill="#fff3cd" stroke="#d7d7d7"/>
   <text x="505" y="130" text-anchor="middle">171時間 26分</text>
 
   <!-- Note -->

--- a/.local/r2/posts/pe-comprehensive-management/h24-primary/img/pdpc-diagram-ii-1-3.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h24-primary/img/pdpc-diagram-ii-1-3.svg
@@ -59,6 +59,6 @@
   <line x1="212" y1="260" x2="250" y2="330" stroke="#222" stroke-width="1.5" marker-end="url(#arr5)"/>
   <line x1="312" y1="260" x2="260" y2="330" stroke="#222" stroke-width="1.5" marker-end="url(#arr5)"/>
 
-  <ellipse cx="250" cy="350" rx="70" ry="20" fill="#3a7d44" stroke="#228822" stroke-width="2"/>
+  <ellipse cx="250" cy="350" rx="70" ry="20" fill="#3a7d44" stroke="#3a7d44" stroke-width="2"/>
   <text x="250" y="355" text-anchor="middle" fill="#ffffff" font-weight="bold">ゴール（達成）</text>
 </svg>

--- a/.local/r2/posts/pe-comprehensive-management/h24-primary/img/safety-org-structure-ii-1-29.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h24-primary/img/safety-org-structure-ii-1-29.svg
@@ -24,23 +24,23 @@
   <text x="652" y="65" text-anchor="middle" fill="#ffffff" font-size="8">（金融業、保険業など）</text>
 
   <!-- Row: 区分 -->
-  <rect x="5"   y="68" width="160" height="20" fill="#aaccee" stroke="#d7d7d7"/>
+  <rect x="5"   y="68" width="160" height="20" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="85"  y="82" text-anchor="middle" font-weight="bold">区分</text>
 
-  <rect x="165" y="68" width="180" height="20" fill="#ddeeff" stroke="#d7d7d7"/>
+  <rect x="165" y="68" width="180" height="20" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="255" y="82" text-anchor="middle">100人以上</text>
 
-  <rect x="345" y="68" width="100" height="20" fill="#ddeeff" stroke="#d7d7d7"/>
+  <rect x="345" y="68" width="100" height="20" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="395" y="82" text-anchor="middle">50人以上</text>
 
-  <rect x="445" y="68" width="100" height="20" fill="#ddeeff" stroke="#d7d7d7"/>
+  <rect x="445" y="68" width="100" height="20" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="495" y="82" text-anchor="middle">100人以上</text>
 
-  <rect x="545" y="68" width="215" height="20" fill="#ddeeff" stroke="#d7d7d7"/>
+  <rect x="545" y="68" width="215" height="20" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="652" y="82" text-anchor="middle">1000人以上</text>
 
   <!-- Row: 総括安全衛生管理者 -->
-  <rect x="5"   y="88" width="160" height="45" fill="#eef5ff" stroke="#d7d7d7"/>
+  <rect x="5"   y="88" width="160" height="45" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="85"  y="100" text-anchor="middle" font-weight="bold">総括安全衛生管理者</text>
   <text x="85"  y="112" text-anchor="middle" font-size="8">（安衛法10条、</text>
   <text x="85"  y="123" text-anchor="middle" font-size="8">安衛令2条）</text>
@@ -58,7 +58,7 @@
   <text x="652" y="114" text-anchor="middle">1000人以上</text>
 
   <!-- Row: 安全管理者 -->
-  <rect x="5"   y="133" width="160" height="45" fill="#eef5ff" stroke="#d7d7d7"/>
+  <rect x="5"   y="133" width="160" height="45" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="85"  y="145" text-anchor="middle" font-weight="bold">安全管理者</text>
   <text x="85"  y="157" text-anchor="middle" font-size="8">（安衛法11条、</text>
   <text x="85"  y="168" text-anchor="middle" font-size="8">安衛令3条）</text>
@@ -76,7 +76,7 @@
   <text x="652" y="159" text-anchor="middle">―</text>
 
   <!-- Row: 衛生管理者 -->
-  <rect x="5"   y="178" width="160" height="45" fill="#eef5ff" stroke="#d7d7d7"/>
+  <rect x="5"   y="178" width="160" height="45" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="85"  y="190" text-anchor="middle" font-weight="bold">衛生管理者</text>
   <text x="85"  y="202" text-anchor="middle" font-size="8">（安衛法12条、</text>
   <text x="85"  y="213" text-anchor="middle" font-size="8">安衛令4条）</text>
@@ -94,7 +94,7 @@
   <text x="652" y="204" text-anchor="middle">50人以上</text>
 
   <!-- Row: 産業医 -->
-  <rect x="5"   y="223" width="160" height="45" fill="#eef5ff" stroke="#d7d7d7"/>
+  <rect x="5"   y="223" width="160" height="45" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="85"  y="235" text-anchor="middle" font-weight="bold">産業医</text>
   <text x="85"  y="247" text-anchor="middle" font-size="8">（安衛法13条、</text>
   <text x="85"  y="258" text-anchor="middle" font-size="8">安衛令5条）</text>
@@ -112,7 +112,7 @@
   <text x="652" y="249" text-anchor="middle">50人以上</text>
 
   <!-- Row: 安全委員会 -->
-  <rect x="5"   y="268" width="160" height="45" fill="#eef5ff" stroke="#d7d7d7"/>
+  <rect x="5"   y="268" width="160" height="45" fill="#e8f0fe" stroke="#d7d7d7"/>
   <text x="85"  y="280" text-anchor="middle" font-weight="bold">安全委員会</text>
   <text x="85"  y="292" text-anchor="middle" font-size="8">（安衛法17条、</text>
   <text x="85"  y="303" text-anchor="middle" font-size="8">安衛令8条、安衛令21条）</text>

--- a/.local/r2/posts/pe-comprehensive-management/h24-primary/img/xy-theory-ii-1-9.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h24-primary/img/xy-theory-ii-1-9.svg
@@ -61,8 +61,8 @@
   <!-- Row: 組織構造 -->
   <rect x="10" y="228" width="130" height="50" fill="#f5f5f5" stroke="#555" stroke-width="1"/>
   <text x="75" y="249" text-anchor="middle">組織</text>
-  <text x="75" y="264" text-anchor="middle">（4）発電士の</text>
-  <text x="75" y="270" text-anchor="middle" font-size="9">管理階層は解消</text>
+  <text x="75" y="260" text-anchor="middle" font-size="9">（4）発電士の</text>
+  <text x="75" y="272" text-anchor="middle" font-size="9">管理階層は解消</text>
 
   <rect x="140" y="228" width="250" height="50" fill="#e8f0fe" stroke="#555" stroke-width="1"/>
   <text x="265" y="244" text-anchor="middle" font-size="10">中央集権的な階層型組織</text>

--- a/.local/r2/posts/pe-comprehensive-management/h25-primary/img/fault-tree-i-1-27.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h25-primary/img/fault-tree-i-1-27.svg
@@ -4,7 +4,7 @@
     text { font-family: sans-serif; }
     .event { fill: #e8f0fe; stroke: #2e6da4; stroke-width: 1.5; }
     .gate-and { fill: #e8f0fe; stroke: #2e6da4; stroke-width: 1.5; }
-    .gate-or { fill: #f8d7da; stroke: #633; stroke-width: 1.5; }
+    .gate-or { fill: #f8d7da; stroke: #1a3a5c; stroke-width: 1.5; }
     .basic { fill: #d0e8d0; stroke: #3a7d44; stroke-width: 1.5; }
     .line { stroke: #222; stroke-width: 1.5; fill: none; }
     .label { font-size: 11px; fill: #222; }

--- a/.local/r2/posts/pe-comprehensive-management/h30-secondary/img/figure-4-03.svg
+++ b/.local/r2/posts/pe-comprehensive-management/h30-secondary/img/figure-4-03.svg
@@ -6,32 +6,32 @@
   <text x="280" y="178" text-anchor="middle" fill="#1a3a5c" font-size="12">様々な課題</text>
   <!-- Surrounding boxes -->
   <!-- Top -->
-  <rect x="200" y="10" width="160" height="45" rx="6" fill="#cde0f5" stroke="#2e6da4" stroke-width="1.5"/>
+  <rect x="200" y="10" width="160" height="45" rx="6" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5"/>
   <text x="280" y="30" text-anchor="middle" fill="#1a3a5c" font-size="12">労働生産性の向上</text>
   <text x="280" y="47" text-anchor="middle" fill="#1a3a5c" font-size="11">女性や高齢者の労働参加の促進</text>
   <line x1="280" y1="57" x2="280" y2="118" stroke="#2e6da4" stroke-width="1.5"/>
   <!-- Left top -->
-  <rect x="10" y="30" width="150" height="40" rx="6" fill="#cde0f5" stroke="#2e6da4" stroke-width="1.5"/>
+  <rect x="10" y="30" width="150" height="40" rx="6" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5"/>
   <text x="85" y="47" text-anchor="middle" fill="#1a3a5c" font-size="12">長時間労働の抑制</text>
   <text x="85" y="62" text-anchor="middle" fill="#1a3a5c" font-size="11">必要人材要件の急速な変化</text>
   <line x1="162" y1="55" x2="200" y2="135" stroke="#2e6da4" stroke-width="1.5"/>
   <!-- Left bottom -->
-  <rect x="10" y="200" width="150" height="40" rx="6" fill="#cde0f5" stroke="#2e6da4" stroke-width="1.5"/>
+  <rect x="10" y="200" width="150" height="40" rx="6" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5"/>
   <text x="85" y="218" text-anchor="middle" fill="#1a3a5c" font-size="12">多様な働き方への対応</text>
   <text x="85" y="233" text-anchor="middle" fill="#1a3a5c" font-size="11">深夜営業を受托できない</text>
   <line x1="162" y1="220" x2="200" y2="165" stroke="#2e6da4" stroke-width="1.5"/>
   <!-- Bottom -->
-  <rect x="200" y="248" width="160" height="40" rx="6" fill="#cde0f5" stroke="#2e6da4" stroke-width="1.5"/>
+  <rect x="200" y="248" width="160" height="40" rx="6" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5"/>
   <text x="280" y="265" text-anchor="middle" fill="#1a3a5c" font-size="12">多様な働き方への対応</text>
   <text x="280" y="282" text-anchor="middle" fill="#1a3a5c" font-size="11">パートタイム労働者賃金の低さ</text>
   <line x1="280" y1="248" x2="280" y2="182" stroke="#2e6da4" stroke-width="1.5"/>
   <!-- Right top -->
-  <rect x="400" y="30" width="150" height="40" rx="6" fill="#cde0f5" stroke="#2e6da4" stroke-width="1.5"/>
+  <rect x="400" y="30" width="150" height="40" rx="6" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5"/>
   <text x="475" y="47" text-anchor="middle" fill="#1a3a5c" font-size="12">就業者数の減少</text>
   <text x="475" y="62" text-anchor="middle" fill="#1a3a5c" font-size="11">年平均労働時間の長さ</text>
   <line x1="400" y1="55" x2="362" y2="135" stroke="#2e6da4" stroke-width="1.5"/>
   <!-- Right bottom -->
-  <rect x="400" y="200" width="150" height="40" rx="6" fill="#cde0f5" stroke="#2e6da4" stroke-width="1.5"/>
+  <rect x="400" y="200" width="150" height="40" rx="6" fill="#e8f0fe" stroke="#2e6da4" stroke-width="1.5"/>
   <text x="475" y="218" text-anchor="middle" fill="#1a3a5c" font-size="12">技術革新に伴う</text>
   <text x="475" y="233" text-anchor="middle" fill="#1a3a5c" font-size="11">雇用の変化</text>
   <line x1="400" y1="218" x2="362" y2="165" stroke="#2e6da4" stroke-width="1.5"/>

--- a/.local/r2/posts/pe-comprehensive-management/iso-26000/img/iso-26000-7-core-subjects.svg
+++ b/.local/r2/posts/pe-comprehensive-management/iso-26000/img/iso-26000-7-core-subjects.svg
@@ -15,18 +15,18 @@
   </g>
 
   <!-- Central: 組織統治 -->
-  <circle cx="290" cy="275" r="70" fill="#2e6da4" stroke="#0f3c99" stroke-width="2"/>
+  <circle cx="290" cy="275" r="70" fill="#2e6da4" stroke="#1a3a5c" stroke-width="2"/>
   <text x="290" y="270" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">組織統治</text>
-  <text x="290" y="292" text-anchor="middle" font-size="10" fill="#d8e3f5">Organizational</text>
-  <text x="290" y="306" text-anchor="middle" font-size="10" fill="#d8e3f5">Governance</text>
+  <text x="290" y="292" text-anchor="middle" font-size="10" fill="#e8f0fe">Organizational</text>
+  <text x="290" y="306" text-anchor="middle" font-size="10" fill="#e8f0fe">Governance</text>
 
   <!-- Top: 人権 -->
-  <circle cx="290" cy="130" r="55" fill="#fef2e9" stroke="#d4a017" stroke-width="1.5"/>
+  <circle cx="290" cy="130" r="55" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5"/>
   <text x="290" y="125" text-anchor="middle" font-size="13" font-weight="bold" fill="#d4a017">人権</text>
   <text x="290" y="146" text-anchor="middle" font-size="10" fill="#555">Human Rights</text>
 
   <!-- Top-right: 労働慣行 -->
-  <circle cx="415" cy="200" r="55" fill="#fef2e9" stroke="#d4a017" stroke-width="1.5"/>
+  <circle cx="415" cy="200" r="55" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5"/>
   <text x="415" y="196" text-anchor="middle" font-size="13" font-weight="bold" fill="#d4a017">労働慣行</text>
   <text x="415" y="216" text-anchor="middle" font-size="9" fill="#555">Labour Practices</text>
 
@@ -47,7 +47,7 @@
   <text x="165" y="366" text-anchor="middle" font-size="9" fill="#555">Consumer Issues</text>
 
   <!-- Top-left: コミュニティ -->
-  <circle cx="165" cy="200" r="55" fill="#fef2e9" stroke="#d4a017" stroke-width="1.5"/>
+  <circle cx="165" cy="200" r="55" fill="#fff3cd" stroke="#d4a017" stroke-width="1.5"/>
   <text x="165" y="190" text-anchor="middle" font-size="12" font-weight="bold" fill="#d4a017">コミュニティ</text>
   <text x="165" y="208" text-anchor="middle" font-size="12" font-weight="bold" fill="#d4a017">への参画</text>
   <text x="165" y="224" text-anchor="middle" font-size="9" fill="#555">Community</text>

--- a/.local/r2/posts/pe-comprehensive-management/linear-programming/img/lp-graphical-method.svg
+++ b/.local/r2/posts/pe-comprehensive-management/linear-programming/img/lp-graphical-method.svg
@@ -20,7 +20,7 @@
   <line x1="60" y1="270" x2="345" y2="270" stroke="#222" stroke-width="1.5" marker-end="url(#lp-ax)"/>
   <line x1="60" y1="270" x2="60" y2="12" stroke="#222" stroke-width="1.5" marker-end="url(#lp-ax)"/>
   <text x="350" y="290" text-anchor="end" fill="#555" font-size="13" font-style="italic">x₁</text>
-  <text x="40" y="20" text-anchor="middle" fill="#555" font-size="13" font-style="italic">x₂</text>
+  <text x="40" y="10" text-anchor="middle" fill="#555" font-size="13" font-style="italic">x₂</text>
   <text x="48" y="283" fill="#555" font-size="10">O</text>
 
   <!-- 目盛り x軸 -->

--- a/.local/r2/posts/pe-comprehensive-management/linear-programming/img/lp-graphical-method.svg
+++ b/.local/r2/posts/pe-comprehensive-management/linear-programming/img/lp-graphical-method.svg
@@ -12,9 +12,9 @@
 
   <!-- 実行可能領域 -->
   <polygon points="60,270 228,270 172,120 60,70"
-           fill="#3498db" fill-opacity="0.12" stroke="#3498db" stroke-width="1.5"/>
-  <text x="120" y="205" fill="#3498db" font-size="11" font-weight="bold">実行可能</text>
-  <text x="125" y="220" fill="#3498db" font-size="11" font-weight="bold">領域</text>
+           fill="#2e6da4" fill-opacity="0.12" stroke="#2e6da4" stroke-width="1.5"/>
+  <text x="120" y="205" fill="#2e6da4" font-size="11" font-weight="bold">実行可能</text>
+  <text x="125" y="220" fill="#2e6da4" font-size="11" font-weight="bold">領域</text>
 
   <!-- 軸 -->
   <line x1="60" y1="270" x2="345" y2="270" stroke="#222" stroke-width="1.5" marker-end="url(#lp-ax)"/>

--- a/.local/r2/posts/pe-comprehensive-management/management-tradeoffs/img/tradeoff-frequency-matrix.svg
+++ b/.local/r2/posts/pe-comprehensive-management/management-tradeoffs/img/tradeoff-frequency-matrix.svg
@@ -7,8 +7,8 @@
     .legend { fill: #1a3a5c; font-family: "Hiragino Sans", "Yu Gothic", sans-serif; }
   </style>
 
-  <line x1="105" y1="60" x2="435" y2="60" stroke="#d1d5db" stroke-width="1"/>
-  <line x1="105" y1="60" x2="105" y2="310" stroke="#d1d5db" stroke-width="1"/>
+  <line x1="105" y1="60" x2="435" y2="60" stroke="#d7d7d7" stroke-width="1"/>
+  <line x1="105" y1="60" x2="105" y2="310" stroke="#d7d7d7" stroke-width="1"/>
 
   <text x="150" y="45" text-anchor="middle" font-size="14" class="label">人的資源</text>
   <text x="230" y="45" text-anchor="middle" font-size="14" class="label">情報</text>
@@ -36,7 +36,7 @@
   <text x="390" y="100" text-anchor="middle" font-size="24" class="cell-main">S</text>
   <text x="390" y="117" text-anchor="middle" font-size="10" class="cell-sub">環境コスト</text>
 
-  <rect x="190" y="125" width="80" height="60" fill="#0284c7" rx="2"/>
+  <rect x="190" y="125" width="80" height="60" fill="#2e6da4" rx="2"/>
   <text x="230" y="160" text-anchor="middle" font-size="24" class="cell-main">B</text>
   <text x="230" y="177" text-anchor="middle" font-size="10" class="cell-sub">人事DX</text>
 
@@ -48,11 +48,11 @@
   <text x="390" y="160" text-anchor="middle" font-size="24" class="cell-main">C</text>
   <text x="390" y="177" text-anchor="middle" font-size="10" class="cell-sub">多様性</text>
 
-  <rect x="270" y="185" width="80" height="60" fill="#0284c7" rx="2"/>
+  <rect x="270" y="185" width="80" height="60" fill="#2e6da4" rx="2"/>
   <text x="310" y="220" text-anchor="middle" font-size="24" class="cell-main">B</text>
   <text x="310" y="237" text-anchor="middle" font-size="10" class="cell-sub">セキュリティ</text>
 
-  <rect x="350" y="185" width="80" height="60" fill="#0284c7" rx="2"/>
+  <rect x="350" y="185" width="80" height="60" fill="#2e6da4" rx="2"/>
   <text x="390" y="220" text-anchor="middle" font-size="24" class="cell-main">B</text>
   <text x="390" y="237" text-anchor="middle" font-size="10" class="cell-sub">倫理</text>
 
@@ -67,7 +67,7 @@
     <rect x="90" y="0" width="22" height="14" fill="#b22234" rx="2"/>
     <text x="118" y="12" font-size="12" class="legend">A 頻出</text>
 
-    <rect x="175" y="0" width="22" height="14" fill="#0284c7" rx="2"/>
+    <rect x="175" y="0" width="22" height="14" fill="#2e6da4" rx="2"/>
     <text x="203" y="12" font-size="12" class="legend">B 中</text>
 
     <rect x="250" y="0" width="22" height="14" fill="#8a8a8a" rx="2"/>

--- a/.local/r2/posts/pe-comprehensive-management/monte-carlo-simulation/img/monte-carlo-s-curve.svg
+++ b/.local/r2/posts/pe-comprehensive-management/monte-carlo-simulation/img/monte-carlo-s-curve.svg
@@ -36,7 +36,7 @@
   <text x="215" y="252" class="t-axis" text-anchor="middle">作業完了日数</text>
 
   <!-- 縦軸ラベル -->
-  <text x="25" y="130" class="t-axis" text-anchor="middle" transform="rotate(-90,25,130)">完了可能性（累積）</text>
+  <text x="18" y="130" class="t-axis" text-anchor="middle" transform="rotate(-90,18,130)">完了可能性（累積）</text>
 
   <!-- S字曲線（累積分布関数 CDF 風） -->
   <path d="M 70 218 Q 110 215 145 195 Q 185 155 215 100 Q 245 60 285 50 Q 320 47 360 45"

--- a/.local/r2/posts/pe-comprehensive-management/pm-theory/img/pm-quadrant.svg
+++ b/.local/r2/posts/pe-comprehensive-management/pm-theory/img/pm-quadrant.svg
@@ -36,7 +36,7 @@
   <line x1="50" y1="160" x2="350" y2="160" stroke="#555" stroke-width="1.5" marker-end="url(#arr-pm)" />
 
   <!-- 軸目盛 -->
-  <text x="195" y="22" class="t-axis-mark" text-anchor="end">高</text>
+  <text x="195" y="38" class="t-axis-mark" text-anchor="end">高</text>
   <text x="195" y="305" class="t-axis-mark" text-anchor="end">低</text>
   <text x="48" y="156" class="t-axis-mark" text-anchor="end">弱</text>
   <text x="352" y="156" class="t-axis-mark" text-anchor="start">強</text>

--- a/.local/r2/posts/pe-comprehensive-management/progress-management/img/banana-curve.svg
+++ b/.local/r2/posts/pe-comprehensive-management/progress-management/img/banana-curve.svg
@@ -1,6 +1,6 @@
 <svg width="440" height="290" viewBox="0 0 440 290" xmlns="http://www.w3.org/2000/svg" font-family="sans-serif" style="max-width:440px;width:100%" role="img" aria-label="バナナ曲線（工程管理曲線）— 上方許容限界・予定工程・下方許容限界と実績曲線の関係">
   <!-- Banana envelope fill -->
-  <path d="M 55 230 C 130 120 230 60 405 50 C 310 50 200 210 55 230 Z" fill="#f2f2f2" opacity="0.8"/>
+  <path d="M 55 230 C 130 120 230 60 405 50 C 310 50 200 210 55 230 Z" fill="#f5f5f5" opacity="0.8"/>
 
   <!-- Axes -->
   <line x1="55" y1="230" x2="415" y2="230" stroke="#222" stroke-width="1.5"/>

--- a/.local/r2/posts/pe-comprehensive-management/progress-management/img/evm-chart.svg
+++ b/.local/r2/posts/pe-comprehensive-management/progress-management/img/evm-chart.svg
@@ -5,7 +5,7 @@
 
   <!-- Axis labels -->
   <text x="22" y="140" font-size="11" fill="#222" transform="rotate(-90 22 140)" text-anchor="middle">コスト</text>
-  <text x="245" y="290" text-anchor="middle" font-size="11" fill="#222">時間</text>
+  <text x="245" y="268" text-anchor="middle" font-size="11" fill="#222">時間</text>
   <text x="60" y="258" text-anchor="middle" font-size="10" fill="#555">着工</text>
   <text x="425" y="258" text-anchor="middle" font-size="10" fill="#555">完了予定</text>
 

--- a/.local/r2/posts/pe-comprehensive-management/system-reliability/img/series-parallel-formulas.svg
+++ b/.local/r2/posts/pe-comprehensive-management/system-reliability/img/series-parallel-formulas.svg
@@ -1,6 +1,6 @@
   <svg width="400" height="120" viewBox="0 0 400 120" xmlns="http://www.w3.org/2000/svg" font-family="sans-serif" font-size="12" style="max-width:400px;width:100%" role="img" aria-label="直列・並列信頼度の計算式">
     <!-- 直列 -->
-    <rect x="10" y="10" width="180" height="100" rx="6" fill="#eef" stroke="#aab"/>
+    <rect x="10" y="10" width="180" height="100" rx="6" fill="#e8f0fe" stroke="#d7d7d7"/>
     <text x="100" y="32" text-anchor="middle" fill="#222" font-weight="bold" font-size="13">直列</text>
     <text x="100" y="55" text-anchor="middle" fill="#222" font-size="12">信頼度 = a₁ × a₂</text>
     <!-- 直列図 -->
@@ -13,7 +13,7 @@
     <line x1="180" y1="80" x2="190" y2="80" stroke="#555" stroke-width="1.5"/>
 
     <!-- 並列 -->
-    <rect x="210" y="10" width="180" height="100" rx="6" fill="#ffe" stroke="#bba"/>
+    <rect x="210" y="10" width="180" height="100" rx="6" fill="#fff3cd" stroke="#d7d7d7"/>
     <text x="300" y="32" text-anchor="middle" fill="#222" font-weight="bold" font-size="13">並列</text>
     <text x="300" y="52" text-anchor="middle" fill="#222" font-size="11">信頼度 = 1－(1－a₁)×(1－a₂)</text>
     <!-- 並列図 -->

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "update-image-refs": "node .claude/scripts/update-mdx-image-refs.mjs",
     "prebuild": "npm run generate-webp && npm run update-image-refs",
     "build": "rm -rf out && npm run refresh-indexes && node scripts/generate-search-index.mjs && next build && node scripts/generate-sitemap.mjs && node scripts/generate-rss.mjs",
+    "audit-svg": "node .claude/skills/quality/check-mdx/scripts/rules/svg/audit.mjs",
     "ogp": "node .claude/skills/conversion/ogp-create/scripts/ogp-create.mjs",
     "start": "next start -p 3020",
     "lint": "eslint src/",


### PR DESCRIPTION
## Summary

Issue #64「[SVG] デザイン一貫性の継続改善」の Tier 2 MEDIUM 違反のうち、**P2-text-overlap (11→0) と P6-color-drift (79→0) を完全解消**。残る Tier 2 は P5-wide-viewbox 50 件（手動リサイズ要、別セッションで対応）。

## audit-svg 数値

| 指標 | Before (2026-04-29) | After | 変化 |
|---|---|---|---|
| 走査 | 117 files | 117 files | - |
| 違反あり | 66 files | 62 files | -6% |
| **HIGH** | 0 | **0** ✓ | 維持 |
| **MEDIUM** | 140 | **50** | **-64%** |
| LOW | 518 | 517 | - |
| P2-text-overlap | 11 | **0** ✓ | -100% |
| P6-color-drift | 79 | **0** ✓ | -100% |
| P5-wide-viewbox | 50 | 50 | 別 PR で対応 |
| P4-tiny-font (LOW) | 518 | 517 | scope 外 |

## 変更内容

### 1. detector 改善（rotation skip in P2）
- `.claude/skills/quality/check-mdx/scripts/rules/svg/detect.mjs`
- P1 と同じく回転テキスト（軸ラベル等）の bbox 重なり判定を skip。textBBox は rotation 非対応のため水平展開した phantom bbox が tick label と偽陽性で重なる問題を解消。

### 2. P2-text-overlap 11 件 → 0（10 ファイル）
| ファイル | 修正内容 |
|---|---|
| evm-chart | 「時間」軸ラベルを formula box 外に移動 |
| pm-quadrant | 「高」を軸タイトル「P 機能」と分離 |
| monte-carlo-s-curve | 回転 y 軸ラベル位置調整 |
| lp-graphical-method | x₂ 軸ラベルを arrow tip より上に |
| xy-theory-ii-1-9 | フォントサイズ統一 + y 位置 |
| bpt-distribution-known/unknown | 回転 y 軸 + 「現在」注釈の y 移動 |
| regression-line | 3 行キャプションを 1 行に集約 |
| cost-duration-curve | 「（直接＋間接の合計 最小）」位置調整 |
| error-cancellation | 「理想視準」を text-anchor=end に |

### 3. P6-color-drift 79 件 → 0（22 ファイル / 157 置換）
- bulk script で allowlist 外 hex を `svg-tokens.json` の 16 色トークンへ統一
- マッピング群:
  - Tailwind palette (`#1e293b`, `#334155`, `#475569`, `#db2777` 等) → brand トークン
  - 中間色 (`#7030a0` 等) → 最近接トークン
  - 淡色 (`#fed7aa`, `#d1fae5`, `#fce7f3`) → fill トークン

### 4. 副次回帰の手動修正
- `four-e-overview.svg` Card 4: `#db2777` → `#b22234` 変換で濃色 fill + 白 E text の P8 違反が誘発されたため、Card 3 と同じパターン（淡 fill + 濃色 stroke + 濃色 text）に変更。

### 5. npm run audit-svg 追加
- 将来の sweep を 1 コマンドで実行可能に（package.json）

## Test plan

- [x] audit-svg HIGH = 0 維持
- [x] audit-svg P2-text-overlap = 0
- [x] audit-svg P6-color-drift = 0
- [x] pre-commit hook が新規 P8 をブロックしないこと（修正済みのため通過）
- [ ] ローカル `npm run dev` で代表 5 ページの SVG 表示確認（PR レビュー時にユーザー目視）
  - https://localhost:3020/docs/pe-comprehensive-management-progress-management
  - https://localhost:3020/docs/pe-comprehensive-management-pm-theory
  - https://localhost:3020/docs/pe-comprehensive-management-monte-carlo-simulation
  - https://localhost:3020/docs/pe-comprehensive-management-four-e-countermeasures
  - https://localhost:3020/docs/pe-comprehensive-management-correlation-analysis

## 残作業（本 PR スコープ外）

- **P5-wide-viewbox 50 件**: viewBox > 400 のリサイズ。手動レイアウトで 5〜10 時間。Issue #64 で継続。
- **P4-tiny-font 517 件 (LOW)**: font-size < 11px。優先度低。
- **孤児 SVG 81 件**: 参照されていない SVG の整理（別 Issue）。

Issue #64 にも結果をコメント追記予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)