### PR TITLE
feat(category): カテゴリ hub を 2 カラム化（転職アフィリを右サイドバー上部へ）＋ note CTA をモバイル1枚に圧縮

### DIFF
--- a/.claude/scripts/report-monetization-coverage.mts
+++ b/.claude/scripts/report-monetization-coverage.mts
@@ -34,7 +34,7 @@ import {
 } from "../../src/lib/magazine-placement.ts";
 import { getMagazine } from "../../src/lib/note-magazines.ts";
 import {
-  resolveCategoryAffiliate,
+  resolveCategoryCareerAd,
   HOME_AFFILIATE,
   resolveCareerSidebarAd,
 } from "../../src/config/affiliate-creatives.ts";
@@ -193,8 +193,9 @@ for (const [page, t] of traffic) {
     noteCta = resolveCategoryMagazines(category)
       .filter((s) => getMagazine(s.magazineId))
       .map((s) => s.magazineId);
-    const aff = resolveCategoryAffiliate(category);
-    affiliate = aff ? (aff.kind === "career" ? "GKS" : "SAT") : null;
+    // 転職プログラム名（"DXConsulting" / "BuildJob" / "GKS"）。trackLabel = "{program}-sidebar"。
+    const aff = resolveCategoryCareerAd(category);
+    affiliate = aff ? aff.trackLabel.replace(/-sidebar$/, "") : null;
   } else {
     continue;
   }

--- a/docs/handoffs/2026-06-16-affiliate-ssot.md
+++ b/docs/handoffs/2026-06-16-affiliate-ssot.md
@@ -34,3 +34,33 @@
 
 - **`affiliate-courses.json` 完全一元化**: 全 creative の実体（href/imageSrc/pixelSrc/expiresAt）を 1 ファイルに集約し、各コンポーネント・`page.tsx` はそこを参照、lint 許可リストも自動導出（`affiliate-mats.json` との二重管理を解消）。現状は creative がコンポーネント／config に分散（各 1 箇所・重複なし）で運用可。**トリガー＝講座案件 5 件以上 or JSON 管理に移行したくなったとき**（詳細は 02 台帳「再検討トリガー #1」）。
 - インライン `DokugakuKeikenLink` は PR バッジ非表示（元の生リンク挙動を保存）。文中リンクへの PR 表示付与は別途デザイン判断。
+
+---
+
+# 追記: カテゴリ hub 転職サイドバー新設＋資格別セグメント（PR #256・2026-06-16）
+
+- ブランチ: `feat/category-hub-career-sidebar`（PR #256・`develop` ベース・**未マージ**）
+- 真実源（ポインタ）: `docs/project/04_運営/02_アフィリエイト提携状況.md`（カテゴリ hub 節 + DX creative 保管庫）。`07_アフィリ×note共存設計.md` WP2 を上書き。
+
+## 要約
+
+カテゴリ hub（`/category/{slug}`）の note CTA 縦積みでモバイル記事到達が阻害され（pe は 3 枚積み）、転職アフィリも最下部で不可視だった問題を、docs サイドバー方式のミラーで解消。あわせて資格層に転職 creative をセグメント。
+
+## 変更（コミット 3 本）
+
+1. `03874cb` civil カテゴリ hub を 2 カラム化（右サイドバー sticky 上部に転職バナー＝ピクセル源／モバイルは本文 1 セクション目直後に visible バナー href のみ）。note CTA をモバイル 1 枚／PC 2 枚並びに圧縮。
+2. `d01c5aa` note 圧縮を全カテゴリ共通化＋pe-comprehensive を転職サイドバー対象に追加（当初 GKS/BuildJob 流用）。
+3. `841e928` **資格別セグメント**（`resolveCategoryCareerAd` 新設）: civil=施工管理系（`resolveCareerSidebarAd`＝BuildJob/GKS）、pe=**ハイクラス DX/コンサル転職**（`PE_CONSULTING_CAREER_AD`, mat `4B5OO5+NTCZ6+4SXU+NUES1`）。GKS の「20代未経験/施工管理」が総監シニア層にミスマッチだったのを解消。旧 `resolveCategoryAffiliate`（gate 専用・props 未使用）撤去。`affiliate-mats.json` に DX mat 登録（9 種に）。
+
+- 1 ページ 1 ピクセル維持（ピクセルは PC サイドバー側のみ）。concrete / pe-construction / pe-first-stage は非該当＝単一カラム維持（空サイドバー無し）。
+
+## 検証済み
+
+`type-check` 緑 / `lint`（対象 0 error）/ `check-affiliate-mats` 緑（9/9）/ pre-commit・pre-push OK。civil/pe ともに 2 カラム＋ピクセル 1＋バナー 2、concrete 単一カラムを dev curl で確認（BuildJob 版時点）。**本番 build はローカル worktree 制約（Turbopack の symlink 拒否＋ディスク ENOSPC）で未実行**＝CI（権威ゲート）で確認。
+
+## 次アクション（ユーザー判断）
+
+1. PR #256 を `develop` マージ → `/deploy` で `main`
+2. **DX バナー画像の実描画を PR プレビュー / dev で目視**（creative URL は提供 HTML を逐語コピー・当方は実表示未確認）
+3. pe の DX 案件の位置づけが「ハイクラス DX/コンサル」想定どおりか最終確認（違えば creative 差替は `PE_CONSULTING_CAREER_AD` 1 箇所）
+4. スキル/エージェントへの影響なし（カテゴリ hub アフィリを参照する skill/agent は無し・`check-doc-coupling` 緑）

