### PR TITLE
ci(metrics): 週次レビュー用に7日窓スナップショットを追加（NSM 精度向上）

### DIFF
--- a/.github/workflows/fetch-metrics.yml
+++ b/.github/workflows/fetch-metrics.yml
@@ -44,10 +44,26 @@ jobs:
           GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
         run: npm run fetch-ga4-data -- --dimension date
 
+      # 週次レビュー(オフライン)用: クリーンな7日窓の Organic Search スナップショット。
+      # 既定の channel フェッチは28日窓のため WoW にならない。これは ga4-channel-organic-*.json として出力され、
+      # weekly-review のオフライン経路が最新2ファイルで NSM の週次比較を算出する。
+      - name: Fetch GA4 (organic, 7d for weekly NSM)
+        env:
+          GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ./credentials/gsc-service-account.json
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+        run: npm run fetch-ga4-data -- --dimension channel --days 7 --organic-only
+
       - name: Fetch GSC
         env:
           GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ./credentials/gsc-service-account.json
         run: npm run fetch-gsc-data
+
+      # 週次レビュー(オフライン)用: クリーンな7日窓の日次 GSC スナップショット（gsc-date-*.json）。
+      # 既定の query フェッチは28日窓。最新2ファイルの日次 clicks/impressions 合計で週次比較を算出する。
+      - name: Fetch GSC (date, 7d for weekly trend)
+        env:
+          GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ./credentials/gsc-service-account.json
+        run: npm run fetch-gsc-data -- --dimension date --days 7
 
       - name: Check data integrity
         id: integrity


### PR DESCRIPTION
## 目的
クラウドルーティン `doboku-weekly-review`（オフライン経路）が読むメトリクスを、**正確な週次 WoW** にする。

## 背景
CI がコミットする既定の `ga4-channel-*.json` / `gsc-query-*.json` は **28日窓**。クラウドルーティンには GA4/GSC のライブ認証が無く、コミット済みファイルしか読めないため、これでは NSM の前週比（WoW）が「28日ローリングの差分」になり不正確だった（手動レビューは7日窓を明示要求する `metrics-reader.mjs` を使うため正確）。

## 変更
`fetch-metrics.yml`（毎週金曜 06:00 JST）に2ステップ追加：
- **GA4**: `--dimension channel --days 7 --organic-only` → `ga4-channel-organic-*.json`（7日・JP・Organic Search = NSM）
- **GSC**: `--dimension date --days 7` → `gsc-date-*.json`（7日・日次）

既定の28日フェッチは温存（別ファイル名なので衝突なし）。weekly-review のオフライン経路が最新2ファイルでクリーンな週次比較を算出する。

## 関連
- PR #228（weekly-review を md 保存方式に変更 + オフライン経路を `ga4-channel-organic-*` 優先に更新）
- クラウドルーティン `doboku-weekly-review` の prompt も `ga4-channel-organic-*` を読むよう更新済み

## 注意
- GSC は3日遅延あり。7日窓は直近数日が未確定だが、両週とも同条件のため WoW の方向は有効

🤖 Generated with [Claude Code](https://claude.com/claude-code)