### PR TITLE
content(総監): r0X-secondary のペルソナ導線を立場別ガイド(ハブ)に集約

### DIFF
--- a/.local/r2/posts/pe-comprehensive-management/r03-secondary/article.mdx
+++ b/.local/r2/posts/pe-comprehensive-management/r03-secondary/article.mdx
@@ -65,11 +65,8 @@ dateModified: 2026-05-22
 
 R3 のデータ利活用テーマは、受験者の業務属性によって取り上げる施策・5〜10 年後の最大リスクの設計が大きく変わる。自分の業務経験に最も近い属性の模範論文マガジン（note 有料）で、R03〜R07 の 5 年分のフル論文と 5 管理間トレードオフの組み立て方を確認できる。
 
-<PersonaSelector
-  items={[
-    { persona: "road-municipality", href: "https://note.com/dobokunote/m/m52186ffd12ca?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r03-secondary-persona-road-municipality", caption: "地方公共団体 道路担当（発注者）視点｜AI 点検診断・GIS 住民開示・デジタルツイン統合管理の模範論文（note 有料マガジン R03-R07＋R8予想）" },
-    { persona: "general-contractor", href: "https://note.com/dobokunote/m/m32aaa137f22e?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r03-secondary-persona-general-contractor", caption: "大手ゼネコン土木支店工事部長視点｜施工データ統合・3D 完成形管理・AI 自律施工の模範論文（note 有料マガジン R03-R07）" },
-    { persona: "river-consultant", href: "https://note.com/dobokunote/m/m32132ecb3033?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r03-secondary-persona-river-consultant", caption: "中堅建設コンサル河川・砂防部門部長視点｜流域 GIS 統合・住民共有プラットフォームの模範論文（note 有料マガジン R03-R07）" },
-  ]}
-/>
+自分の立場（発注者／受注者）と分野に最も近い模範論文は、全 14 ペルソナ（自治体の道路・河川・都市計画・下水道・上水道・港湾・砂防・公園緑地・技術基準・契約調達、ゼネコン・河川砂防コンサル・道路橋梁コンサル・都市計画コンサル）をまとめた立場別ガイドから選べます。フルの模範論文（R03〜R07・各 3,000 字級）は note の有料マガジンに収録しています。
+
+[総監記述式 模範論文｜立場別ガイド（発注者／受注者 × 分野・14ペルソナ）](/docs/pe-comprehensive-management-essay-persona-guide)
+
 

--- a/.local/r2/posts/pe-comprehensive-management/r04-secondary/article.mdx
+++ b/.local/r2/posts/pe-comprehensive-management/r04-secondary/article.mdx
@@ -65,10 +65,7 @@ DXを単なるデジタル技術の利用ではなく，デジタル技術を活
 
 R4 の DX による変革テーマは、受験者の業務属性によって取り上げる事業・5 か年計画・タスクフォース設計が大きく変わる。自分の業務経験に最も近い属性の模範論文マガジン（note 有料）で、R03〜R07 の 5 年分のフル論文と 5 管理間トレードオフの組み立て方を確認できる。
 
-<PersonaSelector
-  items={[
-    { persona: "road-municipality", href: "https://note.com/dobokunote/m/m52186ffd12ca?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r04-secondary-persona-road-municipality", caption: "地方公共団体 道路担当（発注者）視点｜BIM/CIM 統合化・設計〜維持管理の統合 DX の模範論文（note 有料マガジン R03-R07＋R8予想）" },
-    { persona: "general-contractor", href: "https://note.com/dobokunote/m/m32aaa137f22e?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r04-secondary-persona-general-contractor", caption: "大手ゼネコン土木支店工事部長視点｜i-Construction・自動化建機・遠隔施工への業態変革の模範論文（note 有料マガジン R03-R07）" },
-    { persona: "river-consultant", href: "https://note.com/dobokunote/m/m32132ecb3033?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r04-secondary-persona-river-consultant", caption: "中堅建設コンサル河川・砂防部門部長視点｜流域治水運営支援サブスク型サービスへの業態変革の模範論文（note 有料マガジン R03-R07）" },
-  ]}
-/>
+自分の立場（発注者／受注者）と分野に最も近い模範論文は、全 14 ペルソナ（自治体の道路・河川・都市計画・下水道・上水道・港湾・砂防・公園緑地・技術基準・契約調達、ゼネコン・河川砂防コンサル・道路橋梁コンサル・都市計画コンサル）をまとめた立場別ガイドから選べます。フルの模範論文（R03〜R07・各 3,000 字級）は note の有料マガジンに収録しています。
+
+[総監記述式 模範論文｜立場別ガイド（発注者／受注者 × 分野・14ペルソナ）](/docs/pe-comprehensive-management-essay-persona-guide)
+

