### PR TITLE
fix(ui): details 内の ExamPoint/RelatedKeywords を外枠から離す

### DIFF
--- a/src/components/ui/SpecSheetList/SpecSheetList.tsx
+++ b/src/components/ui/SpecSheetList/SpecSheetList.tsx
@@ -143,7 +143,7 @@ export default function SpecSheetList({
   const accentClass = accent === "brand" ? styles.rootAccentBrand : "";
 
   return (
-    <section className={`${styles.root} ${accentClass} ${className}`}>
+    <section data-spec-sheet-list className={`${styles.root} ${accentClass} ${className}`}>
       {title && (
         <header className={styles.head}>
           <div className={styles.headRow}>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -359,8 +359,14 @@
     border-bottom: 1px solid var(--rule-soft);
   }
 
-  .prose-blog details > :not(summary) {
+  .prose-blog details > :not(summary):not([data-callout]):not([data-spec-sheet-list]) {
     @apply px-5;
+  }
+
+  /* bordered components inside details: margin で外枠から離す（自身の padding を尊重） */
+  .prose-blog details > [data-callout],
+  .prose-blog details > [data-spec-sheet-list] {
+    @apply mx-5;
   }
 
   .prose-blog details ol {


### PR DESCRIPTION
## 問題

過去問解答ページ（例: [/docs/pe-comprehensive-management-r07-primary#1-25](https://doboku-note.com/docs/pe-comprehensive-management-r07-primary#1-25)）の `<details>解答・解説</details>` 内に置かれた `<ExamPoint>` と `<RelatedKeywords>` が、details の外枠 border と隙間ゼロでくっつく状態だった。

## 根本原因

`globals.css:362` の `.prose-blog details > :not(summary) { @apply px-5 }` は子要素に **内部 padding** を加える設計。

- 段落・リスト等の **borderless 要素** では「内部 padding = 視覚的 indent」として機能（OK）
- しかし `<ExamPoint>`（=`<SpecSheetList>` の `<section>`）と `<RelatedKeywords>`（=`<Callout>` の `<aside>`）は **自身に border を持つ**要素で、かつ水平 margin がゼロ。global rule は内部 padding を増やすのみで、要素の **外側の境界**を details の border から離さない

## 修正方針

bordered components を data 属性で識別し、global rule から除外して margin を付与:

- **SpecSheetList**: `<section>` に `data-spec-sheet-list` 属性を追加
- **Callout**: 既存の `data-callout="<kind>"` 属性をそのまま再利用
- `details > :not(summary)` の px-5 ルールから bordered components を `:not()` で除外
- 除外した components 専用に `mx-5`（margin-left/right: 1.25rem）を付与

これにより:
- bordered components 自身の padding 設定（SpecSheetList の `padding: 4px 16px`、Callout の `pl-5 pr-5`）が尊重される
- 外側 margin で details border から 20px 離れる
- borderless content（段落・リスト・表・hr）の現行レイアウトには影響なし

## 変更ファイル

- `src/components/ui/SpecSheetList/SpecSheetList.tsx`（+1 char: `data-spec-sheet-list` 属性）
- `src/styles/globals.css`（+6行 / -1行: ルール 1 件分割 + 新規ルール追加）

## Test plan

- [x] `npm run type-check` 通過
- [x] `r07-primary` `Ⅰ-1-25` の details 展開で ExamPoint/RelatedKeywords の左右が details 外枠から 20px 離れることを Playwright スクショで確認（`.tmp/r07-1-25-details-after.png`）
- [x] `kyt` ページ末尾の ExamPoint（details 外配置）にレイアウト回帰なし（`.tmp/kyt-exampoint-after.png`）
- [ ] レビュー時にモバイル幅（375px）でも視認確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)