### PR TITLE
feat(skill): OGP意匠の素案試作スキル ogp-design-explore を新設

### DIFF
--- a/.claude/skills/conversion/ogp-create/SKILL.md
+++ b/.claude/skills/conversion/ogp-create/SKILL.md
@@ -200,6 +200,7 @@ cover:
 
 ## 参照
 
+- 意匠の素案試作（前段）: `/ogp-design-explore`（aidesigner / Canva の MCP で OGP デザイン案を試作 → 採用方向を本スキルの satori テンプレに実装して量産）
 - デザイン SSOT: `docs/reference/ogp-prompts.md`（レイアウト・配色・テーマ色・変更履歴の真実源）
 - OGP ギャラリー（一括目視 QA）: `scripts/ogp-gallery.mjs`（`npm run ogp-gallery`）
 - テンプレ定義: `.claude/config/ogp/templates.json`

--- a/.claude/skills/conversion/ogp-design-explore/SKILL.md
+++ b/.claude/skills/conversion/ogp-design-explore/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ogp-design-explore
+user-invocable: true
+description: >
+  OGP 画像（1200×630）の新しいデザイン方向を aidesigner / Canva の MCP で素案として試作し、
+  採用案を satori テンプレート（ogp-create）に落として量産につなげる「意匠の試作専用」スキル。
+  量産・本番生成・per-article 生成はしない（それは /ogp-create）。MCP は外部 API 費用（クレジット）が発生するため都度ユーザー判断で起動する。
+  Use when user asks to [OGPデザイン検討, OGP意匠の素案, OGPデザイン案を作って, OGPリデザインの試作, サムネのデザイン方向を探りたい, /ogp-design-explore].
+---
+
+## 用途
+
+OGP 画像（1200×630）の**見た目の方向性**を、AI デザイン MCP（aidesigner / Canva）で**素案（たたき台）**として試作するためのスキル。配色・レイアウト・タイポの新方向、別テンプレ案、ブランドキット抽出などの「探索フェーズ」を担う。
+
+**量産は必ずコードで行う。** doboku-note の OGP 本番生成は satori ベースの決定論的テンプレート（`/ogp-create`）で 1000 枚超を一括生成しており、テーマ色トークン・CLS・R2 同期・改行戦略が前提。本スキルは「素案 → 採用方向を `/ogp-create` のテンプレに実装 → `npm run ogp` で量産」という流れの**前半（ideation）だけ**を担当し、後半（量産）は `/ogp-create` に渡す。
+
+> Negative trigger: **per-article の OGP を作りたい/全ページ再生成したい場合は本スキルではなく `/ogp-create`**。本スキルで生成した素案 PNG を本番 `ogp.png` として配信しない（決定論・一貫性が崩れる）。
+
+## 前提（MCP の到達性とコスト）
+
+- 接続済み MCP: **aidesigner**（`mcp__aidesigner__*`）と **Canva**（`mcp__claude_ai_Canva__*`）。両者とも claude.ai OAuth 経由のため**会社 PC のプロキシ（外部 API 遮断）でも到達する**（`curl`/node 直叩きとは別経路）。
+- **aidesigner は無料枠でクレジット制限あり**。生成前に必ず `mcp__aidesigner__get_credit_status` を呼んで残量を確認し、**何枚生成してよいかをユーザーに確認**してから着手する（浪費防止）。
+- MCP は**ヘッドレス/CI/cron では使えない**可能性が高い（インタラクティブ認証）。本スキルは対話セッション専用。自動パイプラインに組み込まない。
+
+## 実行手順
+
+### Step 1: スコープとコンテキスト収集
+1. 対象を決める: ①テンプレ全体の新方向、②特定カテゴリ（資格）の見え方、③特定記事の OGP 案、のどれか。
+2. デザイン SSOT と現状を読む:
+   - `docs/reference/ogp-prompts.md`（レイアウト・配色・テーマ色・変更履歴の真実源）
+   - `docs/design-system/note-cover-tokens.json` の `exams[].base`（資格別テーマ色の真実源）
+   - 現行 `ogp.png` を 2〜3 枚 Read（例: `.local/r2/posts/{category}/{localSlug}/ogp.png`）して現状の見た目を把握。一括俯瞰は `npm run ogp-gallery -- --open`。
+
+### Step 2: クレジット確認
+```
+mcp__aidesigner__get_credit_status   # 残量を確認。残りが少なければ生成回数をユーザーに確認
+```
+
+### Step 3: 素案の生成（MCP）
+- **aidesigner**:
+  - `mcp__aidesigner__create_brand_kit_from_url`（`https://doboku-note.com` 等）でサイトの配色からブランドキットを抽出 → 一貫性のある案の土台にする。
+  - `mcp__aidesigner__generate_branding_kit_variations` で 3×3 のブランド案ボードを出し、ユーザーにタイル番号を選ばせてから `create_brand_kit_from_variation` で確定（MCP の運用指示に準拠）。
+  - `mcp__aidesigner__generate_image` / `generate_design`（HTML）で 1200×630 想定の OGP コンセプトを生成、`refine_design` で反復。
+- **Canva**:
+  - `mcp__claude_ai_Canva__generate-design` → `resize-design`（1200×630）→ `export-design`（PNG）。
+  - 一貫性を担保したいなら `create-brand-template-draft` / `create-design-from-brand-template`。
+- **出力は必ず `.tmp/` 配下**に置く（例: `.tmp/ogp-explore/`）。本番 `.local/r2/posts/**/ogp.png` は上書きしない。
+
+### Step 4: 比較・選定
+- 素案を並べてユーザーに提示し、現行テンプレ（mono-tag）・資格別テーマ色との整合で評価。`refine_design` で反復。
+- 「ブランド一貫性（資格色で分野が判別できるか）」「外部リンクカードでの可読性（大タイトル）」「note カバー（G2）との見た目整合」を判断軸にする。
+
+### Step 5: コードへの落とし込み（量産は `/ogp-create`）
+採用方向が決まったら、**MCP の生成物をそのまま配信せず**、決定論的テンプレに実装する:
+1. レンダラを編集: `.claude/skills/conversion/ogp-create/scripts/lib/ogp-templates.mjs`（mono-tag 等の satori レンダ関数）。新テンプレを足す場合は `/ogp-create` の「テンプレート追加手順」に従う（`templates.json` / `rules.json` / `ogp-prompts.md` も更新）。
+2. デザイン SSOT を更新: `docs/reference/ogp-prompts.md`（レイアウト・配色・**変更履歴**）。テーマ色を変えるなら `docs/design-system/note-cover-tokens.json` の `exams[].base`。
+3. 量産＆QA:
+   ```bash
+   npm run ogp -- --all --force     # 全 ogp.png を新意匠で再生成（/ogp-create）
+   npm run ogp-gallery -- --open    # 1 枚の HTML で全点を目視 QA
+   ```
+4. OGP デザインを変えたら `ogp-prompts.md` と `ogp-create` の SKILL.md/テンプレを**同一コミットで更新**（SSOT 二重化を防ぐ）。
+
+## 例
+
+- 「次の OGP 意匠の素案を 3 案ほしい」→ Step1（ogp-prompts.md＋現行3枚）→ Step2（クレジット確認・3案でよいか確認）→ Step3（aidesigner brand kit→variations→generate_image ×3）→ Step4（提示・選定）→ Step5（mono-tag レンダラに実装→`npm run ogp`）。
+- 「総監カテゴリだけ OGP の見え方を変えたい」→ 対象=カテゴリ。テーマ色は `note-cover-tokens.json` の総監 base。素案で配色方向を出し、採用色を tokens に反映→ `/ogp-create` で当該カテゴリを再生成。
+- 「Canva で 1200×630 のサムネ案を起こして」→ Canva `generate-design`→`resize-design`(1200×630)→`export-design`。良ければ意匠を mono-tag に移植。
+
+## トラブルシューティング
+
+| 症状 | 対応 |
+|---|---|
+| aidesigner がクレジット切れ（`entitled:false`・残少） | 生成回数を絞る。Canva 側で試作するか、ユーザーにクレジット追加可否を確認 |
+| MCP が応答しない/CI で使えない | 本スキルは対話セッション専用。自動実行・cron では使わない |
+| 素案を本番に出してよいか迷う | 出さない。必ず `/ogp-create` の satori テンプレに落として量産（決定論・テーマ色・CLS のため） |
+| 生成物がトークンと合わない | MCP 出力はラスタ/概念物。配色をトークン（`exams[].base`）に手で対応付けてからコード実装する |
+
+## 参照
+
+- 量産・本番生成（決定論テンプレ）: `/ogp-create`（`.claude/skills/conversion/ogp-create/SKILL.md`）
+- デザイン SSOT: `docs/reference/ogp-prompts.md`（レイアウト・配色・テーマ色・変更履歴）
+- テーマ色トークン（真実源）: `docs/design-system/note-cover-tokens.json`
+- レンダラ実装: `.claude/skills/conversion/ogp-create/scripts/lib/ogp-templates.mjs`
+- 一括目視 QA: `npm run ogp-gallery`
+- AI デザイン MCP: `aidesigner`（スキル `/aidesigner` でも起動可）/ Canva（`mcp__claude_ai_Canva__*`）
+- スキル設計規約: `docs/reference/skills-design-guide.md`

