### PR TITLE
feat(note): 完全パック公開 + 記述式戦略ハブに総監3マガジンを配線

### DIFF
--- a/src/lib/magazine-placement.ts
+++ b/src/lib/magazine-placement.ts
@@ -82,10 +82,15 @@ const ALL_PERSONA_MAGAZINES: readonly MagazineId[] = [
  * M2「白書 R7 完全対応集」は 2026-05-25 に完全無料リード磁石へ戦略転換 (SoT 削除)。
  * 配置原則:
  * - r8-essay-forecast (¥2,480): R07 年度ページ + essay-exam-strategy hub
+ * - essay-complete-pack / tradeoff-5kanri / setsumon3-policy-bank (2026-06-03 配線):
+ *   essay-exam-strategy hub にパイプライン順で追加。完全パックを筆頭の強 CTA に。
  *
  * 注: essay-template-3d「解答テンプレ 3D」(¥2,980) は 2026-06-01 企画中止により配線削除。
  */
 const NEW_MAGAZINES = {
+  completePack: 'essay-complete-pack' as const,
+  tradeoff5kanri: 'tradeoff-5kanri' as const,
+  setsumon3Bank: 'setsumon3-policy-bank' as const,
   r8Forecast: 'r8-essay-forecast' as const,
 } satisfies Record<string, MagazineId>;
 
@@ -101,11 +106,17 @@ const NEW_MAGAZINES = {
 export function resolvePlacement(slug: string, docGroup: DocGroupKey): ResolvedPlacement {
   // 1. 完全一致: 記述式戦略ハブは精読ガイド + 新規プレミアム + 全 3 ペルソナ模範論文を提示 (強 CTA)
   if (slug === 'pe-comprehensive-management-essay-exam-strategy') {
+    // パイプライン順 (完全パック → 型 → 設問3 → 予想 → 模範論文 → 精読基礎)。
+    // 完全パックを inline 筆頭の強 CTA に。sidebar は sidebarImageUrl を持つ
+    // 精読ガイドを維持（完全パックは sidebarImageUrl 未設定のため画像カードが出ない）。
     return {
       inline: [
-        slot('tankan-reading-guide', slug, 'inline-1'),
-        slot(NEW_MAGAZINES.r8Forecast, slug, 'inline-3'),
-        ...ALL_PERSONA_MAGAZINES.map((m, i) => slot(m, slug, `inline-${i + 4}`)),
+        slot(NEW_MAGAZINES.completePack, slug, 'inline-1'),
+        slot(NEW_MAGAZINES.tradeoff5kanri, slug, 'inline-2'),
+        slot(NEW_MAGAZINES.setsumon3Bank, slug, 'inline-3'),
+        slot(NEW_MAGAZINES.r8Forecast, slug, 'inline-4'),
+        ...ALL_PERSONA_MAGAZINES.map((m, i) => slot(m, slug, `inline-${i + 5}`)),
+        slot('tankan-reading-guide', slug, 'inline-8'),
       ],
       sidebar: [
         slot('tankan-reading-guide', slug, 'sidebar-1'),

--- a/src/lib/note-magazines.ts
+++ b/src/lib/note-magazines.ts
@@ -163,14 +163,13 @@ const MAGAZINES_RAW = {
     badge: 'note 限定',
   },
 
-  // ----- 総監記述式 完全パック (2026-06-01 企画、設問3バンク公開後に実装) -----
+  // ----- 総監記述式 完全パック (2026-06-01 企画、2026-06-03 note 公開) -----
   // 既存5マガジン（クロストレードオフ + 設問3バンク + R8予想 + 模範論文3ペルソナ）のバンドル。
   // 恒常¥7,980 / 試験直前限定¥5,980（試験後に¥7,980へ戻す）。実装前提は noteコンテンツ計画.md M13 参照。
-  // published: false（note 上にバンドル未構築・noteUrl 未取得）。カバーは generate-magazine-covers.mjs で要追加。
   'essay-complete-pack': {
     id: 'essay-complete-pack',
-    published: false,
-    noteUrl: '',
+    published: true,
+    noteUrl: 'https://note.com/dobokunote/m/m171222175fac',
     title: '総監記述式 完全パック｜型×設問3×予想×模範論文 全部入り',
     description:
       '記述式の答案完成パイプラインを1パックで完結。クロストレードオフ（5管理対立の型）＋設問3国家施策バンク（設問3の弾薬）＋R8予想問題集（予想演習）＋模範論文3ペルソナ（フル実演・全ペルソナ）を収録。単品合計¥14,380相当。',


### PR DESCRIPTION
## 概要

公開済みの総監マガジン3本をサイト側 CTA に反映する。記事本文（develop 直 push 済み）と対になるコード変更。

## 変更

- **`note-magazines.ts`**: `essay-complete-pack`（総監記述式 完全パック）を `published:true` 化し noteUrl を設定（2026-06-03 note 公開）。
- **`magazine-placement.ts`**: 記述式戦略ハブ `pe-comprehensive-management-essay-exam-strategy` の inline CTA をパイプライン順（完全パック→型→設問3→予想→3ペルソナ→精読）に再編。完全パックを筆頭の強 CTA に。

## 判断メモ

- `tradeoff-5kanri` / `setsumon3-policy-bank` は SoT 登録済み（`published:true`）。今回はハブへの配線のみ追加。
- sidebar は `sidebarImageUrl` を持つ精読ガイドを維持（完全パックは `sidebarImageUrl` 未設定 → 画像カード非表示になるため）。

## 検証

- `npm run type-check` 通過
- 追加3本のカバー webp 実在を確認（complete-pack / tradeoff-5kanri / setsumon3-policy-bank）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
