### PR TITLE
feat(skill): クラウドルーティン監査スキル /routines を新設

### DIFF
--- a/.claude/skills/management/routines/SKILL.md
+++ b/.claude/skills/management/routines/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: routines
+description: >
+  クラウドルーティン（/schedule で作成する RemoteTrigger 定期エージェント）を一覧・監査する。
+  重複（同一成果物を生成する routine）・残骸 one-shot（self-disable 漏れ）・平文シークレット・
+  cron 衝突・無効ルーティンを検出してレポートする。新規 routine を作る前の重複チェックにも使う。
+  Use when user asks to [ルーティン一覧, ルーティン監査, クラウドルーティン確認, routine 重複チェック, スケジュール一覧, /routines].
+---
+
+クラウドルーティン（claude.ai の RemoteTrigger / `/schedule` で作る定期エージェント）を list して監査する Evaluator 系スキル。
+
+状態は **repo にもローカルにも存在せず、唯一の真実源はクラウド側の `RemoteTrigger list`**。別セッションで作られた routine はコンテキストに痕跡を残さないため、能動的に取得して可視化しないと存在を把握できない。
+
+## 最重要ルール（重複事故の再発防止）
+
+**`/schedule` で routine を新規作成する前に、必ず本スキル（または `RemoteTrigger {action:"list"}`）で既存を確認する。** 同一 repo × 同一成果物（生成ファイルパス／目的）を作る routine が既にあれば、新規作成せず既存を `update` する。
+
+> 背景: 2026-05-30 に既存の `doboku-note weekly PDCA` を確認せず `doboku-weekly-review` を新規作成し、`docs/reviews/weekly/*-review.md` を二重生成する重複を起こした。create 前の list-first を怠ったのが原因。
+
+## ツール準備
+
+`RemoteTrigger` は deferred tool。先に読み込む:
+
+```
+ToolSearch { query: "select:RemoteTrigger" }
+```
+
+## 手順
+
+1. `RemoteTrigger { action: "list" }` で全ルーティンを取得。
+2. 各ルーティンを解析する（`job_config.ccr.session_context.sources` の repo、`cron_expression`、`enabled`、`run_once_at` / `ended_reason`、`events[].data.message.content` の本文）。
+3. 下記ルールで問題を検出する。
+4. **repo（プロジェクト）別**にグルーピングして表で報告。cron は **JST 併記**（UTC+9）。問題は優先度付きで surface。
+
+### 検出ルール
+
+- **重複（最優先）**: 同一 repo かつ本文中の生成ファイルパス／目的が重なる（例: 複数 routine が `docs/reviews/weekly/*-review.md` を生成）。
+- **残骸 one-shot**: `ended_reason == "run_once_fired"` なのに `enabled == true`、または本文に「one-off」「self-disable」「実行後に自分を disable」とあるのに `enabled == true` で次回 fire が将来日付。
+- **平文シークレット**: 本文に `ACCESS_TOKEN` / `API_KEY` / `SECRET` / `PASSWORD` / `Bearer ` や 20 文字以上連続の英数字トークンらしき文字列。露出リスクとして警告。
+- **cron 衝突 / 近接**: 同一 repo で同一時刻帯（同 UTC hour）に複数が fire。リソース競合・PR 衝突の懸念。
+- **無効ルーティン**: `enabled == false` を棚卸し（不要なら手動削除候補）。
+
+## 出力フォーマット
+
+```markdown
+## クラウドルーティン監査（YYYY-MM-DD）
+
+### {repo} （N 個）
+| ルーティン | cron(JST) | 役割 | 状態 |
+|---|---|---|---|
+
+### 検出された問題
+- [重複] ...
+- [残骸 one-shot] ...
+- [平文シークレット] ...
+- [cron 衝突] ...
+
+### 推奨アクション
+- ...
+```
+
+## 制約
+
+- 本スキルは **surface のみ（Evaluator）**。`disable` / `update` の実行はユーザー承認後に行う。
+- routine の **削除は API 不可**。https://claude.ai/code/routines で手動削除する。
+- 修正が必要なら `RemoteTrigger {action:"update", trigger_id, body:{enabled:false}}` 等を別途ユーザー判断で実行。
+- **平文シークレットは値そのものをレポートに転記しない**（「token らしき文字列を検出」とだけ書く）。
+
+## 参照
+
+- `.claude/skills/management/weekly-review/SKILL.md` — 重複事故の当事者（正典は `doboku-note weekly PDCA` routine）
+- 新規作成は built-in の `/schedule` スキル。create 前に必ず本スキルで list-first する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,7 @@ npm run pages:deploy      # Cloudflare Pages に手動デプロイ
 - **情報の置き場（4 ゾーンモデル）**: A=`docs/`（戦略・設計・進捗・週次 PDCA・引き継ぎ）/ B=`docs/reference/`（運用手順・ポリシー）/ C=`.claude/state/`・`.claude/config/`（機械データ・`task-queue.json`、`.claude/state/*.md` 新規作成禁止）/ D=`.claude/skills/`・`.claude/agents/`（実行能力）。**GitHub Issue は使わない**（廃止、タスクは `task-queue.json` に集約）。真実源・判断フローは [information-architecture.md](docs/reference/information-architecture.md)
 - **スキル/エージェント更新ルール**: `.claude/skills/` または `.claude/agents/` を追加・修正・削除した場合は、同一 commit で `docs/reference/skills-guide.md`（一覧）と `docs/reference/skills-registry.md`（退役ログ）または `docs/reference/agents-registry.md` を必ず更新する
 - MDX を追加・編集する前に `docs/reference/content-authoring.md` を Read する