--- a/docs/reference/skills-guide.md
+++ b/docs/reference/skills-guide.md
@@ -35,6 +35,7 @@ title: スキル ナビゲーションガイド
 | `/pdf-to-mdx` | PDF/画像 → MDX 変換（試験別テンプレート）。`--scanned` でテキスト層なしスキャン書籍を視覚 OCR（`scanned-textbook-transcriber`）→ 内部リファレンス .md ＋図クロップ | `PDF変換`, `MDX化`, `スキャン教材の文字起こし`, `書籍OCR`, `/pdf-to-mdx --exam {cem\|civil-construction-1\|general}`, `/pdf-to-mdx --scanned` |
 | `/exam-questions-import` | 過去問集 PDF → MDX（解答追加も可） | `過去問取込`, `/exam-questions-import --exam {civil-primary\|civil-secondary\|pe-primary\|pe-first-stage}` |
 | `/ogp-create` | サイト OGP（mono-tag・全幅＋資格別テーマ色外枠）＋ note 記事カバー（G2・試験色分け）生成。デザイン SSOT は `docs/reference/ogp-prompts.md`、一括目視 QA は `npm run ogp-gallery` | `OGP画像`, `noteカバー`, `/ogp-create` |
+| `/ogp-design-explore` | OGP 意匠の**新方向を aidesigner / Canva の MCP で素案として試作**し、採用案を `/ogp-create` の satori テンプレに落として量産につなぐ。試作専用（量産・per-article 生成は `/ogp-create`）。MCP は外部クレジット消費 | `OGPデザイン検討`, `OGP素案`, `OGPリデザイン試作`, `/ogp-design-explore` |
 | `/magazine-to-pdf` | note マガジンの article.md →「問題文＋解答」中心の紙用 PDF（spec 駆動・A/B案両収録） | `マガジンをPDF`, `記事を紙で`, `模範論文PDF`, `/magazine-to-pdf --spec scripts/pdf-specs/{name}.json [--desktop]` |
 
 ### 品質管理（quality）