--- a/docs/project/04_運営/02_アフィリエイト提携状況.md
+++ b/docs/project/04_運営/02_アフィリエイト提携状況.md
@@ -80,7 +80,19 @@ doboku-note で扱うアフィリエイト案件の提携・申請状況・運�
 - **creative 定数**: `src/config/affiliate-creatives.ts` の `BUILDJOB_CAREER_AD`。`SidebarAdBanner` で描画（PR バッジ・`rel="nofollow sponsored noopener"`・`loading="lazy"`・width/height は自動付与）。
 - **出し分けロジック**: 同ファイル `resolveCareerSidebarAd()` が **2026-09-01 00:00 JST（= 8/31 15:00 UTC）を境**に creative を切替（〜8/31 ビルドジョブ ¥50,000 / 9/1 以降 GKS 自動復帰）。SSG のためビルド時刻で固定 ＝ **9/1 以降の最初の本番再ビルドで自動的に GKS へ戻る**（万一再ビルドが無い場合に備え、定数を手動で `CIVIL_CAREER_AD` に戻すか revert で対応）。
 - **配置**: 全 docs サイドバー上部（位置 A）。期間中はこの 1 枠がビルドジョブの唯一のピクセル発火源。**期間中は GKS のサイドバー枠が止まるため GKS の「表示回数」計測は停止**（GKS のクリック・成果は本文インライン href 経由で従来どおり計測される）。
