### PR TITLE
fix(ui): 右サイドバー 3 カードのリンクフォントを 14px/400 に統一

### DIFF
--- a/src/components/ui/CategoryNavCard/CategoryNavCard.tsx
+++ b/src/components/ui/CategoryNavCard/CategoryNavCard.tsx
@@ -220,13 +220,13 @@ function SectionCard({ variant, currentSlug, currentSection }: { variant: 'sideb
           {keywords.map(kw => (
             <li key={kw.slug}>
               {kw.slug === currentSuffix ? (
-                <span className="block text-xs py-0.5 pl-2 border-l-2 border-blue-500 font-bold text-gray-900 dark:text-gray-100">
+                <span className="block text-sm py-0.5 pl-2 border-l-2 border-blue-500 font-bold text-gray-900 dark:text-gray-100">
                   {kw.title}
                 </span>
               ) : (
                 <Link
                   href={`/docs/pe-comprehensive-management-${kw.slug}`}
-                  className="block text-xs py-0.5 pl-2 border-l-2 border-transparent text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:border-blue-300 dark:hover:border-blue-600 transition-colors"
+                  className="block text-sm py-0.5 pl-2 border-l-2 border-transparent text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:border-blue-300 dark:hover:border-blue-600 transition-colors"
                 >
                   {kw.title}
                 </Link>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -594,6 +594,9 @@
 .toc-content a:hover {
   color: rgba(0, 0, 0, 0.82);
 }
+.toc-content a.active {
+  font-weight: 700;
+}
 .dark .toc-content a {
   color: #a4bcd5;
 }
@@ -622,7 +625,6 @@
   position: relative;
   padding-left: 21px;
   margin-top: 5px;
-  font-weight: 700;
 }
 
 /* H2 dots */


### PR DESCRIPTION
## 問題

PE キーワードページの右サイドバーで、3 カードのリンクのサイズ・太さがバラついていた:

| カード | 修正前 | 修正後 |
|---|---|---|
| 目次 | H2: 14px / **700**、H3: 14px / 400 | 14px / 400（active のみ 700） |
| 同セクションのキーワード | **12px** / 400（active 700） | 14px / 400（active 700） |
| 5 管理学習ガイド | 14px / 400（active 700） | 14px / 400（active 700）※変更なし |

タイトル（16px / 700）と font-family（Hiragino Kaku Gothic ProN）は元から揃っていた。

## 修正方針

全サイドバーリンクを **14px / 400** に統一、**active のみ font-weight: 700** に変更。

## 変更ファイル

- `src/styles/globals.css`:
  - `.toc-content .ol-depth-1 > li` から `font-weight: 700` を削除（H2 のデフォルト太字を解除）
  - `.toc-content a.active` に `font-weight: 700` を追加（active の太字を維持）
- `src/components/ui/CategoryNavCard/CategoryNavCard.tsx:223,229`:
  - SectionCard sidebar variant のリンク・active span を `text-xs` → `text-sm`（12px → 14px）

PillarNavCard はもともと統一基準を満たしていたため変更なし。

## Test plan

- [x] `npm run type-check` 通過
- [x] safety-patrol で 3 カード全てのリンクが computed 14px / 400 になることを Playwright で計測確認
- [x] 5 管理学習ガイドの active（安全管理）のみ太字で他は 400 を視覚確認（`.tmp/sidebar-after.png`）
- [ ] レビュー時に他キーワードページ（kyt 等）でも同一動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)