### PR TITLE
fix(ui): pe-construction過去問マトリクスのモバイル対応（案C）

### DIFF
--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -606,38 +606,66 @@ function PeConstructionExamTable({ docs }: { docs: DocMeta[] }) {
   const rows = PE_CONSTRUCTION_SUBJECTS.filter(s => map.has(s.key));
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-base border-collapse">
-        <thead>
-          <tr className="border-b-2 border-gray-200 dark:border-gray-700">
-            <th className="text-left py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">科目</th>
-            {years.map(y => (
-              <th key={y} className="text-center py-3 px-3 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{colLabel(y)}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map(subject => {
-            const yearMap = map.get(subject.key)!;
-            return (
-              <tr key={subject.key} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                <td className="py-3 px-4 font-medium text-gray-900 dark:text-gray-100">{subject.label}</td>
+    <>
+      {/* モバイル: 科目カード縦積み + 年度ボタングリッド（8列テーブルの横スクロールを回避） */}
+      <div className="zenn-desktop:hidden space-y-4">
+        {rows.map(subject => {
+          const yearMap = map.get(subject.key)!;
+          return (
+            <div key={subject.key} className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+              <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-3">{subject.label}</h4>
+              <div className="flex flex-wrap gap-2">
                 {years.map(y => {
                   const doc = yearMap.get(y);
-                  return (
-                    <td key={y} className="py-3 px-3 text-center">
-                      {doc ? (
-                        <Link href={`/docs/${doc.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">問題</Link>
-                      ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
-                    </td>
-                  );
+                  return doc ? (
+                    <Link
+                      key={y}
+                      href={`/docs/${doc.slug}`}
+                      className="inline-flex items-center rounded-md border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 px-3 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors"
+                    >
+                      {colLabel(y)}
+                    </Link>
+                  ) : null;
                 })}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {/* デスクトップ: 現状マトリクス */}
+      <div className="hidden zenn-desktop:block overflow-x-auto">
+        <table className="w-full text-base border-collapse">
+          <thead>
+            <tr className="border-b-2 border-gray-200 dark:border-gray-700">
+              <th className="text-left py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">科目</th>
+              {years.map(y => (
+                <th key={y} className="text-center py-3 px-3 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{colLabel(y)}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(subject => {
+              const yearMap = map.get(subject.key)!;
+              return (
+                <tr key={subject.key} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                  <td className="py-3 px-4 font-medium text-gray-900 dark:text-gray-100">{subject.label}</td>
+                  {years.map(y => {
+                    const doc = yearMap.get(y);
+                    return (
+                      <td key={y} className="py-3 px-3 text-center">
+                        {doc ? (
+                          <Link href={`/docs/${doc.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">問題</Link>
+                        ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## 概要
`category/pe-construction` の過去問マトリクス（`PeConstructionExamTable`）が **12科目×7年度=8列テーブル**で、モバイルで横スクロール必須・タップ領域が小さい問題を解消（backlog 🟡 案C）。

## 変更
`src/app/category/[slug]/page.tsx` の `PeConstructionExamTable` をレスポンシブ二重レイアウト化（外科的変更・1コンポーネントのみ）:
- **モバイル**（`zenn-desktop:hidden`）: 科目カードを縦積みし、各科目直下に**年度ボタングリッド**（`flex-wrap`・存在年度のみ・px-3 py-2 でタップ領域確保）
- **デスクトップ**（`hidden zenn-desktop:block`）: 現状の8列マトリクスを維持

データ取得・`Link` href・配色（gray/blue）は不変。

## 検証
- `npm run type-check` 通過 / `lint-ui` 通過
- ※ ローカル dev サーバは worktree の symlink node_modules を Turbopack が拒否するため起動不可 → **SSR 検証は CI の build チェックに委譲**（このPRの build が通れば SSR コンパイル OK）。マージ後に develop で `curl` 実確認予定。

## 出典
backlog「pe-construction カテゴリページの過去問マトリクスをモバイル対応に刷新」🟡（案C 推奨）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)