### PR TITLE
ci: actions/checkout・setup-node を v4→v5 に更新（Node20 deprecation 解消）

### DIFF
--- a/.github/workflows/cf-cleanup.yml
+++ b/.github/workflows/cf-cleanup.yml
@@ -23,10 +23,10 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/fetch-metrics.yml
+++ b/.github/workflows/fetch-metrics.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/link-audit.yml
+++ b/.github/workflows/link-audit.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout develop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: develop
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 

--- a/.github/workflows/post-instagram-scheduled.yml
+++ b/.github/workflows/post-instagram-scheduled.yml
@@ -30,13 +30,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: 🧰 Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 1
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 

--- a/.github/workflows/psi-audit.yml
+++ b/.github/workflows/psi-audit.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/r2-audit.yml
+++ b/.github/workflows/r2-audit.yml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout main (production source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/r2-sync.yml
+++ b/.github/workflows/r2-sync.yml
@@ -35,9 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/upload-instagram-assets.yml
+++ b/.github/workflows/upload-instagram-assets.yml
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/uptime-ping.yml
+++ b/.github/workflows/uptime-ping.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout develop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: develop
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 


### PR DESCRIPTION
## 概要

GitHub Actions の Node.js 20 ランタイム deprecation を解消する。`actions/checkout@v4` / `actions/setup-node@v4` は Node 20 で動作し、2026-06-16 以降 Node 24 が強制、2026-09-16 にランナーから Node 20 が削除される。

## 変更

全11ワークフローの checkout / setup-node を Node 24 対応版へ更新（各2箇所・計22箇所）：
- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`

対象: cf-cleanup / ci / cloudflare-deploy / fetch-metrics / link-audit / post-instagram-scheduled / psi-audit / r2-audit / r2-sync / upload-instagram-assets / uptime-ping

## 据え置き

各ワークフローの `node-version: "20"`（ビルドが使う Node 版）はアクション自身のランタイムとは別概念のため変更しない。

## 検証

- `@v4`（checkout/setup-node）残存ゼロを grep 確認
- diff は version 文字列のみ（22 insertions / 22 deletions）
- マージ後の次回実行で deprecation アノテーションが消えることで最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