--- a/docs/reference/skills-registry.md
+++ b/docs/reference/skills-registry.md
@@ -16,7 +16,7 @@ title: スキル ガバナンス記録
 ```
 .claude/skills/
 ├── authoring/       # 10 — 記事を作る
-├── conversion/      # 4 — 形式変換（MDX / OGP 画像 / 紙用 PDF）
+├── conversion/      # 5 — 形式変換（MDX / OGP 画像 / 紙用 PDF）＋ OGP 意匠の素案試作
 ├── quality/         # 13 — MDX・note 公開前品質検査
 ├── management/      # 12 — 計画・分析・戦略
 ├── dev/             # 12 — 開発・CI/CD
@@ -25,10 +25,10 @@ title: スキル ガバナンス記録
 └── ui/              # 1 — UI/UX デザイン
 ```
 
-合計 **64 スキル**（Phase 2 待機を除く）。
+合計 **65 スキル**（Phase 2 待機を除く）。
 
 > 2026-06-17 追加: `metrics/record-sales`（note 販売履歴を SSOT `sales-log.json` に記録するスキル。ダッシュボードペーストから正規化追記＋月次集計。Generator `sales-recorder` 新設）。運用ドキュメント `docs/reference/sales-tracking.md` と同時新設。
-
+> 2026-06-16 追加: `conversion/ogp-design-explore`（OGP 画像 1200×630 の**意匠の新方向を aidesigner / Canva の MCP で素案として試作**する ideation 専用スキル）。`/ogp-create`（satori 決定論テンプレで量産）の**前段**を担い、採用方向を `ogp-templates.mjs`＋`ogp-prompts.md`（SSOT）に落として `npm run ogp` で量産する流れ。**量産・本番生成・per-article 生成はしない**（それは `/ogp-create`）。両 MCP は claude.ai OAuth 経由で会社 PC プロキシでも到達するが、**aidesigner は無料枠クレジット制限あり＝生成前に `get_credit_status` 確認＋ユーザー判断**、CI/headless では不可。`user-invocable: true`（外部 API 費用が発生）。素案は `.tmp/` に出し本番 `ogp.png` を上書きしない。文脈 [[project_ogp_design_ssot]]。
 > 2026-06-14 追加（スキャン書籍取り込み）: `conversion/pdf-to-mdx` に **`--scanned` モード**を追加（テキスト層なしスキャン書籍を視覚 OCR で内部リファレンス `docs/textbook/**.md` ＋図に変換）。手順は `references/scanned-image-pipeline.md` に分離（pdfimages 抽出 → 90°回転/見開き分割 → 並列 OCR → 章分割 → 図 bbox 判定・精密クロップ埋め込み）。あわせて **新エージェント `scanned-textbook-transcriber`（Generator・sonnet）** を新設＝スキャンページ画像の逐語 OCR ファンアウトワーカー（Read 画像＋Write のみ・Bash 不可）。図 bbox は `civil-exam-figure-extractor` と同型 Generator を流用。落とし穴も収録（macOS bash3.2 の `declare -A` 不可・zsh 未クオート非分割 `${=var}`・`pdfimages -j` が pdftoppm より高速＋ネイティブ・ディスク逼迫 ENOSPC で静かに truncate→破損ページはスプレッド直接クロップで救済）。旧メモリ `reference_scanned_pdf_pipeline`（pdftoppm 方式）を pdfimages 方式へ更新。技術士建設部門「論文対策キーワード」168 見開き → 7 章 .md（約312k字）＋図31点で実証。[[project_pe_construction_secondary]]
 
 > 2026-05-29 追加: `authoring/civil-keiken-magazine`（1級・2級土木 施工経験記述 マガジン模範答案の生成・採点。Generator `civil-keiken-essay-writer` ＋ Evaluator `civil-keiken-essay-qa`）。