+- **クラウドルーティン作成ルール**: `/schedule`（RemoteTrigger）で定期エージェントを新規作成する前に、必ず `/routines`（または `RemoteTrigger {action:"list"}`）で既存を確認し、同一成果物を生成する重複・cron 衝突がないか検証する（2026-05-30 weekly-review 重複事故の再発防止）
 
 ### 9. テストは挙動だけでなく意図を検証する
 

--- a/docs/reference/skills-guide.md
+++ b/docs/reference/skills-guide.md
@@ -102,6 +102,7 @@ title: スキル ナビゲーションガイド
 | `/critical-review` | 批判的レビュー | `批判的に見て`, `/critical-review` |
 | `/pre-mortem` | Pre-Mortem の実施 | `Pre-Mortem`, `リスク洗い出し`, `/pre-mortem` |
 | `/distill-proofread-learnings` | 校正作業から新規ルール・ユーザー嗜好を抽出 | `校正から学ぶ`, `新ルール抽出`, `/distill-proofread-learnings` |
+| `/routines` | クラウドルーティン（/schedule）を一覧・監査（重複・残骸・平文トークン・cron 衝突検出）。**新規作成前の重複チェック必須** | `ルーティン一覧`, `ルーティン監査`, `/routines` |
 
 ### UI/UX（ui）
 

--- a/docs/reference/skills-registry.md
+++ b/docs/reference/skills-registry.md
@@ -18,16 +18,17 @@ title: スキル ガバナンス記録
 ├── authoring/       # 9 — 記事を作る
 ├── conversion/      # 4 — 形式変換（MDX / OGP 画像 / 紙用 PDF）
 ├── quality/         # 12 — MDX・note 公開前品質検査
-├── management/      # 11 — 計画・分析・戦略
+├── management/      # 12 — 計画・分析・戦略
 ├── dev/             # 11 — 開発・CI/CD
 ├── analytics/       # 2 — サイト分析
 ├── social/          # 6 — SNS 投稿
 └── ui/              # 1 — UI/UX デザイン
 ```
 
-合計 **56 スキル**（Phase 2 待機を除く）。
+合計 **57 スキル**（Phase 2 待機を除く）。
 
 > 2026-05-29 追加: `authoring/civil-keiken-magazine`（1級・2級土木 施工経験記述 マガジン模範答案の生成・採点。Generator `civil-keiken-essay-writer` ＋ Evaluator `civil-keiken-essay-qa`）。
+> 2026-05-30 追加: `management/routines`（クラウドルーティン /schedule の一覧・監査。重複・残骸 one-shot・平文シークレット・cron 衝突を検出。weekly-review 重複作成事故[2026-05-30]の再発防止。create 前 list-first を運用ルール化）。
 
 ---
 


### PR DESCRIPTION
## 目的
クラウドルーティン（`/schedule` で作る RemoteTrigger 定期エージェント）の**重複作成事故の再発防止**と、定期的なハウスキーピング。

## 背景
2026-05-30、既存の `doboku-note weekly PDCA` routine を確認せず `doboku-weekly-review` を新規作成し、`docs/reviews/weekly/*-review.md` を二重生成する重複を起こした。根本原因は **routine がクラウド側にしか存在しない不可視な状態**で、かつ **作成前に list していなかった**こと。

## 変更
- **新スキル `/routines`**（`.claude/skills/management/routines/`）— RemoteTrigger を list して以下を検出・レポート:
  - 重複（同一 repo × 同一成果物を生成する routine）
  - 残骸 one-shot（self-disable 漏れ）
  - 平文シークレット（プロンプト内のトークン露出）
  - cron 衝突 / 近接、無効ルーティンの棚卸し
  - surface のみ（Evaluator）。削除は API 不可なので claude.ai 手動
- **CLAUDE.md §8**: 「routine 作成前に必ず list-first で重複確認」ルールを追記
- **skills-guide.md / skills-registry.md** 更新（management 11→12、合計 56→57）

## 設計判断
サブエージェントではなく**スキル**で実装。理由: RemoteTrigger はメインコンテキストで確実に呼べる（この環境のサブエージェントは Bash 不可・RemoteTrigger アクセス未検証）／監査は軽い単発処理で委譲の利点が薄い／失敗は「CHECK の欠落」でありルール化が本質。

🤖 Generated with [Claude Code](https://claude.com/claude-code)