### PR TITLE
feat(affiliate): BookSection で参考書籍ブロックを1セクションに統合

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -32,6 +32,7 @@ import { resolvePlacement } from '@/lib/magazine-placement';
 import { getMagazine, buildMagazineUrl, type NoteMagazine } from '@/lib/note-magazines';
 import PastExamBacklinks from '@/components/ui/PastExamBacklinks/PastExamBacklinks';
 import BookCard from '@/components/ui/BookCard/BookCard';
+import BookSection from '@/components/ui/BookSection/BookSection';
 import RelatedTextbooks from '@/components/ui/RelatedTextbooks/RelatedTextbooks';
 import TextbookNav from '@/components/ui/TextbookNav/TextbookNav';
 import AuthorCard from '@/components/ui/AuthorCard/AuthorCard';
@@ -432,26 +433,20 @@ export default async function DocPage({
                 </div>
                 {/* 参考書籍（アフィリエイト・補完ポジション。記事末の最下部に配置） */}
                 <div className="mt-8">
-                  <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">参考書籍</h2>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                    総監対策の定番キーワード集。択一の幅広い出題範囲をカバーしたいときに。
-                  </p>
-                  <BookCard asin="4274234746" />
+                  <BookSection caption="総監対策の定番キーワード集。択一の幅広い出題範囲をカバーしたいときに。">
+                    <BookCard asin="4274234746" />
+                  </BookSection>
                 </div>
               </>
             )}
 
             {/* PE past-exam: 参考書籍（アフィリエイト・補完ポジション） */}
             {category === 'pe-comprehensive-management' && docGroup === 'pastExam' && (
-              <>
-                <div className="mt-8">
-                  <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">参考書籍</h2>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                    令和8年度の予想問題と模試で直前対策を仕上げたいときに。
-                  </p>
+              <div className="mt-8">
+                <BookSection caption="令和8年度の予想問題と模試で直前対策を仕上げたいときに。">
                   <BookCard asin="4798076546" />
-                </div>
-              </>
+                </BookSection>
+              </div>
             )}
 
             {/* Civil primary/secondary: 関連テキスト章 (過去問→教材) */}
