### PR TITLE
fix(affiliate): BookCard が表示されない不具合を修正（lazyOnload タイミング不整合）

### DIFF
--- a/src/components/ui/BookCard/BookCard.tsx
+++ b/src/components/ui/BookCard/BookCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Script from "next/script";
+import { useEffect } from "react";
 import affiliateBooks from "@/config/affiliate-books.json";
 
 interface BookCardProps {
@@ -22,32 +22,93 @@ interface BookCardProps {
  *
  * ステマ規制（2023-10〜）対応として「PR」表示を付与する。
  * 配置原則: 記事末・hub 末の補完導線。ファーストビュー禁止。
+ *
+ * 実装メモ:
+ * - 旧実装は `next/script strategy="lazyOnload"` でローダを発火していたが、
+ *   moshimo bundle.js は IIFE 内で `window.addEventListener("DOMContentLoaded"|"load", F)`
+ *   としてキュー処理関数 F をリスナ登録するだけで即時呼ばない。
+ *   lazyOnload は window.load 後に発火するため両イベントが既に通過済みで、
+ *   F が永遠に呼ばれず `window.msmaflink.q` が処理されない不具合があった。
+ *   useEffect 内で手動ロード後に load イベントを再ディスパッチして F を起動する。
  */
 
-// もしも かんたんリンク公式ローダ（bundle.js を1度だけ body に注入し、
-// msmaflink 呼び出しをキューイングする IIFE）。
-const MOSHIMO_LOADER =
-  "(function(b,c,f,g,a,d,e){b.MoshimoAffiliateObject=a;" +
-  "b[a]=b[a]||function(){arguments.currentScript=c.currentScript" +
-  "||c.scripts[c.scripts.length-2];(b[a].q=b[a].q||[]).push(arguments)};" +
-  "c.getElementById(a)||(d=c.createElement(f),d.src=g,d.id=a," +
-  'e=c.getElementsByTagName("body")[0],e.appendChild(d))})' +
-  '(window,document,"script",' +
-  '"//dn.msmstatic.com/site/cardlink/bundle.js?20220329","msmaflink");';
+const BUNDLE_URL = "https://dn.msmstatic.com/site/cardlink/bundle.js?20220329";
+const SCRIPT_ID = "msmaflink";
+
+type MsmaflinkWindow = typeof window & {
+  MoshimoAffiliateObject?: string;
+  msmaflink?: {
+    (payload: unknown): void;
+    q?: unknown[];
+  };
+};
+
+function ensureLoaderQueue(): void {
+  const w = window as MsmaflinkWindow;
+  if (w.msmaflink) return;
+  w.MoshimoAffiliateObject = "msmaflink";
+  const fn = function (this: unknown) {
+    // eslint-disable-next-line prefer-rest-params
+    const args = arguments as unknown as { currentScript?: Element | null };
+    args.currentScript = document.currentScript;
+    // eslint-disable-next-line prefer-rest-params
+    (fn.q = fn.q || []).push(arguments);
+  } as MsmaflinkWindow["msmaflink"] & { q?: unknown[] };
+  w.msmaflink = fn;
+}
+
+function triggerQueueProcess(): void {
+  // bundle.js の F は DOMContentLoaded / load のリスナとして登録されるだけで、
+  // 自前では即時実行しない。load が既に通過済みなら手動でディスパッチして起動する。
+  if (document.readyState === "complete") {
+    window.dispatchEvent(new Event("load"));
+  }
+}
+
+function loadBundleOnce(): void {
+  const existing = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+  if (existing) {
+    // 既にロード済み（同ページの別 BookCard が先に注入）→ キュー追記後すぐ起動
+    if (existing.dataset.loaded === "true") {
+      triggerQueueProcess();
+    } else {
+      existing.addEventListener("load", triggerQueueProcess, { once: true });
+    }
+    return;
+  }
+  const script = document.createElement("script");
+  script.id = SCRIPT_ID;
+  script.src = BUNDLE_URL;
+  script.async = true;
+  script.addEventListener(
+    "load",
+    () => {
+      script.dataset.loaded = "true";
+      triggerQueueProcess();
+    },
+    { once: true },
+  );
+  document.body.appendChild(script);
+}
 
 export default function BookCard({ asin }: BookCardProps) {
   const books = affiliateBooks as Record<string, unknown>;
   const payload = books[asin];
+  const eid =
+    payload && typeof payload === "object"
+      ? (payload as { eid?: string }).eid
+      : undefined;
 
-  if (!payload || typeof payload !== "object") {
+  useEffect(() => {
+    if (!payload || !eid) return;
+    ensureLoaderQueue();
+    (window as MsmaflinkWindow).msmaflink?.(payload);
+    loadBundleOnce();
+  }, [eid, payload]);
+
+  if (!payload || typeof payload !== "object" || !eid) {
     return null;
   }
-
-  const eid = (payload as { eid?: string }).eid;
-  if (!eid) return null;
-
-  // </script> によるブレイクアウトを防ぐため < をエスケープ
-  const payloadJson = JSON.stringify(payload).replace(/</g, "\\u003c");
 
   return (
     <div className="not-prose my-6">
@@ -63,10 +124,6 @@ export default function BookCard({ asin }: BookCardProps) {
           アフィリエイトリンクを含みます
         </span>
       </div>
-
-      <Script id={`msmaf-${eid}`} strategy="lazyOnload">
-        {`${MOSHIMO_LOADER}msmaflink(${payloadJson});`}
-      </Script>
 
       <div id={`msmaflink-${eid}`}>リンク</div>
     </div>


### PR DESCRIPTION
## 概要

PE キーワード／Civil textbook/primary/secondary など、`<BookCard>` を配置した全ページで「PR バッジは出るがアフィリエイトカード本体が描画されず "リンク" のプレースホルダーのまま残る」不具合を修正。

## 根本原因

旧実装は `next/script strategy="lazyOnload"` で moshimo `bundle.js` を発火していた。しかし bundle.js の IIFE は

```js
window.addEventListener("DOMContentLoaded", F);
window.addEventListener("load", F);
```

としてキュー処理関数 `F` をリスナ登録するだけで、即時実行しない。`lazyOnload` は `window.load` 後に発火するため、両イベントが既に通過済みで `F` が永遠に呼ばれず、`window.msmaflink.q` が処理されない。

### Playwright 実機検証（修正前）

| 項目 | 値 |
|---|---|
| `#msmaflink-NBy9N` innerHTML | `"リンク"`（プレースホルダーのまま） |
| `window.msmaflink.q.length` | `1`（キューに積まれたまま） |
| `<script id="msmaflink">` | 存在（bundle 自体は到達済） |
| `<script id="msmaf-NBy9N">` の親 | `<body>` 直下（DOM 位置も乖離） |

## 修正方針

`next/script` を捨て `useEffect` で手動制御：

1. `msmaflink` キュー関数を初期化（既存があれば共有）
2. `bundle.js` を `SCRIPT_ID` で1度だけ body に注入
3. ロード完了後、`document.readyState === "complete"` なら `window.dispatchEvent(new Event("load"))` で `F` を起動
4. 複数 BookCard 共存（civil-textbook の2冊ペア等）に対応し、後続カードはキュー追記後すぐに `triggerQueueProcess()` を呼ぶ
5. プレースホルダー解決は bundle 側の `eid` ロジックに任せるため、DOM 位置依存も解消

## 影響範囲

- PE キーワード 全ページ（記事末参考書籍）
- Civil textbook/primary/secondary/guide（記事末 BookCard ペア）
- トップページ最下部の参考書籍

## 副作用

合成 `load` イベントを再ディスパッチするため、他の `window.load` リスナ（AdSense lazyOnload・gtag）にも反応する可能性。両者は1度きりの初期化済みのため二重起動の害は限定的だが、デプロイ後 GA・AdSense の挙動異常がないかを確認。

## 検証

- [x] `npm run type-check` パス
- [x] `npm run lint` BookCard.tsx に新規エラーなし
- [x] `npm run build` 成功（errors: 0、Compiled successfully）
- [ ] デプロイ後、本番ページで `#msmaflink-NBy9N` の innerHTML がカード DOM に置換されることを Playwright/手動で確認
- [ ] GA・AdSense の挙動異常がないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_011fGV3ZtbR25EjE2bfBcMZR)_