--- a/.local/r2/posts/pe-comprehensive-management/r05-secondary/article.mdx
+++ b/.local/r2/posts/pe-comprehensive-management/r05-secondary/article.mdx
@@ -99,11 +99,8 @@ W1：（弱みの1つめの記載）
 
 R5 の SWOT 分析テーマは、受験者の業務属性によって取り上げる強み・弱み・3 戦略の立案が大きく変わる。自分の業務経験に最も近い属性の模範論文マガジン（note 有料）で、R03〜R07 の 5 年分のフル論文と 5 管理間トレードオフの組み立て方を確認できる。
 
-<PersonaSelector
-  items={[
-    { persona: "road-municipality", href: "https://note.com/dobokunote/m/m52186ffd12ca?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r05-secondary-persona-road-municipality", caption: "地方公共団体 道路担当（発注者）視点｜データサイエンス予防保全・ナレッジマネジメント・DX 施工管理の SWOT 戦略立案模範論文（note 有料マガジン R03-R07＋R8予想）" },
-    { persona: "general-contractor", href: "https://note.com/dobokunote/m/m32aaa137f22e?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r05-secondary-persona-general-contractor", caption: "大手ゼネコン土木支店工事部長視点｜技術蓄積・施工ノウハウ × 高齢化・採用難の 3 戦略立案模範論文（note 有料マガジン R03-R07）" },
-    { persona: "river-consultant", href: "https://note.com/dobokunote/m/m32132ecb3033?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r05-secondary-persona-river-consultant", caption: "中堅建設コンサル河川・砂防部門部長視点｜地域知見・住民折衝 × 属人化・採用難の 3 戦略立案模範論文（note 有料マガジン R03-R07）" },
-  ]}
-/>
+自分の立場（発注者／受注者）と分野に最も近い模範論文は、全 14 ペルソナ（自治体の道路・河川・都市計画・下水道・上水道・港湾・砂防・公園緑地・技術基準・契約調達、ゼネコン・河川砂防コンサル・道路橋梁コンサル・都市計画コンサル）をまとめた立場別ガイドから選べます。フルの模範論文（R03〜R07・各 3,000 字級）は note の有料マガジンに収録しています。
+
+[総監記述式 模範論文｜立場別ガイド（発注者／受注者 × 分野・14ペルソナ）](/docs/pe-comprehensive-management-essay-persona-guide)
+
 

--- a/.local/r2/posts/pe-comprehensive-management/r06-secondary/article.mdx
+++ b/.local/r2/posts/pe-comprehensive-management/r06-secondary/article.mdx
@@ -77,11 +77,8 @@ dateModified: 2026-05-22
 
 R6 の CN（カーボンニュートラル）テーマは、受験者の業務属性によって取り上げる施策・トレードオフ・2050 年シナリオが大きく変わる。自分の業務経験に最も近い属性の模範論文マガジン（note 有料）で、R03〜R07 の 5 年分のフル論文と 5 管理間トレードオフの組み立て方を確認できる。
 