-- **カテゴリ hub（civil-1 / civil-2 / pe-comprehensive-management）も 2026-06-16 に切替対象へ**: 旧「hub 末のテキストカード `CareerAffiliate`（GKS 据え置き・ファーストビュー外）」を撤去し、**右サイドバー（PC ≥993px・sticky 上部）へ転職枠を新設**（pe は 2026-06-16 に新規追加＝高トラフィックの収益導線ゼロ解消。GKS 素性ミスマッチの注意は下記サマリ参照）。`SidebarAdBanner` で `resolveCareerSidebarAd()` の creative を描画する（＝docs と同じく〜8/31 はビルドジョブ／以降 GKS、バナー creative を使うため text/points 未整備の制約は解消）。**ピクセル源は PC サイドバー側のみ**＝1 ページ 1 ピクセル維持。モバイル（<993px）は本文 1 セクション目直後に同 creative の visible バナー（`pixelSrc` 無し＝href のみ）を配置してインプレッションを確保。`src/app/category/[slug]/page.tsx` で `careerSidebar = categoryAffiliate?.kind === 'career' ? resolveCareerSidebarAd() : null` を判定し civil のみ 2 カラム化（note CTA はモバイル 1 枚／PC 2 枚並びに圧縮して記事グリッドへの到達を阻害しない）。PE / concrete はサイドバー条件に非該当のため従来どおり単一カラム（空サイドバーは出さない）。
+- **カテゴリ hub（civil-1 / civil-2 / pe-comprehensive-management）にサイドバー転職枠を新設**（2026-06-16）: 旧「hub 末のテキストカード `CareerAffiliate`（ファーストビュー外）」を撤去し、**右サイドバー（PC ≥993px・sticky 上部）へ転職枠を新設**。creative は受験者層で**資格別セグメント**（`resolveCategoryCareerAd`）: civil-1/2 = 施工管理系（`resolveCareerSidebarAd`＝〜8/31 ビルドジョブ／以降 GKS）、**pe-comprehensive = ハイクラス DX/コンサル転職（`PE_CONSULTING_CAREER_AD`）**（総監＝シニア技術者・管理職層に適合。GKS の 20代未経験/施工管理ミスマッチを解消）。**ピクセル源は PC サイドバー側のみ**＝1 ページ 1 ピクセル維持。モバイル（<993px）は本文 1 セクション目直後に同 creative の visible バナー（`pixelSrc` 無し＝href のみ）を配置してインプレッションを確保。`src/app/category/[slug]/page.tsx` で `careerSidebar = resolveCategoryCareerAd(slug)`（戻り値 null＝枠なし）を判定し civil-1/2・pe を 2 カラム化（note CTA はモバイル 1 枚／PC 複数並びに圧縮して記事グリッドへの到達を阻害しない）。concrete / pe-construction / pe-first-stage は非該当＝従来どおり単一カラム（空サイドバーは出さない）。
+
+#### ハイクラス DX・コンサル転職（A8.net、提携済）creative 保管庫 — 2026-06-16
+
+総監（技術士）= シニア技術者・管理職層向けのハイクラス／DX・コンサル転職案件。pe-comprehensive-management カテゴリ hub のサイドバー転職枠に充当（GKS の「20代未経験/施工管理」が総監層にミスマッチなため差替）。
+
+- **mat**: `4B5OO5+NTCZ6+4SXU+NUES1`
+- **バナー href**: `https://px.a8.net/svt/ejp?a8mat=4B5OO5+NTCZ6+4SXU+NUES1`
+- **バナー画像（imageSrc、300×250）**: `https://www23.a8.net/svt/bgt?aid=260605733040&wid=001&eno=01&mid=s00000022413004005000&mc=1`
+- **計測ピクセル（pixelSrc）**: `https://www18.a8.net/0.gif?a8mat=4B5OO5+NTCZ6+4SXU+NUES1`
+- **creative 定数**: `src/config/affiliate-creatives.ts` の `PE_CONSULTING_CAREER_AD`。`SidebarAdBanner` で描画。
+- **配置**: pe-comprehensive-management カテゴリ hub のみ（`resolveCategoryCareerAd` で pe → 本案件、civil → 施工管理系）。期間切替なし（DX 固定）。PC サイドバーがピクセル発火源（モバイル本文中バナーは href のみ）。
+- **trackLabel**: `DXConsulting-sidebar`（GA4 クリック計測）。
 
 
 ### 書籍・物販
@@ -103,8 +115,8 @@ doboku-note で扱うアフィリエイト案件の提携・申請状況・運�
 
 > **現状サマリ（最新・2026-06-16）— 以下の 2026-06-02 等の住み分け記述は履歴**
 > - **サイドバー転職枠は全 docs 常設**（2026-06-06 に civil 限定→PE 含む全 docs へ拡大）。creative は `resolveCareerSidebarAd()` が期間で出し分け＝**〜2026-08-31(JST) はビルドジョブ（無料面談 ¥50,000）／9-01 以降 GKS に自動復帰**（`src/config/affiliate-creatives.ts`）。
