### PR TITLE
feat(legal): Amazonアソシエイト開示文の追加

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,6 +7,7 @@ import {
   Target,
   Users,
   Cookie,
+  ShoppingBag,
   Clock,
   Lock,
   UserCheck,
@@ -73,7 +74,7 @@ export default function PrivacyPage() {
               プライバシーポリシー
             </h1>
             <p className="font-mono text-[11px] text-[var(--ink-muted)]">
-              最終更新日 2026.04.05
+              最終更新日 2026.05.21
             </p>
           </div>
         </section>
@@ -207,6 +208,27 @@ export default function PrivacyPage() {
                     Google AdSense 詳細
                   </a>
                 </div>
+              </div>
+            </PolicyCard>
+
+            {/* 5b. アフィリエイトプログラム */}
+            <PolicyCard
+              icon={<ShoppingBag className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+
+              title="アフィリエイトプログラムについて"
+            >
+              <p className="mb-4">
+                当サイトは、Amazonアソシエイト・プログラムおよび株式会社もしものアフィリエイトサービス「もしもアフィリエイト」に参加しています。
+                これらは、商品やサービスを紹介するリンクを掲載し、ユーザーがそのリンク経由で購入・登録した場合に当サイトが紹介料を受け取る仕組みです。
+              </p>
+              <p className="mb-4">
+                これらのプログラムでは、成果の計測のために Cookie を使用します。リンク経由のアクセス情報はプログラム提供事業者により記録されますが、
+                当サイトが個人を特定できる情報を取得することはありません。
+              </p>
+              <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-sm p-4">
+                <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                  Amazonのアソシエイトとして、当メディアは適格販売により収入を得ています。
+                </p>
               </div>
             </PolicyCard>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -65,7 +65,11 @@ export default function Footer() {
           </div>
         </div>
 
-        <div className="mt-8 pt-4 border-t border-[var(--rule-soft)] flex justify-between text-[11px] font-mono text-[var(--ink-muted)] flex-wrap gap-2">
+        <p className="mt-8 pt-4 border-t border-[var(--rule-soft)] text-[12px] text-[var(--ink-muted)] leading-relaxed max-w-[60ch]">
+          Amazonのアソシエイトとして、当メディアは適格販売により収入を得ています。
+        </p>
+
+        <div className="mt-4 flex justify-between text-[11px] font-mono text-[var(--ink-muted)] flex-wrap gap-2">
           <span>© {new Date().getFullYear()} doboku-note</span>
           <span>Built with Next.js · Tailwind · MDX</span>
         </div>


### PR DESCRIPTION
## 目的

もしもアフィリエイト経由の Amazon アソシエイト・プログラム提携申請に必要な規約要件を満たす。

## 変更内容

- **Footer**: 全ページ共通フッターに規約指定の開示文「Amazonのアソシエイトとして、当メディアは適格販売により収入を得ています。」を追加
- **プライバシーポリシー**: 「アフィリエイトプログラムについて」カードを新設（Amazonアソシエイト・もしもアフィリエイト参加の明示、成果計測 Cookie の説明、開示文の再掲）
- 最終更新日を 2026.05.21 に更新

## 検証

- `npm run type-check` 通過
- `npm run build` 通過
- pre-push: tests 103 pass / 3 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)