### PR DESCRIPTION
## 目的
OGP 画像（1200×630）の**デザイン方向を「いつでも検討」**できるようにする ideation 専用スキル。素案は AI デザイン MCP で出し、**量産は従来どおりコード（satori テンプレ）**で行う、という分業を固定する。

## 内容
- `.claude/skills/conversion/ogp-design-explore/SKILL.md`
  - aidesigner / Canva の MCP で OGP 意匠の**素案（たたき台）**を試作 → 採用方向を `/ogp-create` の satori テンプレ（`ogp-templates.mjs`）＋ SSOT（`ogp-prompts.md`）に実装 → `npm run ogp` で量産、という手順を内包
  - **量産・本番生成・per-article 生成はしない**（それは `/ogp-create`）。素案は `.tmp/` に出し本番 `ogp.png` を上書きしない
  - `user-invocable: true`（MCP クレジット消費）。生成前に `get_credit_status` 確認＋ユーザー判断。CI/headless 不可
- `skills-guide.md`（conversion に行追加）/ `skills-registry.md`（conversion 4→5・総計 64→65・2026-06-16 追加ログ）

## MCP 到達性（実測）
両 MCP とも claude.ai OAuth 経由で**会社 PC プロキシでも到達**（`whoami`/`get_credit_status`/`list-brand-kits` で確認済）。aidesigner は無料枠でクレジット制限あり。

## なぜスキル（サブエージェントでない）か
「いつでも検討」＝ユーザー起動ワークフロー／デザイン判断は親エージェント（Opus）／MCP 探索→コード量産の橋渡し、が skill に最も合致。

## 検証
pre-commit 通過: **check-doc-coupling ✓（台帳登録もれなし）** / check-doc-refs ✓（参照パス実在）/ check-sns-urls ✓。skills-design-guide 準拠（frontmatter WHAT+WHEN+trigger、progressive disclosure、user-invocable 基準）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)