### PR TITLE
docs(claude): CLAUDE.md §10 を worktree 分離前提に改訂（複数セッション常態）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,9 @@ npm run pages:deploy      # Cloudflare Pages に手動デプロイ
 
 ### 10. 重要なステップごとにチェックポイントを置く
 
-- **並行エージェント**: 複数エージェントを同時に動かすときは、各エージェントが編集したファイルを即 commit する（`git status` で staged 内容を確認してから commit — 他エージェントの変更を巻き込まないため）
+- **複数セッションは worktree で分離する（最重要）**: 別の Claude Code セッションが同じリポジトリで並行作業するのが常態（2026-06-11 確認）。同一ワークツリーを共有すると、あるセッションの `git reset --hard`／`checkout` が他セッションの未 push コミット・作業ツリーを破壊する（**pathspec commit・push 前確認でも防げない**＝reset が HEAD・index・作業ツリーを丸ごと書き換えるため。2026-06-11 実証：commit が別セッションの reset で消失→gc 復旧不能）。各セッションは `git worktree add <別dir> -b <feature> origin/develop` で独立した HEAD／index／作業ツリーを持ち、`develop` へは PR で集約する（`.git` オブジェクトは共有）。**§5「worktree 原則禁止」は複数セッション常態下では非適用**。
+- **同一ワークツリーで並行せざるを得ないとき**: reflog・`develop` 先頭・未コミットが自分の操作と無関係に動くのは正常（共有 `.git/logs/HEAD` に全プロセス混在記録）。push 前に `git log origin/develop..HEAD` で巻き込み確認。commit は `git commit -- <pathspec>`（`git add -A` 禁止）。他テリトリ不可侵。重要な変更は feature ブランチへ即 push して保全。
+- **並行エージェント（同一セッション内）**: 各エージェントが編集したファイルを即 commit（`git status` で staged 確認）。
 - 長いタスクでは「何を完了し・何を検証し・何が残っているか」を都度整理してから次に進む
 
 ### 11. コードベースの規約に合わせる


### PR DESCRIPTION
複数 Claude セッションが同じリポジトリで並行作業するのが常態。同一ワークツリー共有は reset --hard/checkout で互いのコミット・作業ツリーを破壊し、pathspec commit/push前確認でも防げない（2026-06-11 実証）。各セッションは git worktree で物理分離し develop へ PR 集約する方針を §10 に明記。§5 worktree原則禁止は複数セッション常態下で非適用。

本PR自体が worktree 運用の実例（C:\tmp\doboku-note-claude の専用 worktree で作成）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)