### PR TITLE
feat(home): トップHeroをシンプル化＋技術士第一次試験カードを追加

### DIFF
--- a/.claude/skills/authoring/templates/README.md
+++ b/.claude/skills/authoring/templates/README.md
@@ -49,6 +49,7 @@ templates/
 2. ファイル名を `{exam-id}.md` に変更
 3. `_schema.md` の6つの変数を埋める（詳細は `_schema.md` 参照）
 4. 対応するスキル（`exam-guide`, `exam-questions-import` など）の参照を更新
+5. **サイトに出すなら `src/config/categories.json`（ナビ）と `src/config/home-exam-cards.json`（トップの資格カード）の両方に登録**。整合は `npm run check-home-exam-coverage`（pre-commit / CI）が検査。詳細手順は [exam-content-policy.md](../../../../docs/reference/exam-content-policy.md) Part 4。
 
 ### 3. 設定ファイルの変更
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Type Check
         run: npm run type-check
 
+      - name: Check homepage exam coverage
+        run: npm run check-home-exam-coverage
+
       - name: Unit Tests
         run: npm test
 

--- a/docs/reference/exam-content-policy.md
+++ b/docs/reference/exam-content-policy.md
@@ -152,7 +152,8 @@ doboku-note は複数の資格試験を扱うが、試験ごとに「**何を / 
 4. `/review` のディスパッチ表（`.claude/skills/dev/review/SKILL.md`）に行を追加
 5. `/improve-article --mode verify` のルートテーブル（`.claude/skills/authoring/improve-article --mode verify/SKILL.md`）に行を追加
 6. このファイル（exam-content-policy.md）と `agents-registry.md` を更新
-7. **OGP 画像を生成**（公開前必須）: `npm run ogp -- --all`（未生成分のみ生成）→ 新規 `ogp.png` を pathspec commit。**新カテゴリは OGP が 0 枚から始まる**ため、これを忘れると `og:image` が R2 で 404 になり、**note / X / Facebook 等の外部リンクカードが生成されない**（2026-06-12 pe-construction で全114本が該当）。`published:false` のドラフトは仕様上スキップされる＝公開化（`published:true`）のタイミングで再実行する。`ogp.png` は `r2-sync.yml` の path フィルタ（`**/ogp.png`）経由で main push 時に R2 同期される。詳細 → [measurement-incidents.md](./measurement-incidents.md)「2026-06-12 OGP 404」
+7. **トップページの資格カードに追加**（公開＝サイトに出すなら必須）: `src/config/home-exam-cards.json` にカード（`slug`/`order`/`label`/`en`/`subtitle`/`description`/`nextExam`/`stats`）を追加する。**ナビ（`categories.json`）と別管理**なのは、カードのコピーがナビ用と意図的に異なるため（例: ナビ「技術士第二次試験（建設部門）」⇄ カード「技術士（建設部門）」）。「どの資格をトップに出すか」は `categories.json` の `visible`（≠false）/`variant`（≠reference）が真実源で、両者の整合は `npm run check-home-exam-coverage`（pre-commit / CI ゲート）が強制する。**これを忘れると、公開済みコンテンツがあってもトップの資格カードに出ない**（2026-06-15 pe-first-stage 21本が該当＝ナビからのみ到達可能だった）。意図的にトップへ出さない資格は `categories.json` で `visible:false` にする。
+8. **OGP 画像を生成**（公開前必須）: `npm run ogp -- --all`（未生成分のみ生成）→ 新規 `ogp.png` を pathspec commit。**新カテゴリは OGP が 0 枚から始まる**ため、これを忘れると `og:image` が R2 で 404 になり、**note / X / Facebook 等の外部リンクカードが生成されない**（2026-06-12 pe-construction で全114本が該当）。`published:false` のドラフトは仕様上スキップされる＝公開化（`published:true`）のタイミングで再実行する。`ogp.png` は `r2-sync.yml` の path フィルタ（`**/ogp.png`）経由で main push 時に R2 同期される。詳細 → [measurement-incidents.md](./measurement-incidents.md)「2026-06-12 OGP 404」
 
 ### 新資格メモ: コンクリート診断士（`concrete-diagnostician`、2026-05-30 新設）
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "upload-images-r2": "tsx .claude/scripts/upload-images-to-r2.mjs",
     "diff-r2": "node .claude/skills/dev/diff-r2/scripts/diff-r2.mjs",
     "check-ogp-coverage": "node scripts/check-ogp-coverage.mjs",
+    "check-home-exam-coverage": "node scripts/check-home-exam-coverage.mjs",
     "fetch-gsc-data": "node .claude/skills/analytics/fetch-gsc-data/scripts/fetch-gsc-data.mjs",
     "fetch-ga4-data": "node .claude/scripts/fetch-ga4-data.mjs",
     "fetch-ga4-cta-clicks": "node .claude/scripts/fetch-ga4-cta-clicks.mjs",