-> - **カテゴリ hub（civil-1 / civil-2 / pe-comprehensive-management）にサイドバー転職枠を新設**（2026-06-16）。docs と同じ `resolveCareerSidebarAd()` の creative を PC 右サイドバー sticky 上部に描画（ピクセル源）。モバイルは本文中 visible バナー（href のみ）。旧 hub 末テキストカードは撤去。concrete / pe-construction / pe-first-stage はアフィリ非該当＝単一カラム維持。**note CTA はカテゴリ横断でモバイル 1 枚／PC 複数並びに圧縮**（旧 縦積み解消）。
->   - ⚠️ **pe（総監）の素性注意（要再評価）**: GKS は「20代未経験/若手・施工管理特化」ターゲットでシニア技術者（総監受験層）とミスマッチ。〜8/31 はビルドジョブ（建設業界特化・広め）で許容範囲だが、**9/1 の GKS 自動復帰後はシニア向け creative への差し替え or pe のみビルドジョブ固定を要検討**。pe は GA4 流入 2 位で収益導線ゼロだったため新設（高トラフィックの収益化機会 > 多少のミスマッチ、という判断。本番反映は /deploy ゲート）。
+> - **カテゴリ hub（civil-1 / civil-2 / pe-comprehensive-management）にサイドバー転職枠を新設**（2026-06-16）。creative は資格別セグメント（`resolveCategoryCareerAd`）。PC 右サイドバー sticky 上部に描画（ピクセル源）、モバイルは本文中 visible バナー（href のみ）。旧 hub 末テキストカードは撤去。concrete / pe-construction / pe-first-stage はアフィリ非該当＝単一カラム維持。**note CTA はカテゴリ横断でモバイル 1 枚／PC 複数並びに圧縮**（旧 縦積み解消）。
+>   - ✅ **pe（総監）の creative は専用化で解決（2026-06-16）**: 当初 GKS（20代未経験/施工管理）想定だったが総監＝シニア技術者層とミスマッチのため、**ハイクラス DX/コンサル転職（`PE_CONSULTING_CAREER_AD`, mat `4B5OO5+NTCZ6+4SXU+NUES1`）へ差替**（`resolveCategoryCareerAd` で pe のみ分岐）。期間切替なし（DX 固定）。civil 系は従来どおり施工管理系（BuildJob/GKS）。pe は GA4 流入 2 位で収益導線ゼロだったため新設。
 > - **`SAT_SIDEBAR_AD` / `CIVIL_SIDEBAR_AD` 定数は撤去済み**（現コードに存在しない）。SAT のサイドバー枠は廃止し、SAT は **記事末テキストリンク `SchoolCourseCTA`** に集約（PE も同様＝「PE サイドバー=SAT」は旧仕様）。
 > - **全 mat の SSOT は `src/config/affiliate-mats.json`**（`scripts/check-affiliate-mats.mjs` が MDX/コードの mat を突合）。本保管庫の URL と差異が出たら json/コードを正とする。
 

--- a/docs/project/04_運営/07_アフィリ×note共存設計.md
+++ b/docs/project/04_運営/07_アフィリ×note共存設計.md
@@ -63,7 +63,7 @@
 | # | サーフェス | 現状 | 判定 | 内容 |
 |---|---|---|---|---|
 | S1 | docs サイドバー SAT（keyword/guide/pastExam・`SAT_SIDEBAR_AD`） | SAT 300×250 | ✅ **変更** | SAT を撤去し、sidebarMagazines が空のとき `/links` note バナーに差し替え（keyword の既存フォールバックを guide/pastExam に拡張） |
-| S2 | カテゴリ hub の SAT カード（`resolveCategoryAffiliate`） | SchoolAffiliate(SAT) | ✅ **削除** | hub には既に完全パック + 精読ガイドの note CTA がある。S5 公開後は course-selection-guide への内部リンクカードに差し替え可 |
+| S2 | カテゴリ hub の SAT カード（旧 `resolveCategoryAffiliate`→現 `resolveCategoryCareerAd`） | SchoolAffiliate(SAT) | ✅ **削除** | hub には既に完全パック + 精読ガイドの note CTA がある。**※2026-06-16（PR #256）に hub を 2 カラム化し転職サイドバーを新設＝SAT 削除後の無アフィリ状態を解消（pe=ハイクラス DX/コンサル転職）。下記 WP2 追記参照** |
 | S3 | essay-exam-strategy 本文の SAT カード | CourseAffiliate(SAT) | ✅ **変更** | カード削除 → management-tradeoffs への内部リンク段落に差し替え（S5 公開後は course-selection-guide リンクへ更新予定） |
 | S4 | exam-application-guide 本文の SAT カード | CourseAffiliate(SAT) | ✅ **変更** | 文言修正で暫定維持（「総監部門の添削対応可否は資料請求で確認を」を明記、断定表現を除去）。アガルート承認後に総監対応講座へ差し替え |
 | S5 | course-selection-guide（独学か講座か） | draft 未公開 | ✅ **新規（公開）** | 「総監対応講座の現状」セクションを追加し published:true（2026-06-11）。note CTA を placement.ts に配線。末尾の SAT カード（実在しない総監講座名）は削除。アガルート承認後のアフィリ受け皿 |
