### PR TITLE
feat(ui): PillarNavCard mobile variant をカード全面クリック可能に

### DIFF
--- a/src/components/ui/PillarNavCard/PillarNavCard.tsx
+++ b/src/components/ui/PillarNavCard/PillarNavCard.tsx
@@ -83,22 +83,15 @@ export default function PillarNavCard({ variant, currentSection }: PillarNavCard
         {PILLARS.map((p) => {
           const isActive = p.sectionPrefix === activePrefix;
           return (
-            <li
-              key={p.slug}
-              className={`rounded-sm border px-4 py-3 transition-colors ${
-                isActive
-                  ? "bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800"
-                  : "border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-500"
-              }`}
-            >
+            <li key={p.slug}>
               <Link
                 href={`${PE_PREFIX}${p.slug}`}
                 aria-current={isActive ? "true" : undefined}
-                className={
+                className={`block rounded-sm border px-4 py-3 transition-colors text-sm ${
                   isActive
-                    ? "text-sm font-bold text-gray-900 dark:text-gray-100"
-                    : "text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                }
+                    ? "bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800 font-bold text-gray-900 dark:text-gray-100"
+                    : "border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-500 text-blue-600 dark:text-blue-400"
+                }`}
               >
                 {p.label}
               </Link>


### PR DESCRIPTION
## Summary

- 5 管理学習ガイドの mobile variant で、カード見た目（ボーダー・パディング部分）はクリックしても遷移しない問題を修正
- `<Link>` を block 化し、カードのスタイル（border / padding / rounded / hover）を `<li>` から移動して、カード全幅をクリッカブルに変更
- block 化に伴い不要となった `hover:underline` を削除（hover signal は border-color 変化で代替）

## Background

PR #200 のマージタイミングの関係で、`claude/fix-exam-anchor-format` 上の本コミット（`af052c3f2`）が PR に乗らずに孤立していた。develop に取り込むため、新規ブランチで cherry-pick した PR。

## Why

- Fitts' 法則違反: 視覚的には「カード = ボタン」に見えるのに、実際の click target はテキスト幅だけ
- タッチデバイスで小さなテキストを正確にタップする必要があり、操作性が低い
- a11y: `aria-current` は付いているが、active 状態の視覚範囲とフォーカスリングの範囲が一致しない

## Scope

- `src/components/ui/PillarNavCard/PillarNavCard.tsx` の mobile variant のみ修正
- sidebar variant は元々カードフレームを持たない通常の sidebar nav なので対象外

## Test plan

- [x] `npm run type-check` 通過
- [ ] localhost:3020 の pillar ページをモバイル幅（DevTools 375px）で開き、5 管理カードのボーダー余白部分をクリックして遷移することを確認
- [ ] active 状態（自分自身の管理）が太字+背景色で表示されることを確認
- [ ] hover 時にボーダー色が変化することを確認
- [ ] ダークモードでも border が visible なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)