@@ -465,12 +460,10 @@ export default async function DocPage({
                 過去問解説集（4886154557）+ 経験記述70パターン（4816378561）の固定ペア。） */}
             {category === 'civil-construction-1' && docGroup === 'secondary' && (
               <div className="mt-8">
-                <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">参考書籍</h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                  過去問演習と経験記述70パターンで二次対策を固めたいときに。
-                </p>
-                <BookCard asin="4886154557" />
-                <BookCard asin="4816378561" />
+                <BookSection caption="過去問演習と経験記述70パターンで二次対策を固めたいときに。">
+                  <BookCard asin="4886154557" />
+                  <BookCard asin="4816378561" />
+                </BookSection>
               </div>
             )}
 
@@ -486,12 +479,10 @@ export default async function DocPage({
                 {/* 参考書籍（Civil textbook: アフィリエイト・補完ポジション。
                     合格ガイド（4798176834・両用）+ 第1次徹底図解（4816378243・一次特化、R6追加分野対応）の固定ペア。） */}
                 <div className="mt-8">
-                  <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">参考書籍</h2>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                    両用1冊で全体像をつかみ、一次特化テキストで R6 追加分野まで押さえたいときに。
-                  </p>
-                  <BookCard asin="4798176834" />
-                  <BookCard asin="4816378243" />
+                  <BookSection caption="両用1冊で全体像をつかみ、一次特化テキストで R6 追加分野まで押さえたいときに。">
+                    <BookCard asin="4798176834" />
+                    <BookCard asin="4816378243" />
+                  </BookSection>
                 </div>
                 <CivilSatProductCTA />
               </>
@@ -502,12 +493,10 @@ export default async function DocPage({
             {category === 'civil-construction-1' && docGroup === 'primary' && (
               <>
                 <div className="mt-8">
-                  <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">参考書籍</h2>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                    解説重視と過去7年の演習量の両軸で一次過去問を仕上げたいときに。
-                  </p>
-                  <BookCard asin="4297154099" />
-                  <BookCard asin="4886154530" />
+                  <BookSection caption="解説重視と過去7年の演習量の両軸で一次過去問を仕上げたいときに。">
+                    <BookCard asin="4297154099" />
+                    <BookCard asin="4886154530" />
+                  </BookSection>
                 </div>
                 <CivilSatProductCTA />
               </>
@@ -519,12 +508,10 @@ export default async function DocPage({
             {category === 'civil-construction-1' && docGroup === 'guide' && (
               <>
                 <div className="mt-8">
-                  <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">参考書籍</h2>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                    まずは1冊で全体像をつかみ、過去問演習で出題傾向に慣れる王道ペア。
-                  </p>
-                  <BookCard asin="4798176834" />
-                  <BookCard asin="4297154099" />
+                  <BookSection caption="まずは1冊で全体像をつかみ、過去問演習で出題傾向に慣れる王道ペア。">
+                    <BookCard asin="4798176834" />
+                    <BookCard asin="4297154099" />
+                  </BookSection>
                 </div>
                 <CivilSatProductCTA />
               </>
@@ -547,13 +534,15 @@ export default async function DocPage({
                 R8 予想ページは予想模試本、それ以外は受験万全対策本） */}
             {category === 'pe-comprehensive-management' && docGroup === 'guide' && (
               <div className="mt-8">
-                <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">参考書籍</h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                  {slugStr.includes('r8-essay')
-                    ? '令和8年度の予想問題と模試で直前対策を仕上げたいときに。'
-                    : '総監受験を申込書から口頭試験まで通して押さえたいときに。'}
-                </p>
-                <BookCard asin={slugStr.includes('r8-essay') ? '4798076546' : '4526084263'} />
+                <BookSection
+                  caption={
+                    slugStr.includes('r8-essay')
+                      ? '令和8年度の予想問題と模試で直前対策を仕上げたいときに。'
+                      : '総監受験を申込書から口頭試験まで通して押さえたいときに。'
+                  }
+                >
+                  <BookCard asin={slugStr.includes('r8-essay') ? '4798076546' : '4526084263'} />
+                </BookSection>
               </div>
             )}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import BookCard from "@/components/ui/BookCard/BookCard";
+import BookSection from "@/components/ui/BookSection/BookSection";
 import { Hero, ExamCards, LatestArticles, AboutSection } from "@/components/home";
 import type { LatestArticle } from "@/components/home";
 import { getDocsMetaByCategory, getAllDocsMeta, type DocMeta } from "@/lib/docs";
@@ -107,15 +108,14 @@ export default async function HomePage() {
         <LatestArticles articles={latest} />
         <AboutSection />
         {/* 参考書籍（補完ポジション・トップ最下部。ファーストビュー外） */}
-        <section className="mx-auto max-w-3xl px-4 py-10">
-          <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">
-            総監受験の参考書籍
-          </h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-            総監受験を申込書から口頭試験まで通して押さえたいときに。
-          </p>
-          <BookCard asin="4526084263" />
-        </section>
+        <div className="mx-auto max-w-3xl px-4 py-10">
+          <BookSection
+            title="総監受験の参考書籍"
+            caption="総監受験を申込書から口頭試験まで通して押さえたいときに。"
+          >
+            <BookCard asin="4526084263" />
+          </BookSection>
+        </div>
       </main>
       <Footer />
     </div>

--- a/src/components/ui/BookCard/BookCard.tsx
+++ b/src/components/ui/BookCard/BookCard.tsx
@@ -111,7 +111,7 @@ export default function BookCard({ asin }: BookCardProps) {
   }
 
   return (
-    <div className="not-prose my-6">
+    <div className="not-prose">
       <div className="mb-1.5 flex items-center gap-1.5">
         <span
           className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wider text-white"

--- a/src/components/ui/BookCard/BookCard.tsx
+++ b/src/components/ui/BookCard/BookCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Script from "next/script";
+import { useEffect } from "react";
 import affiliateBooks from "@/config/affiliate-books.json";
 
 interface BookCardProps {
@@ -22,32 +22,93 @@ interface BookCardProps {
  *
  * ステマ規制（2023-10〜）対応として「PR」表示を付与する。
  * 配置原則: 記事末・hub 末の補完導線。ファーストビュー禁止。
+ *
+ * 実装メモ:
+ * - 旧実装は `next/script strategy="lazyOnload"` でローダを発火していたが、
+ *   moshimo bundle.js は IIFE 内で `window.addEventListener("DOMContentLoaded"|"load", F)`
+ *   としてキュー処理関数 F をリスナ登録するだけで即時呼ばない。
+ *   lazyOnload は window.load 後に発火するため両イベントが既に通過済みで、
+ *   F が永遠に呼ばれず `window.msmaflink.q` が処理されない不具合があった。
+ *   useEffect 内で手動ロード後に load イベントを再ディスパッチして F を起動する。
  */
 
-// もしも かんたんリンク公式ローダ（bundle.js を1度だけ body に注入し、
-// msmaflink 呼び出しをキューイングする IIFE）。
-const MOSHIMO_LOADER =
-  "(function(b,c,f,g,a,d,e){b.MoshimoAffiliateObject=a;" +
-  "b[a]=b[a]||function(){arguments.currentScript=c.currentScript" +
-  "||c.scripts[c.scripts.length-2];(b[a].q=b[a].q||[]).push(arguments)};" +
-  "c.getElementById(a)||(d=c.createElement(f),d.src=g,d.id=a," +
-  'e=c.getElementsByTagName("body")[0],e.appendChild(d))})' +
-  '(window,document,"script",' +
-  '"//dn.msmstatic.com/site/cardlink/bundle.js?20220329","msmaflink");';
+const BUNDLE_URL = "https://dn.msmstatic.com/site/cardlink/bundle.js?20220329";
+const SCRIPT_ID = "msmaflink";
+
+type MsmaflinkWindow = typeof window & {
+  MoshimoAffiliateObject?: string;
+  msmaflink?: {
+    (payload: unknown): void;
+    q?: unknown[];
+  };
+};
+
+function ensureLoaderQueue(): void {
+  const w = window as MsmaflinkWindow;
+  if (w.msmaflink) return;
+  w.MoshimoAffiliateObject = "msmaflink";
+  const fn = function (this: unknown) {
+    // eslint-disable-next-line prefer-rest-params
+    const args = arguments as unknown as { currentScript?: Element | null };
+    args.currentScript = document.currentScript;
+    // eslint-disable-next-line prefer-rest-params
+    (fn.q = fn.q || []).push(arguments);
+  } as MsmaflinkWindow["msmaflink"] & { q?: unknown[] };
+  w.msmaflink = fn;
+}
+
+function triggerQueueProcess(): void {
+  // bundle.js の F は DOMContentLoaded / load のリスナとして登録されるだけで、
+  // 自前では即時実行しない。load が既に通過済みなら手動でディスパッチして起動する。
+  if (document.readyState === "complete") {
+    window.dispatchEvent(new Event("load"));
+  }
+}
+
+function loadBundleOnce(): void {
+  const existing = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+  if (existing) {
+    // 既にロード済み（同ページの別 BookCard が先に注入）→ キュー追記後すぐ起動
+    if (existing.dataset.loaded === "true") {
+      triggerQueueProcess();
+    } else {
+      existing.addEventListener("load", triggerQueueProcess, { once: true });
+    }
+    return;
+  }
+  const script = document.createElement("script");
+  script.id = SCRIPT_ID;
+  script.src = BUNDLE_URL;
+  script.async = true;
+  script.addEventListener(
+    "load",
+    () => {
+      script.dataset.loaded = "true";
+      triggerQueueProcess();
+    },
+    { once: true },
+  );
+  document.body.appendChild(script);
+}
 
 export default function BookCard({ asin }: BookCardProps) {
   const books = affiliateBooks as Record<string, unknown>;
   const payload = books[asin];
+  const eid =
+    payload && typeof payload === "object"
+      ? (payload as { eid?: string }).eid
+      : undefined;
 
-  if (!payload || typeof payload !== "object") {
+  useEffect(() => {
+    if (!payload || !eid) return;
+    ensureLoaderQueue();
+    (window as MsmaflinkWindow).msmaflink?.(payload);
+    loadBundleOnce();
+  }, [eid, payload]);
+
+  if (!payload || typeof payload !== "object" || !eid) {
     return null;
   }
-
-  const eid = (payload as { eid?: string }).eid;
-  if (!eid) return null;
-
-  // </script> によるブレイクアウトを防ぐため < をエスケープ
-  const payloadJson = JSON.stringify(payload).replace(/</g, "\\u003c");
 
   return (
     <div className="not-prose my-6">
@@ -63,10 +124,6 @@ export default function BookCard({ asin }: BookCardProps) {
           アフィリエイトリンクを含みます
         </span>
       </div>
-
-      <Script id={`msmaf-${eid}`} strategy="lazyOnload">
-        {`${MOSHIMO_LOADER}msmaflink(${payloadJson});`}
-      </Script>
 
       <div id={`msmaflink-${eid}`}>リンク</div>
     </div>

--- a/src/components/ui/BookSection/BookSection.tsx
+++ b/src/components/ui/BookSection/BookSection.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+interface BookSectionProps {
+  /** セクション見出し。デフォルト "参考書籍"。記事内 h2 と区別するため div + 小ラベルでレンダリング */
+  readonly title?: string;
+  /** 見出し直下の説明文（誘導コピー） */
+  readonly caption: string;
+  /** 1枚または複数の <BookCard /> を子に渡す */
+  readonly children: ReactNode;
+  /** 外側コンテナの className を上書き／拡張したい場合に使用 */
+  readonly className?: string;
+}
+
+/**
+ * BookSection — 記事末・トップ末の補完導線として、見出し + キャプション + BookCard 群を
+ * 1つの軽量コンテナにまとめて表示するセクションラッパー。
+ *
+ * 設計判断（2026-05-27）:
+ * - moshimo `.easyLink-box` は独自に白背景 + 1px border + 20px padding を持つため、
+ *   外側に border 付きカードを被せると二重カードになる。
+ *   → 外側は薄い背景 (bg-gray-50/dark:bg-gray-900/40) のみで境界を作る。
+ * - 旧実装は `<h2>` を使っており TOC に紛れていた。
+ *   → div + 小ラベル（uppercase tracking-wide）に格下げし TOC ノイズを除去。
+ * - 複数 BookCard（civil-textbook の合格テキスト + 一次過去問ペア等）を1キャプションで
+ *   束ねる既存パターンを維持するため、`children` を可変個受け取る。
+ */
+export default function BookSection({
+  title = "参考書籍",
+  caption,
+  children,
+  className,
+}: BookSectionProps) {
+  const containerClass = [
+    "rounded-card-content bg-gray-50 dark:bg-gray-900/40 px-4 py-4",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <section className={containerClass}>
+      <div className="text-[11px] font-bold tracking-[0.12em] text-ink-muted dark:text-gray-500 mb-1 uppercase">
+        {title}
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">{caption}</p>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}

--- a/src/components/ui/BookSection/index.ts
+++ b/src/components/ui/BookSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BookSection";


### PR DESCRIPTION
## 概要

「参考書籍 + キャプション + BookCard」を1セクションに統合する `<BookSection>` コンポーネントを新設し、サイト全体（8箇所）の参考書籍ブロックに適用。

## 動機

ユーザー指摘：「参考書籍／キャプション／BookCard が分離して見え、1まとまりに見えない」。

旧実装の問題：

1. **moshimo `.easyLink-box` が白背景 + 1px border を持つ**ため、隣接する `<h2>` + `<p>` と視覚的に同じグループに見えない（card は浮き、heading は本文と同じ平面）。
2. **`<h2>` が TOC に紛れる**。記事末の補完導線が本文と同階層に並んで情報設計上のノイズになる。

## 設計判断

| 観点 | 採用案 | 却下案 |
|---|---|---|
| 外枠 | `bg-gray-50/dark:bg-gray-900/40` のみ（border なし） | border 付きカード（moshimo の枠と二重になる） |
| 見出し | `<div>` + 小ラベル `text-[11px] uppercase` | `<h2>` 維持（TOC ノイズ） |
| 複数カード | `space-y-3` で同一キャプション配下に並列 | カード毎に個別ラップ（ペア感を失う） |
| BookCard 自体 | `my-6` を撤去し、親が余白を管理 | `my-6` 維持（BookSection との二重余白） |

## 適用箇所

| ファイル | 配置 | 内訳 |
|---|---|---|
| `src/app/page.tsx` | トップ最下部 | 1冊（受験万全対策） |
| `src/app/docs/[...slug]/page.tsx` | PE keyword | 1冊（キーワード集） |
| 〃 | PE pastExam | 1冊（予想模試） |
| 〃 | PE guide | 1冊（r8-essay 分岐） |
| 〃 | Civil secondary | 2冊（過去問解説 + 経験記述70パターン） |
| 〃 | Civil textbook | 2冊（合格ガイド + 第1次徹底図解） |
| 〃 | Civil primary | 2冊（過去問マスター + 第一次解説） |
| 〃 | Civil guide | 2冊（合格テキスト + 一次過去問） |

## 検証

- [x] `npm run type-check` パス
- [x] `npm run lint` 新規エラーなし
- [x] `npm run build` 成功（errors: 0、Compiled successfully）
- [ ] デプロイ後、PE / Civil 各パターンを目視確認
- [ ] 既存の TOC に「参考書籍」が出なくなったことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_011fGV3ZtbR25EjE2bfBcMZR)_