@@ -196,6 +196,9 @@ note 側は utm_content がスロット位置を既に符号化しているた�
 1. `resolveCategoryAffiliate` の `pe-comprehensive-management` 分岐を `return null` に変更
    （コメントで理由: SAT は総監講座非提供。course-selection-guide 公開後に内部リンクカード化を検討）。
 2. `HOME_AFFILIATE`（トップ）は変更しない。
+
+> [!note] 2026-06-16 更新（PR #256）— この WP2 は後続で上書き
+> 「SAT カード削除」自体は有効だが、その後の**無アフィリ状態は解消**した。`resolveCategoryAffiliate` は撤去し `resolveCategoryCareerAd`（資格別 creative セグメント）に一本化。pe-comprehensive は `return null` ではなく**ハイクラス DX/コンサル転職**（`PE_CONSULTING_CAREER_AD`, mat `4B5OO5+NTCZ6+4SXU+NUES1`）を返す＝カテゴリ hub の収益導線ゼロを解消（総監＝シニア技術者層に適合。GKS の 20代未経験/施工管理ミスマッチを回避）。詳細: `02_アフィリエイト提携状況.md` カテゴリ hub 節 / `docs/handoffs/2026-06-16-affiliate-ssot.md` 追記。
 
 ### ✅ WP3: PE MDX 3 ページの SAT 表記是正（S3/S4/S5 前半）
 

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -12,7 +12,7 @@ import MagazineInlineCard from '@/components/ui/MagazineInlineCard';
 import { resolveCategoryMagazines } from '@/lib/magazine-placement';
 import { getMagazine, buildMagazineUrl } from '@/lib/note-magazines';
 import SidebarAdBanner from '@/components/ui/SidebarAdBanner';
-import { resolveCategoryAffiliate, resolveCareerSidebarAd } from '@/config/affiliate-creatives';
+import { resolveCategoryCareerAd } from '@/config/affiliate-creatives';
 
 const PE_CHAPTERS: PeChapter[] = peChaptersData.chapters;
 
