### PR TITLE
feat(note): 自治体道路担当マガジンを公開（published: true）

### DIFF
--- a/docs/note/magazines/総監模範論文-自治体道路担当/R03/article.md
+++ b/docs/note/magazines/総監模範論文-自治体道路担当/R03/article.md
@@ -29,7 +29,7 @@ price: 500
 
 自治体 道路担当ペルソナの模範論文（R03-R07 過去問＋R8 予想）をまとめた **magazine** もあわせてご覧ください。各記事を単品でそろえるよりお得なセット価格です。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca
 
 ---
 
@@ -210,4 +210,4 @@ https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
 
 テーマは毎年異なりますが、自治体 道路担当として書ける論点とトレードオフには共通パターンがあります。まとめて読むことで、テーマが変わっても応用できる「自分用テンプレート」が構築できます。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca

--- a/docs/note/magazines/総監模範論文-自治体道路担当/R04/article.md
+++ b/docs/note/magazines/総監模範論文-自治体道路担当/R04/article.md
@@ -31,7 +31,7 @@ price: 500
 
 自治体 道路担当ペルソナの模範論文（R03-R07 過去問＋R8 予想）をまとめた **magazine** もあわせてご覧ください。各記事を単品でそろえるよりお得なセット価格です。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca
 
 ---
 
@@ -262,4 +262,4 @@ BIM/CIM導入の実務障壁（職員スキル・コンサル能力・予算不�
 
 テーマは毎年異なりますが、自治体 道路担当として書ける論点とトレードオフには共通パターンがあります。まとめて読むことで、テーマが変わっても応用できる「自分用テンプレート」が構築できます。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca

--- a/docs/note/magazines/総監模範論文-自治体道路担当/R05/article.md
+++ b/docs/note/magazines/総監模範論文-自治体道路担当/R05/article.md
@@ -30,7 +30,7 @@ price: 500
 
 自治体 道路担当ペルソナの模範論文（R03-R07 過去問＋R8 予想）をまとめた **magazine** もあわせてご覧ください。各記事を単品でそろえるよりお得なセット価格です。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca
 
 ---
 
@@ -258,4 +258,4 @@ R5 の SWOT 分析は「組織として継続的にアウトプットを出す�
 
 テーマは毎年異なりますが、自治体 道路担当として書ける論点とトレードオフには共通パターンがあります。まとめて読むことで、テーマが変わっても応用できる「自分用テンプレート」が構築できます。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca

--- a/docs/note/magazines/総監模範論文-自治体道路担当/R06/article.md
+++ b/docs/note/magazines/総監模範論文-自治体道路担当/R06/article.md
@@ -29,7 +29,7 @@ price: 500
 
 自治体 道路担当ペルソナの模範論文（R03-R07 過去問＋R8 予想）をまとめた **magazine** もあわせてご覧ください。各記事を単品でそろえるよりお得なセット価格です。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca
 
 ---
 
@@ -228,4 +228,4 @@ R6 の CN テーマは「現状取組の限界 → 施策の組合せ → 2050 �
 
 テーマは毎年異なりますが、自治体 道路担当として書ける論点とトレードオフには共通パターンがあります。まとめて読むことで、テーマが変わっても応用できる「自分用テンプレート」が構築できます。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca

--- a/docs/note/magazines/総監模範論文-自治体道路担当/R07/article.md
+++ b/docs/note/magazines/総監模範論文-自治体道路担当/R07/article.md
@@ -28,7 +28,7 @@ price: 500
 
 自治体 道路担当ペルソナの模範論文（R03-R07 過去問＋R8 予想）をまとめた **magazine** もあわせてご覧ください。各記事を単品でそろえるよりお得なセット価格です。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca
 
 ---
 
@@ -256,4 +256,4 @@ R7 の三層構造は「現在の限界 → 5 年以内の現実的施策 → �
 
 テーマは毎年異なりますが、自治体 道路担当として書ける論点とトレードオフには共通パターンがあります。まとめて読むことで、テーマが変わっても応用できる「自分用テンプレート」が構築できます。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca

--- a/docs/note/magazines/総監模範論文-自治体道路担当/R08-yosou/article.md
+++ b/docs/note/magazines/総監模範論文-自治体道路担当/R08-yosou/article.md
@@ -26,7 +26,7 @@ price: 500
 
 自治体 道路担当ペルソナの模範論文（R03-R07 過去問＋R8 予想）をまとめた **magazine** もあわせてご覧ください。各記事を単品でそろえるよりお得なセット価格です。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca
 
 ---
 
@@ -286,4 +286,4 @@ R8 予想テーマでは、過去問対策に加えて以下の 4 点が評価�
 
 テーマは毎年異なりますが、自治体 道路担当として書ける論点とトレードオフには共通パターンがあります。まとめて読むことで、テーマが変わっても応用できる「自分用テンプレート」が構築できます。
 
-https://note.com/dobokunote/m/PLACEHOLDER_ROAD_MAGAZINE
+https://note.com/dobokunote/m/m52186ffd12ca

--- a/src/lib/note-magazines.ts
+++ b/src/lib/note-magazines.ts
@@ -94,8 +94,8 @@ const MAGAZINES_RAW = {
 
   'essay-road-municipality-magazine': {
     id: 'essay-road-municipality-magazine',
-    published: false,
-    noteUrl: '',
+    published: true,
+    noteUrl: 'https://note.com/dobokunote/m/m52186ffd12ca',
     title: '総監記述式 模範論文｜自治体 道路担当 R3-R7 + R8予想セット',
     description:
       'R03（データ利活用）〜R07（少子高齢化）の過去問 5 年分 + R08 予想問題集（気候変動適応・資源循環）。過去問 5 年分はいずれも橋梁長寿命化（維持管理）版とバイパス整備・道路建設（新設）版の A 案／B 案 2 バージョン併記、R08 予想は自治体 道路担当フル解答 2 本の合計 6 記事。地方自治体の道路担当（発注者）の立場で「経済性 × 安全 × 社会環境」を主軸に、各記事に設問全文を再掲して組み立てた論文構成を解説。試験 1 ヶ月前（2026-06）に R08 予想章を追加公開予定。',


### PR DESCRIPTION
## 概要

note 上で自治体道路担当マガジンが作成された（https://note.com/dobokunote/m/m52186ffd12ca）ことを受け、サイト表示用 SoT を公開状態に更新する。

## 変更点

`src/lib/note-magazines.ts` の `essay-road-municipality-magazine` entry:

- `noteUrl`: `''` → `'https://note.com/dobokunote/m/m52186ffd12ca'`
- `published`: `false` → `true`

これにより `getMagazine()` が当該マガジンを返すようになり、develop→main デプロイ後、関連ドキュメントページにマガジン CTA カード（タイトル・説明・カバー画像・価格）が表示される。

## 関連

- 各記事本文のマガジン誘導リンク（PLACEHOLDER → 実 URL）は develop の commit `49d947e82` で対応済み。
- マガジンのタイトル・説明・価格・カバー画像（imageUrl）は本セッションで現状（R3-R7＋R8予想・6記事・¥2,480・ヘッダー対応カバー）に同期済み。

## 検証

- `npm run type-check` 通過
- entry の他フィールド（title/description/imageUrl/price 等）は既に現状同期済みのため無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)
