### PR TITLE
feat(links): /links リンクハブ + X 固定ポスト草案 + 運用ガイド

### DIFF
--- a/docs/reference/links-hub.md
+++ b/docs/reference/links-hub.md
@@ -1,0 +1,123 @@
+# /links リンクハブ 運用ガイド
+
+`src/app/links/page.tsx` に実装した SNS bio 用リンクハブ（ブリッジページ）の設計意図・運用方針・メンテ手順をまとめた内部ドキュメント。
+
+最終更新: 2026-05-26
+
+## 1. 目的とポジショニング
+
+| 項目 | 内容 |
+|---|---|
+| **公開 URL** | `https://doboku-note.com/links` |
+| **性質** | リンクハブ / ブリッジページ（Linktree 相当の自前実装） |
+| **主目的** | SNS bio から流入したユーザーを目的別の送客先へ分岐させる中継地 |
+| **主な流入元** | Instagram bio リンク（最優先）／ X URL 欄 ／ YouTube 概要欄（将来） |
+| **主な送客先** | note 無料記事 (M2)・note 有料マガジン (M9/M5/M6/M8/M3)・サイト試験ハブ・X |
+
+### ランディングページ・About ページとの違い
+
+| 種類 | 主目的 | 構成 | このページ |
+|---|---|---|---|
+| ランディングページ | 1 アクションへの CVR 最大化 | 訴求 → 証拠 → CTA の縦長 | ✗ 該当しない |
+| **リンクハブ** | **複数の目的地への分岐** | **短い名乗り + リンク一覧** | **✓ これ** |
+| About ページ | 運営者・サイトの理解促進 | 経歴・編集方針を物語で説明 | `/about` 側で担当 |
+
+「すでに SNS で接触した人が、別チャネルへ飛び移る中継地」として設計。情報量を絞り、ボタンの並びを主役にしている。
+
+## 2. SNS 各チャネルでの貼り方
+
+### Instagram
+- bio リンク欄に **唯一のリンク** として `https://doboku-note.com/links` を貼る
+- bio 本文中に「詳細はリンクから↓」と誘導する一文を入れる
+
+### X (Twitter)
+- プロフィール URL 欄: `https://doboku-note.com`（サイトトップ）を維持
+- 固定ポストスレッドで個別 note URL を案内（`/links` への送客は不要）
+- 補助的に bio 本文または固定ポスト末尾で `/links` を紹介してもよい
+
+### YouTube（将来）
+- 各動画の概要欄テンプレに `/links` を含めるか、サイトトップを優先するかは流入分析後に判断
+
+## 3. セクション構成（上から下）
+
+1. **プロフィールヒーロー**: アバター + アカウント名 + 1 行ティザー
+2. **導入文**: 運営者の信頼根拠 + サイト/note の役割分担 + 推奨入口の提示
+3. **Featured（M2 完全無料）**: 最目立つ accent カラーボタン
+4. **note 有料マガジン**: M9 / M5 / M6 / M8 / M3 — `note-magazines.ts` の `MagazineId` から動的取得
+5. **無料サイトコンテンツ**: 総監カテゴリ / 1級土木カテゴリ / About
+6. **SNS**: X
+
+各セクション見出しに「**こんな方へ**」のサブテキストを 1 行添えて、訪問者が自分の目的に合う場所を素早く判断できるようにしている。
+
+## 4. データソース（SSoT）
+
+| データ | 真実源 | 用途 |
+|---|---|---|
+| 運営者情報（名前・アバター・職歴・X URL） | `src/config/author.ts` | プロフィールヒーロー + SNS セクション |
+| 有料マガジン情報（タイトル・description・URL） | `src/lib/note-magazines.ts` | note 有料マガジンセクション |
+| M2 完全無料記事 URL | このページ内に直書き（M2 は note-magazines.ts に含めない仕様） | Featured セクション |
+
+**M2 を note-magazines.ts に含めない理由**: M2 は 2026-05-25 に「¥2,480 magazine → 完全無料リード磁石」へ戦略転換され、note 上で単独無料記事として運用されているため、`NoteMagazine` 型（badge / price フィールド前提）に乗せていない。詳細は `docs/handoffs/2026-05-25-whitepaper-r7-free-lead-magnet.md` を参照。
+
+## 5. UTM 設計
+
+GA4 で SNS bio → /links → 各送客先の流入経路を区別するため、すべての外部リンクに UTM パラメータを付与している。
+
+| 区分 | utm_source | utm_medium | utm_campaign | utm_content |
+|---|---|---|---|---|
+| M2 完全無料 | `links` | `referral` | `link-hub` | `m2-free-whitepaper` |
+| M9/M5/M6/M8/M3 有料マガジン | `doboku-note` | `referral` | `note-magazine` | `link-hub-{magazine-id}` |
+
+**utm_source が異なる理由**: 有料マガジンは `note-magazines.ts` の `buildMagazineUrl()` を共通利用しており、サイト内の他箇所（記事内 CTA・サイドバー）からの送客と統一規約で扱う方が分析しやすい。M2 だけが /links 独自の UTM になっている。
+
+**集計時のクエリ例**:
+- /links 経由の総 note クリック: `utm_campaign IN ('link-hub', 'note-magazine') AND utm_content LIKE 'link-hub-%' OR utm_content='m2-free-whitepaper'`
+- /links → M2 リード磁石のみ: `utm_content='m2-free-whitepaper'`
+- /links → 有料マガジン全体: `utm_content LIKE 'link-hub-%'`
+
+## 6. メンテ手順
+
+### 新しい有料マガジンを追加するとき
+
+1. `src/lib/note-magazines.ts` に新エントリを追加し `published: true` + `noteUrl` を埋める
+2. `src/app/links/page.tsx` の `PAID_MAGAZINE_IDS` 配列に新 `MagazineId` を追加（順序が表示順）
+3. `npm run type-check` で型エラーなしを確認
+4. dev サーバーで `http://localhost:3020/links` を開き目視確認
+
+### マガジンを一時非公開にしたいとき
+
+`note-magazines.ts` の対象エントリの `published: false` に変更するだけで、`getMagazine()` が `null` を返し /links から自動非表示になる。`PAID_MAGAZINE_IDS` 配列を編集する必要はない。
+
+### Featured（M2）を別の無料記事に切り替えるとき
+
+`src/app/links/page.tsx` 上部の `M2_FREE_NOTE_URL` 定数とその直下のヒーロー導入文・Featured ボタンのタイトル/サブテキストを編集。完全無料リード磁石は試験季節と連動して入れ替わる前提（例: 試験直後は「2026 解答全文再現」が Featured に昇格しうる）。
+
+### 試験季節に合わせた強調変更
+
+試験 3 週前〜直前は M3 R8予想問題集を Featured に並列表示する案あり。実装するなら Featured セクションを `<section>` で 2 つ並べる構成に拡張。優先度判定は試験前 6 週間以内かどうかで `Date` 比較ロジックを入れる選択肢もあるが、現状は手動切替で十分。
+
+## 7. やらないこと
+
+- **ヒーローを長文化しない** — リンクハブで本文長文化は離脱要因（業界ベンチマークで非スクロール離脱 60% 超）。詳しい運営者紹介は `/about` に集約
+- **Header navigation に出さない** — SNS bio 専用の中継ページなので、サイト内回遊からは原則アクセスしない設計。Header に出すと一般訪問者の目に入り「リンク集だけのページ」と誤認されサイトの体系性が薄まる
+- **同じ文章を /about と両方に書かない** — Red Line #4（重複コンテンツ）回避。/links の導入文は要約に留め、深掘りは /about への送客で対応
+- **アフィリエイトリンクを並べない** — このページは運営者の自社商品（note・サイト）のハブ。書籍紹介などのアフィリエイトは `docs/reference/book-list.md` 経由で別ページにする
+
+## 8. 計測 KPI（提案）
+
+| 指標 | 計測方法 | 目標目安 |
+|---|---|---|
+| /links のページビュー (PV) | GA4 ページレポート | Instagram フォロワー数 × 月 5-10% |
+| /links 滞在時間 | GA4 エンゲージメント | 30 秒以上（リンクハブとしては短くてよい） |
+| /links → M2 無料記事クリック率 | utm_content=m2-free-whitepaper の流入数 ÷ /links PV | 25-40% |
+| /links → 有料マガジン総クリック率 | utm_content LIKE 'link-hub-%' ÷ /links PV | 5-15% |
+| Instagram bio リンク経由 PV | GA4 acquisition / referrer = "l.instagram.com" | 月 50-300 |
+
+## 9. 関連ドキュメント
+
+- `docs/project/03_SNS/01_SNS集客戦略.md` — SNS チャネル別の役割（IG = SEO カタログ動線）
+- `docs/project/03_SNS/02_チャネル動線設計.md` — UTM 統一フォーマット・bio link 着地点の Phase 別ロードマップ
+- `docs/note/noteコンテンツ計画.md` — note 商品ラインナップとマガジン進捗
+- `src/lib/note-magazines.ts` — 有料マガジン SSoT
+- `src/config/author.ts` — 運営者情報 SSoT
+- `docs/reference/content-authoring.md` — MDX/コンテンツ執筆ルール