@@ -720,14 +720,12 @@ export default async function CategoryPage({
     .map((s) => ({ slot: s, magazine: getMagazine(s.magazineId) }))
     .filter((x): x is { slot: typeof x.slot; magazine: NonNullable<typeof x.magazine> } => Boolean(x.magazine));
 
-  // アフィリエイト（civil のみ）。docs ページのサイドバー条件をミラーし、転職アフィリを
-  // PC 右サイドバー上部に sticky 配置してファーストビュー内でインプレッションを確保する。
-  // モバイルは本文 1 セクション目の直後に visible 配置する（記事到達を阻害しない位置）。
+  // 転職アフィリ（資格別セグメント）。PC は右サイドバー上部に sticky 配置してファーストビュー内で
+  // インプレッションを確保し、モバイルは本文 1 セクション目の直後に visible 配置する（記事到達を阻害しない）。
   // ピクセルは PC サイドバー側のみ発火させ「1 ページ 1 ピクセル」を厳守（モバイルは href のみ）。
-  // creative は resolveCareerSidebarAd で期間出し分け（〜2026-08-31 ビルドジョブ / 以降 GKS）。
-  const categoryAffiliate = resolveCategoryAffiliate(slug);
-  const careerSidebar =
-    categoryAffiliate?.kind === 'career' ? resolveCareerSidebarAd() : null;
+  // creative は資格層に合わせて出し分け（civil=施工管理系 BuildJob/GKS、pe=ハイクラス DX/コンサル）。
+  // 戻り値 null＝転職枠なし（concrete / pe-construction / pe-first-stage は単一カラム）。
+  const careerSidebar = resolveCategoryCareerAd(slug);
   // モバイル本文中の visible バナー（pixelSrc を渡さない＝PC サイドバー側が唯一の発火源）。
   const mobileCareerAd = careerSidebar ? (
     <div className="zenn-desktop:hidden my-10">

--- a/src/config/affiliate-creatives.ts
+++ b/src/config/affiliate-creatives.ts
@@ -49,6 +49,21 @@ export const BUILDJOB_CAREER_AD = {
 } as const;
 
 /**
+ * ハイクラス DX・コンサル転職（A8.net）。技術士（総監）= シニア技術者・管理職層向け。300×250 + pixel。
+ * GKS（20代未経験/施工管理）が総監層にミスマッチなため、pe カテゴリ hub のサイドバー転職枠に充てる
+ * （2026-06-16）。資格別セグメント: civil=施工管理系（BuildJob/GKS）/ pe=ハイクラス DX/コンサル。
+ */
+export const PE_CONSULTING_CAREER_AD = {
+  href: "https://px.a8.net/svt/ejp?a8mat=4B5OO5+NTCZ6+4SXU+NUES1",
+  imageSrc:
+    "https://www23.a8.net/svt/bgt?aid=260605733040&wid=001&eno=01&mid=s00000022413004005000&mc=1",
+  pixelSrc: "https://www18.a8.net/0.gif?a8mat=4B5OO5+NTCZ6+4SXU+NUES1",
+  alt: "ハイクラス DX・コンサル転職",
+  width: 300,
+  height: 250,
+} as const;
+
+/**
  * サイドバー転職枠の creative を期間で出し分ける（ビルド時に評価＝SSG）。
  * - 2026-08-31（JST）まで: ビルドジョブ（無料面談 ¥50,000 の増額キャンペーン中、GKS の 2 倍報酬）。
  * - 2026-09-01（JST）以降: GKS に自動復帰（ビルドジョブの増額終了想定）。
@@ -104,37 +119,26 @@ export type CategoryAffiliate =
     };
 
 /**
- * カテゴリ hub に転職アフィリの「枠を出すか」を返すゲート（2026-06-16〜）。
+ * カテゴリ hub の右サイドバー転職枠 creative を「カテゴリ別」に解決する（2026-06-16〜）。
+ * 受験者層に creative をセグメントする（戻り値 null = 転職枠なし＝単一カラム）。
+ * page.tsx の careerSidebar 判定（ゲート）も兼ねる。
  *
- * 注: カテゴリ hub の 2 カラム化以降、`src/app/category/[slug]/page.tsx` は本戻り値の
- * `kind === 'career'` のみを参照し（careerSidebar 判定）、実 creative は `resolveCareerSidebarAd()`
- * が描画する（期間で BuildJob ↔ GKS を出し分け）。下記 `props` は後方互換のため残置＝**現状未使用**。
+ * - civil-1 / civil-2（施工管理・現場/若手層）→ `resolveCareerSidebarAd()`（期間で BuildJob ↔ GKS）。
+ * - pe-comprehensive-management（総監＝シニア技術者・管理職層）→ ハイクラス DX/コンサル転職
+ *   （`PE_CONSULTING_CAREER_AD`）。GKS の「20代未経験/施工管理」ミスマッチを解消（2026-06-16 差替）。
+ *   GA4 流入 2 位の高トラフィックページの収益導線ゼロも解消。
+ * - それ以外（concrete 系 / pe-construction / pe-first-stage）→ null（docs でもアフィリ無し）。
  *
- * - civil-1 / civil-2 → 転職枠あり（受験者＝資格でキャリアアップ層と一致）。
- * - pe-comprehensive-management → 転職枠あり（2026-06-16 新設）。GA4 流入 2 位の高トラフィックページの
- *   収益導線ゼロを解消。**素性注意**: 総監（技術士）= シニア建設技術者層。GKS は「20代未経験/若手・
- *   施工管理特化」がターゲットでミスマッチ。〜2026-08-31 はビルドジョブ（建設業界特化・広め）で適合するが、
- *   9/1 の GKS 自動復帰後はシニア向け creative への差し替えを要検討（または pe のみ BuildJob 固定）。
- *   真実源: docs/project/04_運営/02_アフィリエイト提携状況.md。
- * - それ以外（concrete 系 / pe-construction / pe-first-stage）→ なし（docs でもアフィリ無し）。
+ * 真実源: docs/project/04_運営/02_アフィリエイト提携状況.md。
  */
-export function resolveCategoryAffiliate(category: string): CategoryAffiliate | null {
-  if (
-    category === "civil-construction-1" ||
-    category === "civil-construction-2" ||
-    category === "pe-comprehensive-management"
-  ) {
-    return {
-      kind: "career",
-      props: {
-        service: "GKSキャリア",
-        category: "施工管理 転職エージェント",
-        href: CIVIL_CAREER_AD.href,
-        imageSrc: CIVIL_CAREER_AD.imageSrc,
-        trackingPixelUrl: CIVIL_CAREER_AD.pixelSrc,
-        points: ["施工管理に特化した求人", "在職中でも無料で相談 OK"],
-      },
-    };
+export function resolveCategoryCareerAd(
+  category: string,
+): { creative: SidebarAdCreative; trackLabel: string } | null {
+  if (category === "pe-comprehensive-management") {
+    return { creative: PE_CONSULTING_CAREER_AD, trackLabel: "DXConsulting-sidebar" };
+  }
+  if (category === "civil-construction-1" || category === "civil-construction-2") {
+    return resolveCareerSidebarAd();
   }
   return null;
 }

--- a/src/config/affiliate-mats.json
+++ b/src/config/affiliate-mats.json
@@ -19,6 +19,15 @@
       "note": "新規無料キャリア面談 ¥50,000 の増額キャンペーン期限。期限後はサイドバーが resolveCareerSidebarAd により GKS へ自動復帰。期限後に本 mat が配置され続けていれば WARN。"
     },
     {
+      "mat": "4B5OO5+NTCZ6+4SXU+NUES1",
+      "program": "dx-consulting",
+      "label": "ハイクラス DX・コンサル転職（技術士/総監 シニア層向け）",
+      "surfaces": ["sidebar", "inline"],
+      "definedIn": "src/config/affiliate-creatives.ts (PE_CONSULTING_CAREER_AD)",
+      "expiresAt": null,
+      "note": "pe-comprehensive-management カテゴリ hub 専用。GKS（20代未経験/施工管理）が総監（シニア技術者）にミスマッチなため差替（resolveCategoryCareerAd）。"
+    },
+    {
       "mat": "4B3RUZ+6Y22UQ+5TRO+5YJRM",
       "program": "sat",
       "label": "SAT eラーニング（現場系国家資格・テキストリンク）",


### PR DESCRIPTION
## 背景・課題

`/category/civil-construction-1` で、ヒーロー直下に note マガジン CTA が縦積みされ、**モバイルで記事グリッドへの到達を阻害**。さらに転職アフィリは全コンテンツ最下部でインプレッションがほぼ出ない構成だった。`/category/pe-comprehensive-management` は **3 枚積みでさらに悪く**、GA4 流入 2 位の高トラフィックなのに収益導線ゼロだった。

docs ページのサイドバー方式をミラーして再設計。

## 変更

| | Before | After |
|---|---|---|
| PC 転職アフィリ | 最下部（ほぼ不可視） | 右サイドバー sticky 上部＝ファーストビュー内 |
| モバイル転職アフィリ | 最下部 | 本文1セクション目直後（mid-content） |
| note CTA | 縦積み（civil 2 / pe 3） | モバイル1枚／PC 複数並びに圧縮（全カテゴリ共通） |
| pe-comprehensive | アフィリ無し・単一カラム | 転職サイドバー新設・2カラム化 |
| concrete / pe-construction / pe-first-stage | 単一カラム | 変更なし（空サイドバー無し） |

- **1ページ1ピクセル厳守**: ピクセルは PC サイドバー側のみ発火。モバイル本文中バナーは href のみ（DOM 上のピクセル `<img>` は実測 1 個）。
- creative は既存 `resolveCareerSidebarAd()` で期間出し分け（〜2026-08-31 ビルドジョブ / 9-01 GKS 自動復帰）。

## ⚠️ 要レビュー: pe（総監）の転職アフィリ素性

GKS は「**20代未経験/若手・施工管理特化**」がターゲットで、総監（技術士＝シニア建設技術者）とミスマッチ。〜8/31 はビルドジョブ（建設業界特化・広め）で許容範囲だが、**9/1 の GKS 自動復帰後はシニア向け creative への差し替え or pe のみビルドジョブ固定を要検討**。「高トラフィックの収益化機会 > 多少のミスマッチ」という判断で新設したが、pe へのアフィリ可否はこの PR で最終判断可能（本番反映は `/deploy` ゲート）。pe を外す場合も note 圧縮は単一カラム側で維持される。

## 検証

- `type-check` ✓ / `lint`（対象ファイル 0 error）✓ / **production build ✓**（1034 ページ SSG）
- dev curl: civil-1/civil-2/pe = `<aside>`+ピクセル1+バナー2、concrete = 単一カラム・アフィリ0
- Playwright: モバイル=note 1枚＋mid-content バナー、PC=サイドバー右上にバナー を目視確認
- SSOT `docs/project/04_運営/02_アフィリエイト提携状況.md` を同期更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)