### PR TITLE
ci(youtube): 予約投稿ワークフローの npm ci 失敗を解消（--legacy-peer-deps）

### DIFF
--- a/.github/workflows/post-youtube-scheduled.yml
+++ b/.github/workflows/post-youtube-scheduled.yml
@@ -45,7 +45,7 @@ jobs:
           cache: "npm"
 
       - name: 📦 Install deps
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: 🔍 Validate schedule (重複チェック)
         run: node .claude/scripts/youtube/validate-schedule.mjs


### PR DESCRIPTION
## 概要

YouTube 予約投稿ワークフロー `post-youtube-scheduled.yml`（毎日 04:00 JST cron）が **06-06 以降連日失敗**していた原因を解消する。

## 原因

`Install deps` ステップだけ `--legacy-peer-deps` が漏れており、`@eslint/js@^10` vs `eslint@^9` の peer 依存衝突で `npm ci` が `ERESOLVE` で落ち、**アップロードステップに到達できていなかった**。認証・quota・schedule データはいずれも正常（Secrets 7点登録済み・pending 193件）。

他 8 ワークフロー（ci / cloudflare-deploy / fetch-metrics / r2-audit / r2-sync / psi-audit / upload-instagram-assets）はすべて `--legacy-peer-deps` で同じ既知衝突を回避済み。本 PR は YouTube ワークフローを同じ回避策に揃えるだけの1行修正。

```diff
-        run: npm ci
+        run: npm ci --legacy-peer-deps
```

## 注意

- cron は **main** の定義で動くため、develop マージ後 `/deploy` で main に乗って初めて自動投稿が復旧する。
- 復旧後は pending 193件（多数が publishAt 期限超過）を quota 上限 ≈6本/日で順次アップロードする見込み。
- 別件: Instagram 予約投稿ワークフローも連日失敗しているが、原因は別物（`INSTAGRAM_ACCESS_TOKEN` / `INSTAGRAM_BUSINESS_ACCOUNT_ID` の Secrets 未設定）。本 PR の対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)