--- a/scripts/check-home-exam-coverage.mjs
+++ b/scripts/check-home-exam-coverage.mjs
@@ -1,0 +1,89 @@
+/**
+ * トップページの資格カード（src/config/home-exam-cards.json）と
+ * カテゴリ定義（src/config/categories.json）の整合を検査する。
+ *
+ * 背景（2026-06-15 制定）:
+ *   ナビは categories.json から自動生成されるが、トップの資格カードは別管理だったため、
+ *   公開済みの新資格（pe-first-stage 21本）がトップに出ていない事故が起きた。
+ *   再発防止として「visible≠false かつ variant≠reference のカテゴリは必ず
+ *   home-exam-cards.json にカードを持つ」ことを機械的に強制する。
+ *
+ * 不整合（赤落ち）条件:
+ *   - visible≠false・variant≠reference のカテゴリに対応する home カードが無い
+ *   - home カードの slug が categories.json に存在しない / visible:false / variant=reference
+ *   - home カードに必須フィールドが欠落
+ *
+ * Usage: node scripts/check-home-exam-coverage.mjs
+ */
+
+import { readFileSync } from "node:fs";
+
+const CATEGORIES = "src/config/categories.json";
+const HOME_CARDS = "src/config/home-exam-cards.json";
+const REQUIRED_FIELDS = ["slug", "order", "label", "en", "subtitle", "description", "nextExam", "stats"];
+
+function load(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (e) {
+    console.error(`[check-home-exam-coverage] ✗ ${path} を読めません: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+const categories = load(CATEGORIES);
+const homeCards = load(HOME_CARDS);
+
+const catBySlug = new Map(categories.map((c) => [c.slug, c]));
+const homeSlugs = new Set(homeCards.map((c) => c.slug));
+const errors = [];
+
+// 1) トップに出すべきカテゴリ（visible≠false・variant≠reference）に home カードがあるか
+for (const c of categories) {
+  if (c.visible === false) continue;
+  if (c.variant === "reference") continue;
+  if (!homeSlugs.has(c.slug)) {
+    errors.push(
+      `カテゴリ "${c.slug}"（visible・variant=${c.variant}）が ${HOME_CARDS} に未掲載 ` +
+        `→ トップの資格カードに出ません。意図的に出さない場合は categories.json で visible:false に。`,
+    );
+  }
+}
+
+// 2) home カードが正当なカテゴリを指しているか＋必須フィールド
+for (const card of homeCards) {
+  const cat = catBySlug.get(card.slug);
+  if (!cat) {
+    errors.push(`${HOME_CARDS} の "${card.slug}" が ${CATEGORIES} に存在しません。`);
+  } else {
+    if (cat.visible === false) {
+      errors.push(`${HOME_CARDS} の "${card.slug}" は categories.json で visible:false（トップに出すべきでない）。`);
+    }
+    if (cat.variant === "reference") {
+      errors.push(`${HOME_CARDS} の "${card.slug}" は variant=reference（資格カードに不適）。`);
+    }
+  }
+  for (const f of REQUIRED_FIELDS) {
+    if (card[f] === undefined) errors.push(`${HOME_CARDS} の "${card.slug}" に必須フィールド "${f}" が欠落。`);
+  }
+}
+
+// 3) order の重複検出（カード並びが不定になるのを防ぐ）
+const seenOrder = new Map();
+for (const card of homeCards) {
+  if (seenOrder.has(card.order)) {
+    errors.push(`${HOME_CARDS} の order=${card.order} が重複（"${seenOrder.get(card.order)}" と "${card.slug}"）。`);
+  } else {
+    seenOrder.set(card.order, card.slug);
+  }
+}
+
+if (errors.length) {
+  console.error("[check-home-exam-coverage] ✗ トップの資格カードとカテゴリ定義に不整合:");
+  for (const e of errors) console.error("  - " + e);
+  process.exit(1);
+}
+
+console.log(
+  `[check-home-exam-coverage] ✓ トップ資格カード ${homeCards.length} 件と categories.json が整合`,
+);

--- a/scripts/install-pre-commit.mjs
+++ b/scripts/install-pre-commit.mjs
@@ -58,6 +58,12 @@ node scripts/check-doc-coupling.mjs --staged
 if [ $? -ne 0 ]; then
   exit 1
 fi
+
+# トップの資格カード(home-exam-cards.json)と categories.json の整合（公開済み新資格のトップ未掲載の再発防止）
+node scripts/check-home-exam-coverage.mjs
+if [ $? -ne 0 ]; then
+  exit 1
+fi
 `;
 
 if (!existsSync(HOOKS_DIR)) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { Hero, ExamCards, LatestArticles, AboutSection } from "@/components/home
 import type { LatestArticle } from "@/components/home";
 import { getDocsMetaByCategory, getAllDocsMeta, type DocMeta } from "@/lib/docs";
 import categoriesData from "@/config/categories.json";
+import homeExamCardsData from "@/config/home-exam-cards.json";
 import { CategoryDef } from "@/lib/categories";
 
 // 2026-04-26 #84 LCP 追加改善（Task B-2 revert）:
@@ -19,62 +20,72 @@ import { CategoryDef } from "@/lib/categories";
 
 const categories = categoriesData as CategoryDef[];
 
-const EXAM_DATA = [
-  {
-    slug: "civil-construction-1",
-    label: "1級土木施工管理技士",
-    en: "CCCE Grade 1",
-    subtitle: "第1次・第2次検定 完全対策",
-    description: "土木工事の施工計画・品質管理・安全管理を体系的に整理。過去問題、キーワード解説、記述式の要点を収録。",
-    nextExam: "2026年7月 第1次 / 10月 第2次",
-    variant: "civil" as const,
-  },
-  {
-    slug: "civil-construction-2",
-    label: "2級土木施工管理技士",
-    en: "CCCE Grade 2",
-    subtitle: "第1次・第2次検定 完全対策（前期・後期2回開催）",
-    description: "受験資格緩和後の若手技術者向け。令和3年度〜7年度 過去問解説、経験記述ガイド、分野別の基礎ポイントを収録。",
-    nextExam: "2026年6月 前期 / 10月 後期・第2次",
-    variant: "civil" as const,
-  },
-  {
-    slug: "pe-comprehensive-management",
-    label: "技術士（総合技術監理部門）",
-    en: "PE Comprehensive Management",
-    subtitle: "筆記・口頭試験 論文対策",
-    description: "5つの管理技術（経済性・人的資源・情報・安全・社会環境）のキーワード集。各概念の定義・要点・過去問リンクを収録。",
-    nextExam: "2026年7月 筆記 / 12月 口頭",
-    variant: "pe" as const,
-  },
-  {
-    slug: "pe-construction",
-    label: "技術士（建設部門）",
-    en: "PE Civil Engineering",
-    subtitle: "必須・選択11科目 記述式 過去問（R元〜R7）",
-    description: "技術士第二次試験 建設部門の必須科目・選択科目11科目（道路・河川砂防・都市計画・土質・鋼コン・施工計画ほか）の記述式 過去問を年度別・科目別に収録。出題テーマの論点キーワードと論文の書き方も整理。",
-    nextExam: "2026年7月 筆記",
-    variant: "pe" as const,
-  },
-  {
-    slug: "concrete-chief-engineer",
-    label: "コンクリート主任技師",
-    en: "JCI Senior Concrete Engineer",
-    subtitle: "四肢択一・小論文 完全対策",
-    description: "材料・配合設計・施工・耐久性・品質管理など8分野を体系整理。分野別の過去問解説・テキスト・小論文対策を収録。",
-    nextExam: "2026年11月（予定）",
-    variant: "civil" as const,
-  },
-  {
-    slug: "pe-first-stage",
-    label: "技術士 第一次試験",
-    en: "PE First Stage",
-    subtitle: "適性・基礎・専門（建設部門）過去問（R元〜R7）",
-    description: "技術士第二次試験の前提となる第一次試験対策。令和元〜7年度の適性科目・基礎科目・専門科目（建設部門）の過去問を年度別・科目別に収録し、頻出論点と出題範囲を体系的に整理。",
-    nextExam: "2026年11月（予定）",
-    variant: "pe" as const,
-  },
-];
+// トップの資格カード固有のコピー（label/subtitle/description/en/nextExam/stats/order）は
+// ナビ用の categories.json と意図的に異なる（例: pe-construction はナビ「技術士第二次試験（建設部門）」
+// に対しカードは「技術士（建設部門）」）。そのためカード固有データは home-exam-cards.json に分離する。
+// 「どの資格をトップに出すか」は categories.json（visible / variant）が真実源で、両者の slug 整合は
+// scripts/check-home-exam-coverage.mjs（pre-commit / CI）が強制する。
+// → 新資格をトップに出すには home-exam-cards.json にカードを追加する。
+type HomeStatSpec = {
+  label: string;
+  total?: boolean;
+  groups?: string[];
+  tags?: string[];
+  distinctYear?: boolean;
+  value?: string;
+};
+type HomeExamCard = {
+  slug: string;
+  order: number;
+  label: string;
+  en: string;
+  subtitle: string;
+  description: string;
+  nextExam: string;
+  stats: HomeStatSpec[];
+};
+const homeExamCards = homeExamCardsData as HomeExamCard[];
+const categoryBySlug = new Map(categories.map((c) => [c.slug, c]));
+
+function computeStat(metas: DocMeta[], spec: HomeStatSpec): { k: string; v: string } {
+  if (spec.value !== undefined) return { k: spec.label, v: spec.value };
+  if (spec.distinctYear) {
+    const years = new Set(metas.map((m) => (String(m.slug).match(/r\d+/) || [])[0]).filter(Boolean));
+    return { k: spec.label, v: String(years.size) };
+  }
+  if (spec.total) return { k: spec.label, v: metas.length.toLocaleString() };
+  const groups = spec.groups ?? [];
+  const tags = spec.tags ?? [];
+  const n = metas.filter(
+    (m) => (m.group ? groups.includes(m.group) : false) || tags.some((t) => m.tags?.includes(t)),
+  ).length;
+  return { k: spec.label, v: n.toLocaleString() };
+}
+
+// categories.json（visible≠false・variant≠reference）に存在する資格だけを、
+// home-exam-cards.json の order 順でカード化する。variant はカテゴリ定義から取得（単一ソース）。
+function buildExamCards() {
+  return [...homeExamCards]
+    .filter((card) => {
+      const cat = categoryBySlug.get(card.slug);
+      return !!cat && cat.visible !== false && cat.variant !== "reference";
+    })
+    .sort((a, b) => a.order - b.order)
+    .map((card) => {
+      const cat = categoryBySlug.get(card.slug)!;
+      const metas = getDocsMetaByCategory(card.slug);
+      return {
+        slug: card.slug,
+        label: card.label,
+        en: card.en,
+        subtitle: card.subtitle,
+        description: card.description,
+        nextExam: card.nextExam,
+        variant: cat.variant as "civil" | "pe",
+        stats: card.stats.map((s) => computeStat(metas, s)),
+      };
+    });
+}
 
 function pickRecent(allMeta: DocMeta[], n: number): LatestArticle[] {
   const labelByCategory = new Map<string, string>();
@@ -109,65 +120,7 @@ function pickRecent(allMeta: DocMeta[], n: number): LatestArticle[] {
 
 export default async function HomePage() {
   const allMeta = getAllDocsMeta();
-  const civil = getDocsMetaByCategory("civil-construction-1");
-  const civil2 = getDocsMetaByCategory("civil-construction-2");
-  const pe = getDocsMetaByCategory("pe-comprehensive-management");
-  const concrete = getDocsMetaByCategory("concrete-chief-engineer");
-  const peConstruction = getDocsMetaByCategory("pe-construction");
-  const peFirstStage = getDocsMetaByCategory("pe-first-stage");
-
-  // 表示順は技術士系をまとめる（1級→2級→第一次→建設(二次)→総監→コンクリ主任）。
-  // EXAM_DATA の定義順とは独立に、ここで並べた順序がトップのカード並びになる。
-  const exams = [
-    {
-      ...EXAM_DATA[0]!,
-      stats: [
-        { k: "記事", v: civil.length.toLocaleString() },
-        { k: "過去問", v: civil.filter((m) => m.tags?.includes("past-questions") || m.group === "primary" || m.group === "secondary").length.toLocaleString() },
-        { k: "教科書", v: civil.filter((m) => m.tags?.includes("textbook") || m.group === "textbook").length.toLocaleString() },
-      ],
-    },
-    {
-      ...EXAM_DATA[1]!,
-      stats: [
-        { k: "記事", v: civil2.length.toLocaleString() },
-        { k: "過去問", v: civil2.filter((m) => m.tags?.includes("past-questions") || m.group === "primary" || m.group === "secondary").length.toLocaleString() },
-        { k: "ガイド", v: civil2.filter((m) => m.tags?.includes("guide") || m.group === "guide").length.toLocaleString() },
-      ],
-    },
-    {
-      ...EXAM_DATA[5]!,
-      stats: [
-        { k: "過去問", v: peFirstStage.filter((m) => m.group === "primary" || m.tags?.includes("past-questions")).length.toLocaleString() },
-        { k: "年度", v: String(new Set(peFirstStage.map((m) => (String(m.slug).match(/r\d+/) || [])[0]).filter(Boolean)).size) },
-        { k: "科目", v: "3" },
-      ],
-    },
-    {
-      ...EXAM_DATA[3]!,
-      stats: [
-        { k: "記事", v: peConstruction.length.toLocaleString() },
-        { k: "過去問", v: peConstruction.filter((m) => m.group === "past-exam" || m.tags?.includes("past-questions")).length.toLocaleString() },
-        { k: "ガイド", v: peConstruction.filter((m) => m.group === "guide" || m.tags?.includes("guide")).length.toLocaleString() },
-      ],
-    },
-    {
-      ...EXAM_DATA[2]!,
-      stats: [
-        { k: "記事", v: pe.length.toLocaleString() },
-        { k: "キーワード", v: pe.filter((m) => m.group === "keyword" || m.tags?.includes("keyword")).length.toLocaleString() },
-        { k: "過去問", v: pe.filter((m) => m.group === "pastExam" || m.tags?.includes("past-questions")).length.toLocaleString() },
-      ],
-    },
-    {
-      ...EXAM_DATA[4]!,
-      stats: [
-        { k: "記事", v: concrete.length.toLocaleString() },
-        { k: "過去問", v: concrete.filter((m) => m.group === "primary" || m.tags?.includes("past-questions")).length.toLocaleString() },
-        { k: "テキスト", v: concrete.filter((m) => m.group === "textbook").length.toLocaleString() },
-      ],
-    },
-  ];
+  const exams = buildExamCards();
 
   const articleCount = allMeta.filter((m) => m.published !== false).length;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,6 +65,15 @@ const EXAM_DATA = [
     nextExam: "2026年11月（予定）",
     variant: "civil" as const,
   },
+  {
+    slug: "pe-first-stage",
+    label: "技術士 第一次試験",
+    en: "PE First Stage",
+    subtitle: "適性・基礎・専門（建設部門）過去問（R元〜R7）",
+    description: "技術士第二次試験の前提となる第一次試験対策。令和元〜7年度の適性科目・基礎科目・専門科目（建設部門）の過去問を年度別・科目別に収録し、頻出論点と出題範囲を体系的に整理。",
+    nextExam: "2026年11月（予定）",
+    variant: "pe" as const,
+  },
 ];
 
 function pickRecent(allMeta: DocMeta[], n: number): LatestArticle[] {
@@ -105,7 +114,10 @@ export default async function HomePage() {
   const pe = getDocsMetaByCategory("pe-comprehensive-management");
   const concrete = getDocsMetaByCategory("concrete-chief-engineer");
   const peConstruction = getDocsMetaByCategory("pe-construction");
+  const peFirstStage = getDocsMetaByCategory("pe-first-stage");
 
+  // 表示順は技術士系をまとめる（1級→2級→第一次→建設(二次)→総監→コンクリ主任）。
+  // EXAM_DATA の定義順とは独立に、ここで並べた順序がトップのカード並びになる。
   const exams = [
     {
       ...EXAM_DATA[0]!,
@@ -124,11 +136,11 @@ export default async function HomePage() {
       ],
     },
     {
-      ...EXAM_DATA[2]!,
+      ...EXAM_DATA[5]!,
       stats: [
-        { k: "記事", v: pe.length.toLocaleString() },
-        { k: "キーワード", v: pe.filter((m) => m.group === "keyword" || m.tags?.includes("keyword")).length.toLocaleString() },
-        { k: "過去問", v: pe.filter((m) => m.group === "pastExam" || m.tags?.includes("past-questions")).length.toLocaleString() },
+        { k: "過去問", v: peFirstStage.filter((m) => m.group === "primary" || m.tags?.includes("past-questions")).length.toLocaleString() },
+        { k: "年度", v: String(new Set(peFirstStage.map((m) => (String(m.slug).match(/r\d+/) || [])[0]).filter(Boolean)).size) },
+        { k: "科目", v: "3" },
       ],
     },
     {
@@ -137,6 +149,14 @@ export default async function HomePage() {
         { k: "記事", v: peConstruction.length.toLocaleString() },
         { k: "過去問", v: peConstruction.filter((m) => m.group === "past-exam" || m.tags?.includes("past-questions")).length.toLocaleString() },
         { k: "ガイド", v: peConstruction.filter((m) => m.group === "guide" || m.tags?.includes("guide")).length.toLocaleString() },
+      ],
+    },
+    {
+      ...EXAM_DATA[2]!,
+      stats: [
+        { k: "記事", v: pe.length.toLocaleString() },
+        { k: "キーワード", v: pe.filter((m) => m.group === "keyword" || m.tags?.includes("keyword")).length.toLocaleString() },
+        { k: "過去問", v: pe.filter((m) => m.group === "pastExam" || m.tags?.includes("past-questions")).length.toLocaleString() },
       ],
     },
     {
@@ -167,8 +187,9 @@ export default async function HomePage() {
         {/* note 有料教材ハブへの導線（複数資格を横断するトップは単一商品でなく /links 集約へ）。
             data-cta="note" で AnalyticsProvider のクリック計測対象になる。 */}
         <div className="mx-auto max-w-3xl px-4 pt-10">
-          <h2 className="text-lg font-bold text-ink-strong dark:text-white mb-1">note 有料教材</h2>
-          <p className="text-sm text-ink-muted dark:text-gray-400 mb-3">
+          <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--ink-muted)] mb-3">Premium</div>
+          <h2 className="font-serif text-xl sm:text-2xl font-black text-[var(--ink)] mb-1.5">note 有料教材</h2>
+          <p className="text-[14px] text-[var(--ink-muted)] mb-4">
             記述式・経験記述の模範答案集や精読ガイドをまとめています。
           </p>
           <div className="max-w-sm">

--- a/src/components/home/ExamCards.tsx
+++ b/src/components/home/ExamCards.tsx
@@ -28,7 +28,7 @@ function ExamCard({ e }: { e: ExamData }) {
       className="group block bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section p-6 sm:p-8 transition-all hover:border-[var(--accent)] hover:shadow-lift hover:-translate-y-0.5"
     >
       <div className="flex items-start justify-between gap-4 mb-5">
-        <div className="w-14 h-14 bg-[var(--accent-fill)] text-[var(--accent)] rounded-card-content flex items-center justify-center">
+        <div className="w-14 h-14 bg-[var(--accent-fill)] text-[var(--accent)] rounded-card-content flex items-center justify-center transition-colors group-hover:bg-[var(--accent)] group-hover:text-[var(--paper)]">
           <ExamIcon variant={e.variant} />
         </div>
         <div className="text-right">
@@ -57,8 +57,9 @@ function ExamCard({ e }: { e: ExamData }) {
 
 export default function ExamCards({ exams }: ExamCardsProps) {
   return (
-    <section className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 py-8 sm:py-10">
+    <section id="exams" className="scroll-mt-24 max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 py-8 sm:py-10">
       <div className="mb-6 sm:mb-8">
+        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--ink-muted)] mb-3">Exams</div>
         <h2 className="font-serif text-2xl sm:text-3xl font-black text-[var(--ink)]">対応する資格・試験</h2>
         <p className="text-[14px] text-[var(--ink-muted)] mt-1.5">現場と試験を往復する、体系的な学習コンテンツ</p>
       </div>

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,41 +1,40 @@
-import { NotebookPen, FileText, Hash, Calendar } from "lucide-react";
+import { NotebookPen, FileText, Calendar, ArrowRight } from "lucide-react";
 
 interface HeroProps {
   articleCount: number;
-  keywordCount?: number | undefined;
   lastUpdated?: string | undefined;
 }
 
-export default function Hero({ articleCount, keywordCount, lastUpdated }: HeroProps) {
+export default function Hero({ articleCount, lastUpdated }: HeroProps) {
   return (
-    <section className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 pt-10 sm:pt-14 pb-6 sm:pb-8">
-      <div className="flex items-center gap-2 mb-5 flex-wrap">
+    <section className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 pt-16 sm:pt-24 pb-10 sm:pb-16 text-center">
+      <div className="flex items-center justify-center gap-2 mb-7 flex-wrap">
         <span className="inline-flex items-center gap-1.5 font-mono text-[11px] tracking-wider uppercase text-[var(--accent)] px-2.5 py-1 bg-[var(--accent-fill)] rounded-full">
           <NotebookPen className="w-3 h-3" strokeWidth={1.75} />
           doboku-note
         </span>
         <span className="font-mono text-[11px] text-[var(--ink-muted)]">土木系資格試験 対策ノート</span>
       </div>
-      <h1 className="font-serif font-black tracking-tight leading-[1.2] text-[var(--ink)] text-[32px] sm:text-[44px] md:text-[56px] lg:text-[64px] max-w-[22ch] text-balance">
-        土木の現場と試験を、ひとつのノートに。
+      <h1 className="font-serif font-black tracking-tight leading-[1.18] text-[var(--ink)] text-[36px] sm:text-[52px] md:text-[64px] lg:text-[72px] mx-auto max-w-[18ch] text-balance">
+        土木の試験対策を、ひとつに。
       </h1>
-      <p className="mt-5 sm:mt-6 text-[15px] sm:text-[17px] leading-[1.95] text-[var(--ink-body)] max-w-[62ch]">
-<strong className="text-[var(--ink)]">1級・2級土木施工管理技士</strong>、<strong className="text-[var(--ink)]">技術士（建設部門・総合技術監理部門）</strong>、<strong className="text-[var(--ink)]">コンクリート主任技師</strong>など、土木・建設系の実務資格に対応した学習ノート。現場経験に裏打ちされた知見を、過去問・キーワード解説・記述式対策として体系的にお届けします。
+      <p className="mt-6 sm:mt-7 text-[15px] sm:text-[18px] leading-[1.9] text-[var(--ink-body)] mx-auto max-w-[56ch]">
+        1級・2級土木施工管理技士、技術士（第一次試験・建設部門・総合技術監理部門）、コンクリート主任技師。土木・建設系の実務資格を現場目線で体系的に学べる試験対策ハブ。
       </p>
-      <div className="mt-6 flex items-center gap-5 flex-wrap font-mono text-[11px] text-[var(--ink-muted)] tabular-nums">
+      <div className="mt-8 sm:mt-9 flex items-center justify-center">
+        <a
+          href="#exams"
+          className="inline-flex items-center gap-2 font-mono text-[12px] tracking-wider uppercase text-[var(--paper)] bg-[var(--accent)] px-5 py-3 rounded-full hover:opacity-90 transition-opacity"
+        >
+          <span>資格を選んで学ぶ</span>
+          <ArrowRight className="w-4 h-4" strokeWidth={2} />
+        </a>
+      </div>
+      <div className="mt-6 flex items-center justify-center gap-5 flex-wrap font-mono text-[11px] text-[var(--ink-muted)] tabular-nums">
         <span className="flex items-center gap-1.5">
           <FileText className="w-3 h-3" />
           {articleCount.toLocaleString()} articles
         </span>
-        {keywordCount && (
-          <>
-            <span aria-hidden>·</span>
-            <span className="flex items-center gap-1.5">
-              <Hash className="w-3 h-3" />
-              {keywordCount.toLocaleString()} keywords
-            </span>
-          </>
-        )}
         {lastUpdated && (
           <>
             <span aria-hidden>·</span>

--- a/src/config/home-exam-cards.json
+++ b/src/config/home-exam-cards.json
@@ -1,0 +1,86 @@
+[
+  {
+    "slug": "civil-construction-1",
+    "order": 1,
+    "label": "1級土木施工管理技士",
+    "en": "CCCE Grade 1",
+    "subtitle": "第1次・第2次検定 完全対策",
+    "description": "土木工事の施工計画・品質管理・安全管理を体系的に整理。過去問題、キーワード解説、記述式の要点を収録。",
+    "nextExam": "2026年7月 第1次 / 10月 第2次",
+    "stats": [
+      { "label": "記事", "total": true },
+      { "label": "過去問", "groups": ["primary", "secondary"], "tags": ["past-questions"] },
+      { "label": "教科書", "groups": ["textbook"], "tags": ["textbook"] }
+    ]
+  },
+  {
+    "slug": "civil-construction-2",
+    "order": 2,
+    "label": "2級土木施工管理技士",
+    "en": "CCCE Grade 2",
+    "subtitle": "第1次・第2次検定 完全対策（前期・後期2回開催）",
+    "description": "受験資格緩和後の若手技術者向け。令和3年度〜7年度 過去問解説、経験記述ガイド、分野別の基礎ポイントを収録。",
+    "nextExam": "2026年6月 前期 / 10月 後期・第2次",
+    "stats": [
+      { "label": "記事", "total": true },
+      { "label": "過去問", "groups": ["primary", "secondary"], "tags": ["past-questions"] },
+      { "label": "ガイド", "groups": ["guide"], "tags": ["guide"] }
+    ]
+  },
+  {
+    "slug": "pe-first-stage",
+    "order": 3,
+    "label": "技術士 第一次試験",
+    "en": "PE First Stage",
+    "subtitle": "適性・基礎・専門（建設部門）過去問（R元〜R7）",
+    "description": "技術士第二次試験の前提となる第一次試験対策。令和元〜7年度の適性科目・基礎科目・専門科目（建設部門）の過去問を年度別・科目別に収録し、頻出論点と出題範囲を体系的に整理。",
+    "nextExam": "2026年11月（予定）",
+    "stats": [
+      { "label": "過去問", "groups": ["primary"], "tags": ["past-questions"] },
+      { "label": "年度", "distinctYear": true },
+      { "label": "科目", "value": "3" }
+    ]
+  },
+  {
+    "slug": "pe-construction",
+    "order": 4,
+    "label": "技術士（建設部門）",
+    "en": "PE Civil Engineering",
+    "subtitle": "必須・選択11科目 記述式 過去問（R元〜R7）",
+    "description": "技術士第二次試験 建設部門の必須科目・選択科目11科目（道路・河川砂防・都市計画・土質・鋼コン・施工計画ほか）の記述式 過去問を年度別・科目別に収録。出題テーマの論点キーワードと論文の書き方も整理。",
+    "nextExam": "2026年7月 筆記",
+    "stats": [
+      { "label": "記事", "total": true },
+      { "label": "過去問", "groups": ["past-exam"], "tags": ["past-questions"] },
+      { "label": "ガイド", "groups": ["guide"], "tags": ["guide"] }
+    ]
+  },
+  {
+    "slug": "pe-comprehensive-management",
+    "order": 5,
+    "label": "技術士（総合技術監理部門）",
+    "en": "PE Comprehensive Management",
+    "subtitle": "筆記・口頭試験 論文対策",
+    "description": "5つの管理技術（経済性・人的資源・情報・安全・社会環境）のキーワード集。各概念の定義・要点・過去問リンクを収録。",
+    "nextExam": "2026年7月 筆記 / 12月 口頭",
+    "stats": [
+      { "label": "記事", "total": true },
+      { "label": "キーワード", "groups": ["keyword"], "tags": ["keyword"] },
+      { "label": "過去問", "groups": ["pastExam"], "tags": ["past-questions"] }
+    ]
+  },
+  {
+    "slug": "concrete-chief-engineer",
+    "order": 6,
+    "label": "コンクリート主任技師",
+    "en": "JCI Senior Concrete Engineer",
+    "subtitle": "四肢択一・小論文 完全対策",
+    "description": "材料・配合設計・施工・耐久性・品質管理など8分野を体系整理。分野別の過去問解説・テキスト・小論文対策を収録。",
+    "nextExam": "2026年11月（予定）",
+    "stats": [
+      { "label": "記事", "total": true },
+      { "label": "過去問", "groups": ["primary"], "tags": ["past-questions"] },
+      { "label": "テキスト", "groups": ["textbook"], "tags": [] }
+    ]
+  }
+]


### PR DESCRIPTION
## 概要

トップページ（https://doboku-note.com/）のデザインをブラッシュアップし、Hero をシンプル化。あわせて調査で判明した「技術士 第一次試験コンテンツ（公開21本）がトップの資格カードに未掲載」を是正し、**同種の抜けを二度と起こさない仕組み（データ駆動化＋機械ゲート）**を導入。

## 背景（調査結果）

- 技術士（建設部門, 120本超）は既にトップ掲載・本番反映済み
- 技術士 第一次試験（pe-first-stage, 21本）は公開済みでナビからは到達可能だが、トップの資格カードに無かった
- 根本原因: ナビは `categories.json` から自動生成される一方、トップの資格カードは `page.tsx` の `EXAM_DATA` にハードコードされた**二重管理**で、新資格が手動追加漏れになりやすかった
- 旧 Hero の見出しが長く不自然改行 → 短く・中央寄せに刷新（参考: generative-agents.co.jp の「短い見出し・中央寄せ・余白・CTA1つ」。配色とserifは個性維持）

## 変更点

### 1. Hero シンプル化（`src/components/home/Hero.tsx`）
- 見出しを「土木の試験対策を、ひとつに。」に短縮（不自然改行を解消）
- 中央寄せ・余白増・大型 serif、CTA をプライマリ1つ（資格を選んで学ぶ → `#exams`）に集約
- 未使用の keyword カウンタ・`keywordCount` prop を撤去

### 2. 資格カードのデータ駆動化（`src/app/page.tsx` ＋ 新 `src/config/home-exam-cards.json`）
- `EXAM_DATA` ハードコードを撤去し、`categories.json`（`visible`≠false・`variant`≠reference）× `home-exam-cards.json` から **order 順でカードを導出**。`variant` はカテゴリ定義から取得（単一ソース化）
- カード固有コピー（label/subtitle/description/en/nextExam/stats/order）は `home-exam-cards.json` に分離。**ナビ用 `categories.json` と意図的に異なる**（例: ナビ「技術士第二次試験（建設部門）」⇄ カード「技術士（建設部門）」）
- 統計値は spec 駆動（total / groups+tags / distinctYear / value）で算出。**ビルド出力は #247 リファクタ前と全6カード・全統計値・全ラベルが完全一致**（behavior-preserving を確認）
- 技術士 第一次試験カードを追加（過去問21・年度7・科目3）、6枚=3行×2に整列

### 3. 再発防止ゲート（新 `scripts/check-home-exam-coverage.mjs`）
- `categories.json` の visible な資格が `home-exam-cards.json` に無ければ赤落ち（OGP/doc-coupling と同型）
- pre-commit（`install-pre-commit.mjs`）と CI（`ci.yml` の Type Check 直後）にゲート追加
- これにより、今回の pe-first-stage クラスの「公開済みなのにトップ未掲載」を自動検出

### 4. 手順書の更新
- `docs/reference/exam-content-policy.md` Part 4 と `.claude/skills/authoring/templates/README.md` §2 に「トップページ掲載」ステップを追記（新資格追加フローの SSOT）

### 5. トーン統一（`src/app/page.tsx` / `ExamCards.tsx`）
- 「note 有料教材」見出しを serif＋mono小ラベルに統一、アイコンのホバー反転＋`#exams` アンカー

## 検証

- `npm run type-check` exit 0
- `npm run build` 完走（errors: 0、1034ページ静的生成）
- `npm run check-home-exam-coverage` ✓（6件整合）
- **プリレンダリングHTMLでリファクタ前後の資格カードが完全一致**（slug・順序・ラベル・統計値）
- pre-commit: lint-ui ✓ / check-sns-urls ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