-<PersonaSelector
-  items={[
-    { persona: "road-municipality", href: "https://note.com/dobokunote/m/m52186ffd12ca?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r06-secondary-persona-road-municipality", caption: "地方公共団体 道路担当（発注者）視点｜ICT 施工・BIM/CIM 物流最適化・道路発電の模範論文（note 有料マガジン R03-R07＋R8予想）" },
-    { persona: "general-contractor", href: "https://note.com/dobokunote/m/m32aaa137f22e?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r06-secondary-persona-general-contractor", caption: "大手ゼネコン土木支店工事部長視点｜低炭素コンクリート・電動建機・建設副産物再利用の模範論文（note 有料マガジン R03-R07）" },
-    { persona: "river-consultant", href: "https://note.com/dobokunote/m/m32132ecb3033?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r06-secondary-persona-river-consultant", caption: "中堅建設コンサル河川・砂防部門部長視点｜グリーンインフラ・自然再興・河川自然再生の模範論文（note 有料マガジン R03-R07）" },
-  ]}
-/>
+自分の立場（発注者／受注者）と分野に最も近い模範論文は、全 14 ペルソナ（自治体の道路・河川・都市計画・下水道・上水道・港湾・砂防・公園緑地・技術基準・契約調達、ゼネコン・河川砂防コンサル・道路橋梁コンサル・都市計画コンサル）をまとめた立場別ガイドから選べます。フルの模範論文（R03〜R07・各 3,000 字級）は note の有料マガジンに収録しています。
+
+[総監記述式 模範論文｜立場別ガイド（発注者／受注者 × 分野・14ペルソナ）](/docs/pe-comprehensive-management-essay-persona-guide)
+
 

--- a/.local/r2/posts/pe-comprehensive-management/r07-secondary/article.mdx
+++ b/.local/r2/posts/pe-comprehensive-management/r07-secondary/article.mdx
@@ -65,11 +65,8 @@ dateModified: 2026-05-22
 
 R7 の少子高齢化テーマは、受験者の業務属性によって取り上げる事業・トレードオフ・2050 年シナリオが大きく変わる。自分の業務経験に最も近い属性の模範論文マガジン（note 有料）で、R03〜R07 の 5 年分のフル論文と 5 管理間トレードオフの組み立て方を確認できる。
 
-<PersonaSelector
-  items={[
-    { persona: "road-municipality", href: "https://note.com/dobokunote/m/m52186ffd12ca?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r07-secondary-persona-road-municipality", caption: "地方公共団体 道路担当（発注者）視点｜橋梁長寿命化・バイパス改良の模範論文（note 有料マガジン R03-R07＋R8予想）" },
-    { persona: "general-contractor", href: "https://note.com/dobokunote/m/m32aaa137f22e?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r07-secondary-persona-general-contractor", caption: "大手ゼネコン土木支店工事部長視点｜担い手不足・自動化建機・外国人技能者活用の模範論文（note 有料マガジン R03-R07）" },
-    { persona: "river-consultant", href: "https://note.com/dobokunote/m/m32132ecb3033?utm_source=doboku-note&utm_medium=referral&utm_campaign=note-magazine&utm_content=r07-secondary-persona-river-consultant", caption: "中堅建設コンサル河川・砂防部門部長視点｜流域治水の住民参画・若手育成の模範論文（note 有料マガジン R03-R07）" },
-  ]}
-/>
+自分の立場（発注者／受注者）と分野に最も近い模範論文は、全 14 ペルソナ（自治体の道路・河川・都市計画・下水道・上水道・港湾・砂防・公園緑地・技術基準・契約調達、ゼネコン・河川砂防コンサル・道路橋梁コンサル・都市計画コンサル）をまとめた立場別ガイドから選べます。フルの模範論文（R03〜R07・各 3,000 字級）は note の有料マガジンに収録しています。
+
+[総監記述式 模範論文｜立場別ガイド（発注者／受注者 × 分野・14ペルソナ）](/docs/pe-comprehensive-management-essay-persona-guide)
+
 


### PR DESCRIPTION
## 概要
過去問ページ（r03〜r07 secondary）の記事内 `<PersonaSelector>`（厳選3ペルソナ）を撤去し、全14ペルソナを索引する既存ハブ `essay-persona-guide` への単一リンクに集約。

## 背景
#248 で記事外14カード束を撤去しペルソナ導線を記事内3に一本化した結果、この年度ページから直接たどれるペルソナが3に減っていた（ユーザー指摘）。過去問ページ→ハブ→全14ペルソナの導線にすることで、**今後ペルソナを増やしてもハブ1ページの更新だけ**で済む（過去問ページのハードコード排除＝拡張耐性）。

## 変更
- r03〜r07 secondary（5ファイル）：PersonaSelector撤去＋立場別ガイドへの単一リンク追加
- CRLF保持・文字化けなし・ハブURL本番実在（check-sns-urls ✓）・pre-commit全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)