--- a/docs/sns/x/draft/033-pinned-profile/tweets.md
+++ b/docs/sns/x/draft/033-pinned-profile/tweets.md
@@ -1,0 +1,124 @@
+# X 固定ポスト用スレッド (7 ツイート) — プロフィール + note 動線
+
+- 用途: X アカウント `@dobokunotecom` の **固定ポスト**（1/7 をピン留め、2/7 以降は通常スレッド）
+- 目的: 自己紹介で信頼形成 → note 無料リード磁石 (M2) を起点に note 有料マガジン (M9/M5/M6/M8/M3) へ送客 → 末尾でサイトへ
+- 戦略: `docs/project/03_SNS/01_SNS集客戦略.md` v6（X = 信頼/マネタイズ動線、note 誘導が主）
+- 価格表記なし（変更可能性あるため運営者方針）
+- UTM: `utm_source=x&utm_medium=organic&utm_campaign=pinned-thread&utm_content=tweet-NN`
+
+---
+
+## プロフィール文（X 本文欄・160 字以内）
+
+```
+元・地方自治体の土木職（発注者）退職。1級土木施工／1級舗装／コンクリート主任技士・診断士／技術士（建設・総合技術監理）の6資格取得。発注者視点で技術士総監・1級土木の試験対策を発信。R08受験者の入口は固定ポストの無料note白書R7完全対応集
+```
+
+**URL 欄**: `https://doboku-note.com`
+
+---
+
+## Tweet 01: ピン留め — 自己紹介 + M2 完全無料リード磁石
+
+元・地方自治体の土木職（発注者）退職、6資格保有の架（かける）です。
+
+発注者視点で技術士総監・1級土木の合格を支援しています。
+
+まずは完全無料の『白書R7完全対応集』約34,000字から。R08総合復習の決定版です。
+
+https://note.com/dobokunote/n/n60efbccd728b?utm_source=x&utm_medium=organic&utm_campaign=pinned-thread&utm_content=tweet-01
+
+#技術士 #技術士総監
+
+---
+
+## Tweet 02: M9 5管理テキスト精読ガイド
+
+note有料①｜5管理テキスト精読ガイド
+
+安全／情報／経済性／人的資源／社会環境
+キーワード集2026の頻出論点と引っかけパターンを5管理別に体系化。サイトの解説ページへ直リンク付き。
+
+https://note.com/dobokunote/m/m607bf095b02a?utm_source=x&utm_medium=organic&utm_campaign=pinned-thread&utm_content=tweet-02
+
+#技術士 #技術士総監
+
+---
+
+## Tweet 03: M5 ゼネコン模範論文
+
+note有料②｜総監記述式 模範論文｜ゼネコン 5年分セット
+
+R03データ利活用〜R07少子高齢化の5年分。中堅ゼネコン土木部門の立場で「安全×経済性×人的資源」のトレードオフを3,000字級フル論文で構成。
+
+https://note.com/dobokunote/m/m32aaa137f22e?utm_source=x&utm_medium=organic&utm_campaign=pinned-thread&utm_content=tweet-03
+
+#技術士 #技術士総監 #模範論文
+
+---
+
+## Tweet 04: M6 河川コンサル模範論文
+
+note有料③｜総監記述式 模範論文｜建設コンサル河川・砂防 5年分
+
+R03〜R07の5年分。中堅建設コンサル河川・砂防部門部長の立場で「社会環境×安全×情報」を主軸に3,000字級フル論文。
+
+https://note.com/dobokunote/m/m32132ecb3033?utm_source=x&utm_medium=organic&utm_campaign=pinned-thread&utm_content=tweet-04
+
+#技術士 #技術士総監 #模範論文
+
+---
+
+## Tweet 05: M8 自治体道路担当模範論文（運営者ペルソナ一致）
+
+note有料④｜総監記述式 模範論文｜自治体 道路担当 R3-R7+R8予想
+
+過去5年（A/B 2案併記）+ R08予想2本=計6記事。発注者視点で「経済性×安全×社会環境」を主軸。運営者の出自と完全一致。
+
+https://note.com/dobokunote/m/m52186ffd12ca?utm_source=x&utm_medium=organic&utm_campaign=pinned-thread&utm_content=tweet-05
+
+#技術士 #技術士総監
+
+---
+
+## Tweet 06: M3 R8予想問題集（試験直前駆け込み層向け）
+
+note有料⑤（試験直前用）｜R8予想問題集
+
+経済安全保障／資源循環／AI社会／気候変動／災害復旧／老朽化インフラ。
+予想問題＋出題予想根拠＋三層骨子＋自治体道路担当フル模範論文＋3ペルソナアレンジ早見表。
+
+https://note.com/dobokunote/m/m6854c7437d4d?utm_source=x&utm_medium=organic&utm_campaign=pinned-thread&utm_content=tweet-06
+
+#技術士 #技術士総監 #論文対策
+
+---
+
+## Tweet 07: サイト doboku-note.com 誘導
+
+体系学習の本拠地は無料サイト：
+
+doboku-note.com
+・技術士総監キーワード694件
+・過去問H21-R7全680問解説
+・5管理トレードオフ攻略
+
+X→note無料→note有料の3段で、無理なくR08合格まで伴走します。
+
+#技術士 #技術士総監
+
+---
+
+## 投稿手順
+
+1. **既存固定ポストのスクショ保存**（過去エンゲージメントの記録のため）
+2. **プロフィール本文 + URL 欄を更新**（上記の通り）
+3. **Tweet 01 を投稿** → 投稿後にピン留め設定
+4. **Tweet 02 〜 07 を Tweet 01 への返信としてスレッド形式で順次投稿**
+5. **GA4 / note 集客分析で `utm_campaign=pinned-thread` のクリック数を計測**
+
+## 計測 KPI
+
+- 各 tweet-NN の note クリック数（GA4 referrer "x.com" + utm_content）
+- ピン留め後 1 ヶ月のプロフィールクリック率
+- M2 無料記事経由の M9/M5/M6/M8/M3 への 2 段ジャンプ率（note 売上）

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -1,0 +1,247 @@
+import Header from "@/components/layout/Header";
+import Footer from "@/components/layout/Footer";
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import type { Metadata } from "next";
+import { AUTHOR } from "@/config/author";
+import {
+  getMagazine,
+  buildMagazineUrl,
+  type MagazineId,
+} from "@/lib/note-magazines";
+
+export const metadata: Metadata = {
+  title: "Links — doboku-note の入口",
+  description:
+    "技術士総監・1級土木の試験対策コンテンツ入口まとめ。無料 note 記事・有料マガジン・サイト試験ガイド・X アカウントへの動線。",
+  alternates: {
+    canonical: "https://doboku-note.com/links",
+  },
+  openGraph: {
+    type: "website",
+    title: "Links — doboku-note の入口",
+    description:
+      "技術士総監・1級土木の試験対策。無料 note・有料マガジン・サイトハブ・X への動線まとめ。",
+    url: "https://doboku-note.com/links",
+    images: [
+      {
+        url: "https://doboku-note.com/images/og-default.png",
+        width: 1200,
+        height: 630,
+        alt: "doboku-note Links",
+      },
+    ],
+  },
+};
+
+const UTM_BASE = "utm_source=links&utm_medium=referral&utm_campaign=link-hub";
+
+function withUtm(url: string, content: string): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}${UTM_BASE}&utm_content=${content}`;
+}
+
+const M2_FREE_NOTE_URL = withUtm(
+  "https://note.com/dobokunote/n/n60efbccd728b",
+  "m2-free-whitepaper",
+);
+
+const PAID_MAGAZINE_IDS: MagazineId[] = [
+  "tankan-reading-guide",
+  "essay-general-contractor-magazine",
+  "essay-river-consultant-magazine",
+  "essay-road-municipality-magazine",
+  "r8-essay-forecast",
+];
+
+export default function LinksPage() {
+  const paidMagazines = PAID_MAGAZINE_IDS.map((id) => getMagazine(id)).filter(
+    (m): m is NonNullable<typeof m> => m !== null,
+  );
+
+  return (
+    <div className="min-h-screen flex flex-col bg-[var(--bg)] transition-colors duration-300">
+      <Header />
+
+      <main className="flex-grow py-10 sm:py-14">
+        <div className="max-w-[600px] mx-auto px-4 sm:px-6">
+          {/* Profile Hero */}
+          <section className="text-center mb-8">
+            <img
+              src={AUTHOR.imageUrl}
+              alt={`${AUTHOR.name}のプロフィール画像`}
+              width={96}
+              height={96}
+              className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-[var(--rule-soft)]"
+            />
+            <h1 className="font-serif text-2xl sm:text-3xl font-black text-[var(--ink)] mb-2">
+              doboku-note
+            </h1>
+            <p className="text-sm text-[var(--ink-body)] leading-relaxed">
+              技術士総監・1級土木の試験対策ハブ
+              <br />
+              元・地方自治体土木職（発注者）／6資格保有の運営
+            </p>
+          </section>
+
+          {/* 導入文：このページについて */}
+          <section className="mb-10 bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section p-5 text-sm text-[var(--ink-body)] leading-relaxed">
+            <p className="mb-3">
+              発注者として培った実務経験と6資格の受験知見をもとに、
+              <strong className="text-[var(--ink)]">
+                技術士（総合技術監理部門）・1級土木施工管理技士
+              </strong>
+              の合格を支援しています。
+            </p>
+            <p className="mb-3">
+              本サイト doboku-note.com は<strong className="text-[var(--ink)]">体系的な技術解説とキーワード辞書</strong>を無料で公開し、
+              note では<strong className="text-[var(--ink)]">模範論文・予想問題・5管理精読ガイド</strong>などの試験直結教材を提供しています。
+            </p>
+            <p>
+              下のリンクから、目的に合うコンテンツへどうぞ。まずは
+              <strong className="text-[var(--accent)]">完全無料の『白書R7完全対応集』</strong>
+              から読むのがおすすめです。
+            </p>
+          </section>
+
+          {/* Featured: M2 完全無料リード磁石 */}
+          <section className="mb-10">
+            <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--accent)] mb-2 text-center">
+              Featured — 完全無料
+            </p>
+            <p className="text-xs text-[var(--ink-muted)] mb-3 text-center">
+              まず全体像と R08 出題予測をつかみたい方へ
+            </p>
+            <a
+              href={M2_FREE_NOTE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block bg-[var(--accent)] text-white rounded-card-section p-5 sm:p-6 hover:opacity-90 transition-opacity text-center shadow-soft"
+            >
+              <div className="font-serif font-bold text-lg sm:text-xl mb-1.5">
+                白書R7完全対応集
+              </div>
+              <div className="text-sm opacity-95 leading-relaxed">
+                完全無料・約34,000字
+                <br />
+                R08総合復習の決定版
+              </div>
+            </a>
+          </section>
+
+          {/* note 有料マガジン */}
+          <section className="mb-10">
+            <h2 className="font-serif text-lg font-bold text-[var(--ink)] mb-1 text-center">
+              note 有料マガジン
+            </h2>
+            <p className="text-xs text-[var(--ink-muted)] mb-4 text-center">
+              論点整理・模範論文・予想問題で合格を確実にしたい方へ
+            </p>
+            <div className="space-y-3">
+              {paidMagazines.map((mag) => (
+                <a
+                  key={mag.id}
+                  href={buildMagazineUrl(mag, `link-hub-${mag.id}`)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-between bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-content px-4 py-3 hover:border-[var(--accent)] hover:shadow-soft transition-all"
+                >
+                  <div className="min-w-0 flex-1 pr-3">
+                    <div className="font-serif font-bold text-[var(--ink)] text-sm sm:text-base">
+                      {mag.shortTitle ?? mag.title}
+                    </div>
+                    <div className="text-xs text-[var(--ink-muted)] mt-0.5 leading-snug">
+                      {mag.shortDescription ?? mag.description}
+                    </div>
+                  </div>
+                  <ExternalLink
+                    className="w-4 h-4 text-[var(--ink-muted)] shrink-0"
+                    aria-hidden="true"
+                  />
+                </a>
+              ))}
+            </div>
+          </section>
+
+          {/* 無料サイトコンテンツ */}
+          <section className="mb-10">
+            <h2 className="font-serif text-lg font-bold text-[var(--ink)] mb-1 text-center">
+              無料サイトコンテンツ
+            </h2>
+            <p className="text-xs text-[var(--ink-muted)] mb-4 text-center">
+              キーワード・過去問を辞書として日常学習に使いたい方へ
+            </p>
+            <div className="space-y-3">
+              <Link
+                href="/category/pe-comprehensive-management"
+                className="block bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-content px-4 py-3 hover:border-[var(--accent)] hover:shadow-soft transition-all"
+              >
+                <div className="font-serif font-bold text-[var(--ink)] text-sm sm:text-base">
+                  技術士（総合技術監理部門）試験ガイド
+                </div>
+                <div className="text-xs text-[var(--ink-muted)] mt-0.5 leading-snug">
+                  5管理 × 600+ キーワード、過去問 H21-R7 全 680 問解説
+                </div>
+              </Link>
+              <Link
+                href="/category/civil-construction-1"
+                className="block bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-content px-4 py-3 hover:border-[var(--accent)] hover:shadow-soft transition-all"
+              >
+                <div className="font-serif font-bold text-[var(--ink)] text-sm sm:text-base">
+                  1級土木施工管理技士 試験ガイド
+                </div>
+                <div className="text-xs text-[var(--ink-muted)] mt-0.5 leading-snug">
+                  第1次・第2次検定対策、過去問解説、教科書範囲の網羅
+                </div>
+              </Link>
+              <Link
+                href="/about"
+                className="block bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-content px-4 py-3 hover:border-[var(--accent)] hover:shadow-soft transition-all"
+              >
+                <div className="font-serif font-bold text-[var(--ink)] text-sm sm:text-base">
+                  運営者プロフィール
+                </div>
+                <div className="text-xs text-[var(--ink-muted)] mt-0.5 leading-snug">
+                  発注者退職・6 資格保有の運営者について
+                </div>
+              </Link>
+            </div>
+          </section>
+
+          {/* SNS */}
+          <section>
+            <h2 className="font-serif text-lg font-bold text-[var(--ink)] mb-1 text-center">
+              SNS
+            </h2>
+            <p className="text-xs text-[var(--ink-muted)] mb-4 text-center">
+              学習仲間との交流や最新情報・試験季節リマインダーが欲しい方へ
+            </p>
+            <div className="space-y-3">
+              <a
+                href={AUTHOR.twitterUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-content px-4 py-3 hover:border-[var(--accent)] hover:shadow-soft transition-all"
+              >
+                <div>
+                  <div className="font-serif font-bold text-[var(--ink)] text-sm sm:text-base">
+                    X (旧 Twitter)
+                  </div>
+                  <div className="text-xs text-[var(--ink-muted)] mt-0.5 leading-snug">
+                    @dobokunotecom｜試験対策・受験生コミュニティ
+                  </div>
+                </div>
+                <ExternalLink
+                  className="w-4 h-4 text-[var(--ink-muted)] shrink-0"
+                  aria-hidden="true"
+                />
+              </a>
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **`/links` リンクハブ新設** (`src/app/links/page.tsx`): SNS bio 用ブリッジページ。M2 完全無料 Featured + M9/M5/M6/M8/M3 有料マガジン (note-magazines.ts から動的取得) + サイト試験ハブ + X 動線
- **運用ガイド**: `docs/reference/links-hub.md` 9 セクション (UTM 設計・メンテ手順・KPI・やらないこと)
- **X 固定ポスト草案**: `docs/sns/x/draft/033-pinned-profile/tweets.md` 7 ツイートスレッド (全 280 weighted chars 以下、最大 252/280)

## 背景

Instagram bio は外部リンクが 1 個しか貼れないため、Linktree 代替として自前のリンクハブを実装。doboku-note ドメインパワー集約・GA4 完全分析・カスタマイズ自由・コスト ¥0 を実現。X プロフィール強化のための固定ポスト草案も同時に整備。

## UTM 設計

- M2 完全無料: `utm_source=links&utm_medium=referral&utm_campaign=link-hub&utm_content=m2-free-whitepaper`
- M9/M5/M6/M8/M3 有料: `note-magazines.ts` の `buildMagazineUrl()` 経由 `utm_source=doboku-note&utm_campaign=note-magazine&utm_content=link-hub-{magazine-id}`

## Test plan

- [x] `npm run type-check` パス
- [x] dev サーバー `http://localhost:3020/links` で HTTP 200 / `<main>` タグ / 主要キーワード (技術士・1級土木・白書R7・note 有料マガジン・無料サイトコンテンツ) 描画確認
- [x] 全 6 note URL (M2 + M9/M5/M6/M8/M3) に UTM 付与レンダリング確認
- [x] 全 5 件の追加コンテンツ (導入文 3 段落 + 各セクションサブテキスト) 描画確認
- [x] X 草案 7 ツイートすべて 280 weighted chars 以下確認 (max 252)
- [ ] Cloudflare Pages preview deploy で本番ビルド動作確認 (PR push 後)
- [ ] develop マージ後 /deploy スキルで main 昇格 → 本番 curl 検証

## 関連

- 戦略: `docs/project/03_SNS/01_SNS集客戦略.md` v6 (X = 信頼動線 / IG = SEO カタログ動線)
- データソース: `src/config/author.ts` / `src/lib/note-magazines.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)