### PR TITLE
fix(r2-sync): upload-images-to-r2.mjs で失敗時 exit 1（silent failure 防止）

### DIFF
--- a/.claude/scripts/upload-images-to-r2.mjs
+++ b/.claude/scripts/upload-images-to-r2.mjs
@@ -181,3 +181,9 @@ for (let i = 0; i < items.length; i += CONCURRENCY) {
 
 const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 console.log(`\nDone in ${elapsed}s! Uploaded: ${uploaded}, Skipped: ${skipped}, Failed: ${failed}`);
+
+// 1 件でも失敗があれば exit 1（GitHub Actions が success と誤判定する silent failure を防ぐ）
+if (failed > 0) {
+  console.error(`\nERROR: ${failed} file(s) failed to upload. See log above for "FAILED:" entries.`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

R2 sync workflow が **2,582 件全 Unauthorized でも success 判定**になる silent failure バグを修正。

## 背景

2026-04-28 に R2 アクセスキーが失効したが、`.claude/scripts/upload-images-to-r2.mjs` が個別ファイル失敗を `failed++` でカウントするだけで最後に `process.exit(0)` のまま返すため、`Failed: 2582` のログが出ていても GitHub Actions の workflow は ✅ success 判定。結果、4 日間気付かれず `maslow-pyramid.svg` 等の新規追加 SVG が R2 不在のまま production 404 となっていた（Issue 報告: 2026-04-30）。

## 変更

`upload-images-to-r2.mjs` の最後に以下を追加:

```js
if (failed > 0) {
  console.error(`\nERROR: ${failed} file(s) failed to upload. See log above for "FAILED:" entries.`);
  process.exit(1);
}
```

これにより `r2-sync.yml` workflow も fail 判定され、GitHub の通知 / メールアラートが飛ぶ。

## Test plan

- [x] ローカルで script を syntax check（`node --check`）
- [ ] develop merge 後、次回の意図的失敗（無効なキー等）で workflow が fail することを目視確認（reverse test 不要、既に 2026-04-28 の事故ログで failed=2582 の状態が再現していたため）
- [x] 並行作業の `docs/sns-drafts/README.md` 変更には触れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)