### PR TITLE
feat(note): マガジンURL注入のDX改善（npm昇格＋部分注入のlint検知）

### DIFF
--- a/docs/reference/note-essay-review-checklist.md
+++ b/docs/reference/note-essay-review-checklist.md
@@ -300,9 +300,10 @@ content(note): {theme}/article.md を公開レベルに引き上げ（字数圧�
 
 note でマガジンを作成する際は、**マガジン名・説明・価格は `note掲載文.txt`（Step 6f）からコピペ**する。運営者から URL を受領したら：
 
-1. 各記事本文のプレースホルダを実URLに置換：`node .claude/scripts/note/inject-magazine-url.cjs {persona} {magazineURL}`（冒頭・末尾の2箇所×記事数を一括置換）。各記事の frontmatter `noteUrl:`/`noteId:` にも反映（公開済URLの真実源＝記事 frontmatter）
+1. 各記事本文のプレースホルダを実URLに置換：**`npm run note-inject-magazine-url -- {persona} {magazineURL}`**（冒頭・末尾の2箇所×記事数を一括置換。実体は `.claude/scripts/note/inject-magazine-url.cjs`、CRLF保持・旧バリアント吸収・冪等）。各記事の frontmatter `noteUrl:`/`noteId:` にも反映（公開済URLの真実源＝記事 frontmatter）
+   - **手作業で置換しない**: `sed -i` は CRLF を LF に壊す、`{{MAGAZINE_URL}}` 以外の旧バリアントを取りこぼす、冪等性が無い——を全部自前で再実装することになり事故る（2026-06-11 Opus が既存スクリプトを探さず手置換し CRLF を一度破壊）。必ず上記スクリプトを使う（[[feedback_note_magazine_url_injection]]）。
    - **執筆時の規約**: マガジン誘導は **`{{MAGAZINE_URL}}` を単独行**で書く（推奨・新規はこの形式のみ）。`（{{MAGAZINE_URL}}）` のように**全角括弧で囲まない**／同一行に文を置かない（note でリンクカード化できず、注入後に `（https://note.com/.../m/xxxx）` の壊れたリンクになる＝港湾R03事故、2026-06-10）。
-   - **自動検知**: `scripts/note-lint.mjs`（pre-commit）が「マガジンURL／`{{MAGAZINE_URL}}` の非単独行」を BLOCK する。注入漏れ変種は `inject-magazine-url.cjs` の `PLACEHOLDERS` 配列で吸収（空白・括弧バリアントも登録済）。
+   - **自動検知**: `scripts/note-lint.mjs`（pre-commit）が「マガジンURL／`{{MAGAZINE_URL}}` の非単独行」に加え、**部分注入**（同一マガジンdir内に実URL注入済み記事がありながら `{{MAGAZINE_URL}}` が残る記事＝注入漏れ）を BLOCK し、修正コマンド `npm run note-inject-magazine-url -- <persona> <url>`（persona・実URL自動抽出）を提示する。公開前＝全記事 placeholder のときは発火しない。注入漏れ変種は `inject-magazine-url.cjs` の `PLACEHOLDERS` 配列で吸収（空白・括弧バリアントも登録済）。
 2. `src/lib/note-magazines.ts` の該当エントリを `published: true` ＋ `noteUrl`（マガジンURL）に更新。`price` フィールドは Step 6f で既に入っているはず（未記載なら追記）
 3. 個別記事も note 投稿済みなら各 PDF を有料エリアに添付（Step 6e の冒頭訴求と対応）
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "note-meta-lint": "node scripts/note-meta-lint.mjs",
     "note-meta-to-txt": "node scripts/note-meta-to-txt.mjs",
     "note-lint": "node scripts/note-lint.mjs",
+    "note-inject-magazine-url": "node .claude/scripts/note/inject-magazine-url.cjs",
     "x-sync-status": "node scripts/x-sync-status.mjs",
     "x-schedule-view": "node scripts/x-schedule-view.mjs",
     "generate-webp": "node .claude/scripts/generate-webp.mjs",

--- a/scripts/note-lint.mjs
+++ b/scripts/note-lint.mjs
@@ -13,6 +13,7 @@
  *   4. マガジンURL／{{MAGAZINE_URL}} の非単独行 — 括弧囲み・同一行テキストだと note でリンクカード化できない
  *   5. 部分注入 — 同一マガジンに実URL注入済み記事がありながら {{MAGAZINE_URL}} が残る記事（注入漏れ）
  *      → 手作業でなく `npm run note-inject-magazine-url -- <persona> <url>` を使う（CRLF保持・冪等）
+ *   6. 廃止セクション見出し — 「## …からのコメント」（合格者／元公務員からのコメント節、2026-06-10 廃止）
  *
  * 使い方:
  *   node scripts/note-lint.mjs                       # staged の docs/note 配下の article.md を検査（pre-commit 用）
@@ -142,6 +143,18 @@ function checkPartialInjection(file, state) {
   if (!st || !st.placeholderSet.has(file.replace(/\\/g, '/'))) return [];
   return [{ line: 0, msg: `部分注入: 同一マガジンに実URL注入済み記事があるのに本文へ {{MAGAZINE_URL}} 未反映 → 修正: npm run note-inject-magazine-url -- ${st.persona} ${st.url}` }];
 }
+// 廃止セクション見出し（2026-06-10 廃止: 合格者／元公務員からのコメント節）。採点者視点と重複し
+// 運営者の自己紹介フレーミングが不要なため全廃。建設部門二次QAでは減点ルール化済みだが、再混入を
+// pre-commit で物理的に止める（essay/建設部門の両方が対象。2026-06-11 追加）。
+function checkDeprecatedSection(content) {
+  const out = [];
+  content.split('\n').forEach((l, i) => {
+    if (/^##\s+.*からのコメント\s*$/.test(l)) {
+      out.push({ line: i + 1, msg: `廃止セクション見出し（2026-06-10 廃止: 合格者／元公務員からのコメント節）。削除し採点者視点に統合: ${l.trim().slice(0, 30)}` });
+    }
+  });
+  return out;
+}
 
 // --- main ---
 const args = process.argv.slice(2);
@@ -162,7 +175,7 @@ const partialState = buildPartialInjectionState(files);
 let violations = 0;
 for (const f of files) {
   const content = readFileSync(f, 'utf8');
-  const issues = [...checkPipeTable(content), ...checkMojibake(content), ...checkMagazineLinkCard(content), ...checkBoldParen(f), ...checkPartialInjection(f, partialState)];
+  const issues = [...checkPipeTable(content), ...checkMojibake(content), ...checkMagazineLinkCard(content), ...checkBoldParen(f), ...checkPartialInjection(f, partialState), ...checkDeprecatedSection(content)];
   if (issues.length) {
     violations += issues.length;
     const rel = f.replace(ROOT + '\\', '').replace(ROOT + '/', '').replace(/\\/g, '/');

--- a/scripts/note-lint.mjs
+++ b/scripts/note-lint.mjs
@@ -14,6 +14,7 @@
  *   5. 部分注入 — 同一マガジンに実URL注入済み記事がありながら {{MAGAZINE_URL}} が残る記事（注入漏れ）
  *      → 手作業でなく `npm run note-inject-magazine-url -- <persona> <url>` を使う（CRLF保持・冪等）
  *   6. 廃止セクション見出し — 「## …からのコメント」（合格者／元公務員からのコメント節、2026-06-10 廃止）
+ *   7. ツール呼び出しXML残骸 — antml: / <invoke> / <parameter> / <function> / <content>（生成時混入）
  *
  * 使い方:
  *   node scripts/note-lint.mjs                       # staged の docs/note 配下の article.md を検査（pre-commit 用）
@@ -155,6 +156,17 @@ function checkDeprecatedSection(content) {
   });
   return out;
 }
+// ツール呼び出しXMLの残骸（生成時にエージェントの function-call 断片が本文へ混入）。
+// note 試験対策記事にこれらのタグが正当に出ることはまずない＝100% 削除対象（契約調達R07事故、2026-06-11）。
+function checkToolArtifact(content) {
+  const out = [];
+  content.split('\n').forEach((l, i) => {
+    if (/antml:|<\/?(invoke|parameter|function)\b|<\/?content>/.test(l)) {
+      out.push({ line: i + 1, msg: `ツール呼び出しXML残骸（生成時混入）。削除せよ: ${l.trim().slice(0, 40)}` });
+    }
+  });
+  return out;
+}
 
 // --- main ---
 const args = process.argv.slice(2);
@@ -175,7 +187,7 @@ const partialState = buildPartialInjectionState(files);
 let violations = 0;
 for (const f of files) {
   const content = readFileSync(f, 'utf8');
-  const issues = [...checkPipeTable(content), ...checkMojibake(content), ...checkMagazineLinkCard(content), ...checkBoldParen(f), ...checkPartialInjection(f, partialState), ...checkDeprecatedSection(content)];
+  const issues = [...checkPipeTable(content), ...checkMojibake(content), ...checkMagazineLinkCard(content), ...checkBoldParen(f), ...checkPartialInjection(f, partialState), ...checkDeprecatedSection(content), ...checkToolArtifact(content)];
   if (issues.length) {
     violations += issues.length;
     const rel = f.replace(ROOT + '\\', '').replace(ROOT + '/', '').replace(/\\/g, '/');

--- a/scripts/note-lint.mjs
+++ b/scripts/note-lint.mjs
@@ -11,6 +11,8 @@
  *   2. 太字内全角括弧 Pattern A            — note 独自パーサで描画崩れ（check-note-bold-paren.mjs を再利用）
  *   3. U+FFFD（文字化け）
  *   4. マガジンURL／{{MAGAZINE_URL}} の非単独行 — 括弧囲み・同一行テキストだと note でリンクカード化できない
+ *   5. 部分注入 — 同一マガジンに実URL注入済み記事がありながら {{MAGAZINE_URL}} が残る記事（注入漏れ）
+ *      → 手作業でなく `npm run note-inject-magazine-url -- <persona> <url>` を使う（CRLF保持・冪等）
  *
  * 使い方:
  *   node scripts/note-lint.mjs                       # staged の docs/note 配下の article.md を検査（pre-commit 用）
@@ -93,6 +95,54 @@ function checkBoldParen(file) {
   return [];
 }
 
+// --- 部分注入検知（総監模範論文ペルソナ別マガジン限定）---
+// 同一マガジンdir内に「実マガジンURLを単独行で注入済みの記事」と「{{MAGAZINE_URL}} 残存記事」が
+// 混在＝マガジン公開後の inject-magazine-url.cjs 実行漏れ。手作業置換でなく専用スクリプトに誘導する
+// （2026-06-11 追加。公開前＝全記事 placeholder のときは注入済み記事が無いので発火しない）。
+const PERSONA_RE = /docs\/note\/技術士総監\/magazines\/(総監模範論文-[^/]+)\/[^/]+\/article\.md$/;
+function injectedMagazineUrl(content) {
+  for (const l of content.split('\n')) {
+    const t = l.trim();
+    if (/^https:\/\/note\.com\/dobokunote\/m\/[A-Za-z0-9]+(\?\S*)?$/.test(t)) return t.replace(/\?\S*$/, '');
+  }
+  return null;
+}
+// 検査対象 files から関係するマガジンdir をディスク走査し、部分注入状態を作る。
+// 返り値: Map<magName, { url, persona, placeholderSet:Set<正規化絶対パス> }>
+function buildPartialInjectionState(files) {
+  const mags = new Map(); // magName -> { magDirAbs, persona }
+  for (const f of files) {
+    const m = f.replace(/\\/g, '/').match(PERSONA_RE);
+    if (!m) continue;
+    const norm = f.replace(/\\/g, '/');
+    const magDirAbs = norm.slice(0, norm.indexOf(m[1]) + m[1].length);
+    if (!mags.has(m[1])) mags.set(m[1], { magDirAbs, persona: m[1].replace(/^総監模範論文-/, '') });
+  }
+  const state = new Map();
+  for (const [magName, info] of mags) {
+    let url = null;
+    const placeholderSet = new Set();
+    let entries = [];
+    try { entries = readdirSync(info.magDirAbs); } catch { continue; }
+    for (const slug of entries) {
+      const af = join(info.magDirAbs, slug, 'article.md');
+      if (!existsSync(af) || !statSync(af).isFile()) continue;
+      const c = readFileSync(af, 'utf8');
+      if (!url) { const u = injectedMagazineUrl(c); if (u) url = u; }
+      if (c.includes('{{MAGAZINE_URL}}')) placeholderSet.add(af.replace(/\\/g, '/'));
+    }
+    if (url && placeholderSet.size) state.set(magName, { url, persona: info.persona, placeholderSet });
+  }
+  return state;
+}
+function checkPartialInjection(file, state) {
+  const m = file.replace(/\\/g, '/').match(PERSONA_RE);
+  if (!m) return [];
+  const st = state.get(m[1]);
+  if (!st || !st.placeholderSet.has(file.replace(/\\/g, '/'))) return [];
+  return [{ line: 0, msg: `部分注入: 同一マガジンに実URL注入済み記事があるのに本文へ {{MAGAZINE_URL}} 未反映 → 修正: npm run note-inject-magazine-url -- ${st.persona} ${st.url}` }];
+}
+
 // --- main ---
 const args = process.argv.slice(2);
 let files;
@@ -107,10 +157,12 @@ if (args.length === 0) {
 
 if (files.length === 0) { process.exit(0); }
 
+const partialState = buildPartialInjectionState(files);
+
 let violations = 0;
 for (const f of files) {
   const content = readFileSync(f, 'utf8');
-  const issues = [...checkPipeTable(content), ...checkMojibake(content), ...checkMagazineLinkCard(content), ...checkBoldParen(f)];
+  const issues = [...checkPipeTable(content), ...checkMojibake(content), ...checkMagazineLinkCard(content), ...checkBoldParen(f), ...checkPartialInjection(f, partialState)];
   if (issues.length) {
     violations += issues.length;
     const rel = f.replace(ROOT + '\\', '').replace(ROOT + '/', '').replace(/\\/g, '/');


### PR DESCRIPTION
## 背景

技術基準担当マガジン公開時、Sonnet にマガジン導線プレースホルダー `{{MAGAZINE_URL}}` の反映を指示したところ、**既に存在する専用ツール `inject-magazine-url.cjs` に辿り着けず**、手作業（`sed -i`）で置換しようとして CRLF を壊す事故が起きた。Opus でも最初は既存ツールを探さず手置換した。

真因は「Sonnet の理解力不足」ではなく **既存ツールの発見可能性（discoverability）と、反映漏れの検知不足**。CLAUDE.md「モデルは判断が必要な場面だけに使う／コードで決定できるものはサブエージェントに委ねない」に従い、**LLM の理解に頼らず仕組みで担保**する。

## 変更内容

| 軸 | 変更 |
|---|---|
| 発見可能性 | `inject-magazine-url.cjs` を `npm run note-inject-magazine-url` に登録（深いパスより `npm run` 一覧で見つかる） |
| 再発防止（lint） | `note-lint` に**部分注入検知**を追加。総監模範論文ペルソナ別マガジン配下で、同一dir内に実URL注入済み記事がありながら `{{MAGAZINE_URL}}` が残る記事を BLOCK し、persona・実URLを自動抽出した修正コマンドを提示 |
| ドキュメント | `note-essay-review-checklist.md` Step10 を npm 表記化＋手作業置換の禁止と部分注入検知を明記 |

## 設計のポイント

- **公開前は発火しない**: 全記事が `{{MAGAZINE_URL}}`（マガジン未公開・正常状態）のときは注入済み記事が無いので BLOCK しない。「一部だけ注入して残りを忘れた」状態だけを捕捉。
- **スコープ限定**: 検知は `総監模範論文-<persona>` 配下のみ。BK系・他構造を巻き込まず誤検知を抑制。
- **note-magazine-sync スキルとの関係**: 別途新設された `note-magazine-sync` は `note-magazines.ts`（SoT）側のメタ同期が範囲で、**記事本文の注入には触れない**。本PRの lint 検知がその隙間（SoT は埋まったが本文未注入）を commit 時に捕捉する安全網になる。

## 検証

- 正常系（全注入済み）: 発火せず pass
- 部分注入系（1記事を placeholder に戻す）: BLOCK し `npm run note-inject-magazine-url -- 自治体技術基準担当 https://note.com/dobokunote/m/mf9f281e2cb32` を提示
- 冪等性: 注入済み再実行で 0 箇所置換・ファイル不変
- 回帰: 非ペルソナ記事（BK-I 11記事）でクラッシュ・誤検知なし
- package.json JSON 妥当

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記（2026-06-11）: 廃止セクション見出しの検知を追加

別タスクで「## 元公務員（発注者）からのコメント」節（2026-10 廃止決定済み）が essay 側15記事に残存していた取りこぼしが判明。再混入防止として **note-lint に廃止節見出し（`## …からのコメント`）の検知**を追加（commit d8b2f94d1）。建設部門二次QAは減点ルール化済みだが採点依存のため、pre-commit 機械ゲートで essay・建設部門の両方に一律適用する。note-lint hardening を本PRに集約。

## 追記（2026-06-11 その2）: ツール呼び出しXML残骸の検知を追加

別タスクで契約調達R07の本文末尾に生成残骸 `</content></invoke>` が混入していた事故を受け、**note-lint にツール呼び出しXML残骸（`antml:` / `<invoke>` / `<parameter>` / `<function>` / `<content>`）の検知**を追加（commit 909862c5f）。note 試験対策記事にこれらタグが正当に出ることはなく誤検知リスクは極小（正当語 content/function はタグ形式でなければ通過）。note-lint hardening 第3弾。
