### PR TITLE
feat(svg): 図版カタログ生成（コレクションSSOT）

### DIFF
--- a/.claude/scripts/build-svg-catalog.mjs
+++ b/.claude/scripts/build-svg-catalog.mjs
@@ -1,0 +1,113 @@
+/**
+ * SVG カタログ生成 — 図版コレクションの SSOT（派生・機械生成）。
+ *
+ * `.local/r2/posts/**\/img/*.svg`（サイト図版）を走査し、各図版の
+ *   - concept（aria-label）/ viewBox / カテゴリ / slug / ファイル名
+ *   - embedded（該当 article.mdx が src で参照しているか）
+ *   - audit（.claude/state/svg-audit.json の重大度件数）
+ * を join した台帳 `.claude/state/svg-catalog.json` を出力する。
+ *
+ * 手動維持せず再生成で drift を防ぐ（refresh-indexes と同方式）。
+ * svg-gallery.mjs は目視ビュー、svg-audit.json は監査結果、本台帳は
+ * 「どの概念→どのファイル→埋込/監査状態」を一元管理する SSOT。
+ *
+ * Usage: node .claude/scripts/build-svg-catalog.mjs
+ */
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join, relative } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', '..');
+const POSTS = join(ROOT, '.local', 'r2', 'posts');
+const AUDIT = join(ROOT, '.claude', 'state', 'svg-audit.json');
+const OUT = join(ROOT, '.claude', 'state', 'svg-catalog.json');
+
+// --- 監査結果（あれば）を file -> {high,medium,low} に集約 ---
+const auditByFile = {};
+if (existsSync(AUDIT)) {
+  try {
+    const a = JSON.parse(readFileSync(AUDIT, 'utf8'));
+    for (const f of a.findings || []) {
+      const key = String(f.file).replace(/\\/g, '/');
+      const sev = String(f.severity || '').toLowerCase();
+      auditByFile[key] = auditByFile[key] || { high: 0, medium: 0, low: 0 };
+      if (auditByFile[key][sev] !== undefined) auditByFile[key][sev]++;
+    }
+  } catch {
+    console.warn('[svg-catalog] svg-audit.json の読込に失敗。audit 列は空で継続');
+  }
+}
+
+const attr = (svg, name) => {
+  const m = svg.match(new RegExp(`${name}="([^"]*)"`));
+  return m ? m[1] : null;
+};
+
+const entries = [];
+const svgFiles = readdirSync(POSTS, { recursive: true })
+  .map((p) => String(p).replace(/\\/g, '/'))
+  .filter((p) => /\/img\/.+\.svg$/.test(p));
+
+for (const rel of svgFiles) {
+  const abs = join(POSTS, rel);
+  const parts = rel.split('/'); // {category}/{slug}/img/{file}
+  const category = parts[0];
+  const slug = parts[1];
+  const file = parts[parts.length - 1];
+  let svg = '';
+  try { svg = readFileSync(abs, 'utf8'); } catch { continue; }
+
+  const concept = attr(svg, 'aria-label');
+  const viewBox = attr(svg, 'viewBox');
+
+  // embedded: 同 slug の article.(mdx|md) が当 svg を src 参照しているか
+  let embedded = false;
+  for (const a of ['article.mdx', 'article.md']) {
+    const art = join(POSTS, category, slug, a);
+    if (existsSync(art)) {
+      const body = readFileSync(art, 'utf8');
+      if (body.includes(`/img/${file}`)) { embedded = true; break; }
+    }
+  }
+
+  const repoRel = `.local/r2/posts/${rel}`;
+  entries.push({
+    file: repoRel,
+    category,
+    slug,
+    name: file,
+    concept: concept || null,
+    viewBox: viewBox || null,
+    embedded,
+    audit: auditByFile[repoRel] || { high: 0, medium: 0, low: 0 },
+  });
+}
+
+entries.sort((a, b) => a.file.localeCompare(b.file));
+
+const byCategory = {};
+for (const e of entries) byCategory[e.category] = (byCategory[e.category] || 0) + 1;
+
+const summary = {
+  total: entries.length,
+  embedded: entries.filter((e) => e.embedded).length,
+  orphan: entries.filter((e) => !e.embedded).length,
+  missingConcept: entries.filter((e) => !e.concept).length,
+  withHighAudit: entries.filter((e) => e.audit.high > 0).length,
+  byCategory,
+};
+
+const catalog = {
+  description: 'サイト図版SVGの派生カタログ（SSOT）。build-svg-catalog.mjs が生成。手動編集しない。',
+  source: '.local/r2/posts/**/img/*.svg',
+  summary,
+  entries,
+};
+
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, JSON.stringify(catalog, null, 2) + '\n', 'utf8');
+
+console.log(`[svg-catalog] ${summary.total} 図版 → ${relative(ROOT, OUT)}`);
+console.log(`  embedded ${summary.embedded} / orphan ${summary.orphan} / concept欠落 ${summary.missingConcept} / HIGH監査 ${summary.withHighAudit}`);
+console.log('  カテゴリ別:', JSON.stringify(byCategory));

--- a/.claude/state/svg-catalog.json
+++ b/.claude/state/svg-catalog.json
@@ -1,0 +1,2691 @@
+{
+  "description": "サイト図版SVGの派生カタログ（SSOT）。build-svg-catalog.mjs が生成。手動編集しない。",
+  "source": ".local/r2/posts/**/img/*.svg",
+  "summary": {
+    "total": 191,
+    "embedded": 142,
+    "orphan": 49,
+    "missingConcept": 0,
+    "withHighAudit": 0,
+    "byCategory": {
+      "civil-construction-1": 29,
+      "pe-comprehensive-management": 162
+    }
+  },
+  "entries": [
+    {
+      "file": ".local/r2/posts/civil-construction-1/primary-h26-b/img/h26-b-fig-02-cp.svg",
+      "category": "civil-construction-1",
+      "slug": "primary-h26-b",
+      "name": "h26-b-fig-02-cp.svg",
+      "concept": "平成26年度後期 No.13 ネットワーク式工程表。イベント0から9。クリティカルパスは0→1→3→4→7→8→9で必要日数38日。3→4はダミー。作業H（4→7）の最早開始は20日。",
+      "viewBox": "0 0 500 330",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/primary-h26-b/img/h26-b-fig-02.svg",
+      "category": "civil-construction-1",
+      "slug": "primary-h26-b",
+      "name": "h26-b-fig-02.svg",
+      "concept": "ネットワーク式工程表。イベント⓪〜⑨、作業A〜J。⓪→①がA（2日）、④→⑦がH（10日）、③→④はダミー。",
+      "viewBox": "0 0 500 275",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/primary-h27-b/img/h27-b-fig-03-cp.svg",
+      "category": "civil-construction-1",
+      "slug": "primary-h27-b",
+      "name": "h27-b-fig-03-cp.svg",
+      "concept": "平成27年度後期 No.13 ネットワーク式工程表。イベント0から7。クリティカルパスは0→2→4→5→7で工期28日。作業E（3→5）に3日遅延すると経路0→2→3→5→7が30日となり工期は2日遅れる。",
+      "viewBox": "0 0 500 330",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/primary-h27-b/img/h27-b-fig-03.svg",
+      "category": "civil-construction-1",
+      "slug": "primary-h27-b",
+      "name": "h27-b-fig-03.svg",
+      "concept": "ネットワーク式工程表。イベント⓪〜⑦、作業A〜K。③→⑤が作業E（9日）、②→③はダミー。各矢線に作業日数を付す。",
+      "viewBox": "0 0 500 290",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-construction-mgmt-overview/img/pdca-cycle.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-construction-mgmt-overview",
+      "name": "pdca-cycle.svg",
+      "concept": "施工管理の PDCA サイクル：Plan（計画）→ Do（実施）→ Check（検討）→ Act（処置）の循環。P・D は統制機能、C・A は改善機能",
+      "viewBox": "0 0 400 400",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-distance-angle/img/angle-types.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-distance-angle",
+      "name": "angle-types.svg",
+      "concept": "水平角と鉛直角",
+      "viewBox": "0 0 400 260",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-distance-angle/img/distance-types.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-distance-angle",
+      "name": "distance-types.svg",
+      "concept": "水平距離と斜距離の関係",
+      "viewBox": "0 0 400 240",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-distance-angle/img/error-cancellation.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-distance-angle",
+      "name": "error-cancellation.svg",
+      "concept": "対回観測による視準軸誤差の消去原理",
+      "viewBox": "0 0 400 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-grader-compaction/img/compaction-classification.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-grader-compaction",
+      "name": "compaction-classification.svg",
+      "concept": "締固め機械の分類：静的締固め（ロード・タイヤ・タンピングローラ／砂礫・粘性土向け）と動的締固め（振動ローラ・コンパクタ・ランマ／砂・狭所向け）の 2 系統",
+      "viewBox": "0 0 400 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-histogram/img/figure-4-6.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-histogram",
+      "name": "figure-4-6.svg",
+      "concept": "工程能力図: 品質特性値が規格中心付近で時間的に変動する様子を折れ線で示す。上限規格値・規格中心・下限規格値の 3 本の線とデータ点を配置",
+      "viewBox": "0 0 400 260",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-histogram/img/figure-4-7.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-histogram",
+      "name": "figure-4-7.svg",
+      "concept": "ヒストグラムの概念図。中央に分布、左右に下限規格値と上限規格値、両端に 'ゆとり' の矢印、上方に分布幅と目標値を示す",
+      "viewBox": "0 0 400 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-histogram/img/figure-4-8.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-histogram",
+      "name": "figure-4-8.svg",
+      "concept": "演習データ（n=44）のヒストグラム完成例。代表値 19.5〜27.5、度数 1、17、22、3、1 の 5 本のバーと下限規格値の注記",
+      "viewBox": "0 0 400 300",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-histogram/img/figure-4-9.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-histogram",
+      "name": "figure-4-9.svg",
+      "concept": "ヒストグラムの 10 分布パターン (a〜j)。左右対称・ゆとり不足・下限規格値割れ・バラツキ大・左偏り・右偏り・二山・端切れ・端異常高・飛び離れ山。各セルの 2 本の破線は下限規格値・上限規格値",
+      "viewBox": "0 0 400 870",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-network-schedule/img/figure-3-13.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-network-schedule",
+      "name": "figure-3-13.svg",
+      "concept": "作業（アクティビティ）の記法：矢線上に作業名、下に所要時間を書く",
+      "viewBox": "0 0 380 160",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-network-schedule/img/figure-3-14.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-network-schedule",
+      "name": "figure-3-14.svg",
+      "concept": "イベント（結合点）は○で示し、中にイベント番号を書き込む",
+      "viewBox": "0 0 380 170",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-network-schedule/img/figure-3-15.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-network-schedule",
+      "name": "figure-3-15.svg",
+      "concept": "ダミー（疑似作業）は点線矢印で表記し、所要時間ゼロの疑似作業として起終点イベントを区別する",
+      "viewBox": "0 0 380 220",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-network-schedule/img/figure-3-16.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-network-schedule",
+      "name": "figure-3-16.svg",
+      "concept": "先行作業 B・C がすべて完了しないと、後続作業 D は開始できない",
+      "viewBox": "0 0 380 220",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-network-schedule/img/figure-3-17.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-network-schedule",
+      "name": "figure-3-17.svg",
+      "concept": "最早開始時刻（EST）の計算例：左から右に所要時間を加算し、複数経路がある場合は最大値を採る",
+      "viewBox": "0 0 400 250",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-network-schedule/img/figure-3-18.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-network-schedule",
+      "name": "figure-3-18.svg",
+      "concept": "最遅完了時刻（LFT）の計算例：右から左に所要時間を減算し、複数経路がある場合は最小値を採る",
+      "viewBox": "0 0 400 250",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-network-schedule/img/figure-3-19.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-network-schedule",
+      "name": "figure-3-19.svg",
+      "concept": "4つの作業時刻（EST・LFT・EFT・LST）を1つのネットワークで確認する例",
+      "viewBox": "0 0 400 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-network-schedule/img/figure-3-20.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-network-schedule",
+      "name": "figure-3-20.svg",
+      "concept": "クリティカルパス：EST と LFT が等しいイベントを通る最長経路を太線で強調",
+      "viewBox": "0 0 400 260",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-network-schedule/img/figure-3-21-23.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-network-schedule",
+      "name": "figure-3-21-23.svg",
+      "concept": "3種類の余裕時間（トータルフロート・フリーフロート・インターフェアリングフロート）を1つのタイムラインで比較",
+      "viewBox": "0 0 400 340",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-port-regulations/img/figure-7-6.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-port-regulations",
+      "name": "figure-7-6.svg",
+      "concept": "港内の航法要点。防波堤を挟んだ港湾内と港湾外、航路と航法ルール（出船優先・右側航行・追越禁止・並行禁止・投びょう禁止・えい航 200m）を配置した概念図",
+      "viewBox": "0 0 400 510",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 6
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-schedule-overview/img/cost-duration-curve.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-schedule-overview",
+      "name": "cost-duration-curve.svg",
+      "concept": "工事費曲線：直接費・間接費・総建設費と最適工期",
+      "viewBox": "0 0 420 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-shovel-excavator/img/figure-2-10.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-shovel-excavator",
+      "name": "figure-2-10.svg",
+      "concept": "油圧バックホゥの作業装置構成。ブーム・アーム・バケットとブームシリンダ・アームシリンダ・バケットシリンダの配置、および本体（旋回台）との接続を示す側面図",
+      "viewBox": "0 0 400 340",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 8
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-shovel-excavator/img/figure-2-13.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-shovel-excavator",
+      "name": "figure-2-13.svg",
+      "concept": "油圧ショベル兼用屈曲ジブ式移動式クレーンの主要安全装置。過負荷警報装置・定格荷重表示銘板・落下防止バルブ・ブーム/アーム角度センサ・荷重検出圧力センサ・水準器・クレーンモード表示灯の配置",
+      "viewBox": "0 0 400 360",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 15
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-shovel-excavator/img/figure-2-8.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-shovel-excavator",
+      "name": "figure-2-8.svg",
+      "concept": "ショベル系掘削機の分類系統図。掘削機械（バックホゥ・ショベル・ローディングショベル・クラムシェル・ドラグライン）と派生機械（油圧圧砕機・油圧ブレーカ・フォークグラップル）のツリー構造",
+      "viewBox": "0 0 400 540",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 20
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-shovel-excavator/img/figure-2-9.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-shovel-excavator",
+      "name": "figure-2-9.svg",
+      "concept": "バケット容量の概念図。バックホゥ・ショベル（安息角 1:1）とローディングショベル（安息角 1:2）における山積容量と平積容量の比較",
+      "viewBox": "0 0 400 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/civil-construction-1/textbook-tractor-bulldozer/img/travel-device.svg",
+      "category": "civil-construction-1",
+      "slug": "textbook-tractor-bulldozer",
+      "name": "travel-device.svg",
+      "concept": "トラクタの走行装置：クローラ式とホイール式の比較",
+      "viewBox": "0 0 400 260",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/activity-abc/img/abc-two-stage-allocation.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "activity-abc",
+      "name": "abc-two-stage-allocation.svg",
+      "concept": "ABC の 2 段階配賦（資源 → 活動 → 製品）",
+      "viewBox": "0 0 520 200",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 7
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/agile/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "agile",
+      "name": "figure-1.svg",
+      "concept": "アジャイル開発の反復サイクル。計画・開発・テスト・レビューの短いイテレーションを繰り返し、反復ごとに動作するソフトウェアを提供する。",
+      "viewBox": "0 0 380 304",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/alert-levels/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "alert-levels",
+      "name": "figure-1.svg",
+      "concept": "警戒レベル5段階と避難行動。レベル1心構えからレベル5緊急安全確保まで、切迫度に応じた住民行動と発令主体を示すラダー図",
+      "viewBox": "0 0 400 580",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/analytic-hierarchy-process/img/ahp-hierarchy.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "analytic-hierarchy-process",
+      "name": "ahp-hierarchy.svg",
+      "concept": "AHP（階層分析法）の 4 階層構造：上位は総合評価、第 2 階層は重要度係数 W₁・W₂ で分かれる要因 1・要因 2、第 3 階層は W₁₁・W₁₂・W₂₁・W₂₂ で分かれるサブ要因 4 個、最下層は A 案・B 案・C 案の代替案。各階層の重要度係数の和は 1 になる",
+      "viewBox": "0 0 400 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/api/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "api",
+      "name": "figure-1.svg",
+      "concept": "API によるシステム連携。複数の利用側アプリが API という公開された取り決めを介してサービス提供側の機能・データを呼び出す。提供側の内部実装は隠蔽される。",
+      "viewBox": "0 0 400 212",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/appraisal-three-principles/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "appraisal-three-principles",
+      "name": "figure-1.svg",
+      "concept": "人事考課の3指標と3原則。情意考課・成績考課・能力考課の特性を示し、下部に公平・客観性・透明性の3原則を配置した図",
+      "viewBox": "0 0 400 560",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/balance-sheet/img/bs-structure.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "balance-sheet",
+      "name": "bs-structure.svg",
+      "concept": "貸借対照表の構造：左に資産（流動・固定）、右に負債（流動・固定）と純資産を対置し、資産合計＝負債合計＋純資産合計の等式を示す",
+      "viewBox": "0 0 400 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/bathtub-curve/img/bathtub-curve-phases.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "bathtub-curve",
+      "name": "bathtub-curve-phases.svg",
+      "concept": "バスタブカーブ",
+      "viewBox": "0 0 420 240",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 3
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/bathtub-curve/img/bathtub-maintenance-effect.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "bathtub-curve",
+      "name": "bathtub-maintenance-effect.svg",
+      "concept": "予防保全とバスタブカーブ",
+      "viewBox": "0 0 440 220",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 11
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/blockchain-crypto/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "blockchain-crypto",
+      "name": "figure-1.svg",
+      "concept": "ブロックチェーンの連結構造。各ブロックは前ブロックのハッシュ値・取引データ・ナンスを持ち、前ブロックのハッシュ値で時系列に連結される。",
+      "viewBox": "0 0 380 420",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/break-even-point/img/bep-formulas.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "break-even-point",
+      "name": "bep-formulas.svg",
+      "concept": "bep formulas",
+      "viewBox": "0 0 440 130",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/break-even-point/img/break-even-chart.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "break-even-point",
+      "name": "break-even-chart.svg",
+      "concept": "損益分岐点グラフ",
+      "viewBox": "0 0 420 300",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 7
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/business-continuity-plan/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "business-continuity-plan",
+      "name": "figure-1.svg",
+      "concept": "従来の防災活動とBCM（事業継続マネジメント）の比較。目的・対象・主体・時間軸の4観点で対比した2カラム表",
+      "viewBox": "0 0 480 430",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/carbon-neutral/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "carbon-neutral",
+      "name": "figure-1.svg",
+      "concept": "カーボンニュートラル達成の3ステップと残存CO₂処理技術CCS・BECCS・DACCSを縦積みで示した図",
+      "viewBox": "0 0 400 620",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/cash-flow-statement/img/cf-changes-matrix.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "cash-flow-statement",
+      "name": "cf-changes-matrix.svg",
+      "concept": "キャッシュ・フローの増減マトリクス：営業・投資・財務の3区分それぞれで現金を増やす取引と減らす取引の対応",
+      "viewBox": "0 0 400 440",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/cause-and-effect-diagram/img/fishbone-4m.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "cause-and-effect-diagram",
+      "name": "fishbone-4m.svg",
+      "concept": "特性要因図（4M）",
+      "viewBox": "0 0 460 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 8
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/circular-society-basic-act/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "circular-society-basic-act",
+      "name": "figure-1.svg",
+      "concept": "循環型社会の5段階。発生抑制・再使用・再生利用・熱回収・適正処分を優先順位の高い順に上から並べた図",
+      "viewBox": "0 0 400 528",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/citizen-participation/img/arnstein-ladder.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "citizen-participation",
+      "name": "arnstein-ladder.svg",
+      "concept": "アーンスタインの梯子（参加の8段階）",
+      "viewBox": "0 0 460 510",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 4,
+        "low": 1
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/climate-change-adaptation-act/img/heavy-rainfall-trend.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "climate-change-adaptation-act",
+      "name": "heavy-rainfall-trend.svg",
+      "concept": "1時間降水量50mm以上の年間発生回数",
+      "viewBox": "0 0 500 200",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 16
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/cloud-on-premises/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "cloud-on-premises",
+      "name": "figure-1.svg",
+      "concept": "IaaS・PaaS・SaaS の責任分界。アプリケーション・データ・ミドルウェア・OS・ハードウェアの各層について、利用者と事業者のどちらが管理するかを示す。SaaS ほど事業者の管理範囲が広い。",
+      "viewBox": "0 0 400 322",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/concurrent-engineering/img/sequential-vs-concurrent.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "concurrent-engineering",
+      "name": "sequential-vs-concurrent.svg",
+      "concept": "逐次開発とコンカレントエンジニアリングの比較：逐次は前工程完了後に後工程を開始するため期間が長いが、コンカレントは各工程をオーバーラップさせて期間を圧縮する",
+      "viewBox": "0 0 380 360",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/control-limits/img/control-chart.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "control-limits",
+      "name": "control-chart.svg",
+      "concept": "管理限界と管理図：中心線 CL から ±3σ の上方管理限界線 UCL と下方管理限界線 LCL を引き、サンプルが管理限界を超えると工程異常と判定する",
+      "viewBox": "0 0 380 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/copyright/img/authors-rights-structure.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "copyright",
+      "name": "authors-rights-structure.svg",
+      "concept": "著作者の権利の構造：著作者人格権 3 種（公表権・氏名表示権・同一性保持権、一身専属で譲渡不可）と著作権（財産権）11 種（複製権・上演権・演奏権・上映権・公衆送信権・口述権・展示権・頒布権・譲渡権・貸与権・翻訳権/翻案権、譲渡・相続可能）の二層構造",
+      "viewBox": "0 0 400 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/correlation-analysis/img/correlation-scatter-patterns.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "correlation-analysis",
+      "name": "correlation-scatter-patterns.svg",
+      "concept": "相関散布図パターン",
+      "viewBox": "0 0 500 185",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 5
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/correlation-analysis/img/regression-line.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "correlation-analysis",
+      "name": "regression-line.svg",
+      "concept": "回帰直線のイメージ",
+      "viewBox": "0 0 280 200",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 5
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/crisis-communication/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "crisis-communication",
+      "name": "figure-1.svg",
+      "concept": "危機広報の2目的。初動期の安全のための広報（迅速性重視）から収束期の安心のための広報（正確さ・迅速さ・安心感の工夫）へ時間軸で移行する図",
+      "viewBox": "0 0 420 380",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/crisis-management-manual/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "crisis-management-manual",
+      "name": "figure-1.svg",
+      "concept": "危機への対応4段階サイクル。平常時準備・事前作業・緊急事態対応・事後復旧の順に縦に並び、矢印でつながる危機管理サイクル図",
+      "viewBox": "0 0 400 500",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/csr/img/csr-4-pillars.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "csr",
+      "name": "csr-4-pillars.svg",
+      "concept": "CSR の 4 要素：持続可能な企業活動を支える環境・社会・経済の 3 本柱と、それらを支える基盤としてのガバナンス",
+      "viewBox": "0 0 400 340",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/csr/img/csr-csv-evolution.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "csr",
+      "name": "csr-csv-evolution.svg",
+      "concept": "CSR から CSV への発展を示す図：CSR では本業と社会貢献が分離していたが、CSV では両者が統合される",
+      "viewBox": "0 0 600 300",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 1
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/cybersecurity-safety/img/cyber-physical-cascade.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "cybersecurity-safety",
+      "name": "cyber-physical-cascade.svg",
+      "concept": "サイバー攻撃の物理インフラへの3層波及：サイバー空間の攻撃がOT/IT接続点を経由して物理インフラの安全に影響を及ぼす",
+      "viewBox": "0 0 400 285",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/data-mining/img/big-data-analysis-flow.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "data-mining",
+      "name": "big-data-analysis-flow.svg",
+      "concept": "ビッグデータ分析プロセスの 5 段階フロー：①データ収集→②データウェアハウス格納→③データクレンジング→④データマイニング→⑤活用。データマイニング段階は仮説の有無で「機械学習（仮説なし）」と「統計分析（仮説あり）」に分岐する",
+      "viewBox": "0 0 400 540",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/decoupling/img/decoupling-concept.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "decoupling",
+      "name": "decoupling-concept.svg",
+      "concept": "経済成長は右上に伸び続け、天然資源の利用は緩やかに頭打ち、環境影響は中盤でピークを打って減少へ転じる。経済成長と天然資源の間の隙間が相対的デカップリング、経済成長と環境影響の間の隙間が絶対的デカップリング",
+      "viewBox": "0 0 400 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/delphi-method/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "delphi-method",
+      "name": "figure-1.svg",
+      "concept": "デルファイ法のサイクル。予測テーマ特定から専門家への個別アンケート・集計・フィードバック・再アンケートを繰り返し回答が収束する流れを示した縦フロー図",
+      "viewBox": "0 0 400 560",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/demand-forecasting/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "demand-forecasting",
+      "name": "figure-1.svg",
+      "concept": "需要予測の手法分類図：定量的手法（移動平均法・指数平滑法・回帰分析）と定性的手法（デルファイ法・市場調査法）に大別される",
+      "viewBox": "0 0 380 245",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/descriptive-statistics/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "descriptive-statistics",
+      "name": "figure-1.svg",
+      "concept": "記述統計の代表値4種（平均値・中央値・最頻値・四分位数）の特性カード。メリットをpositive、デメリットをwarnのバッジで示す",
+      "viewBox": "0 0 400 620",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/descriptive-statistics/img/figure-2.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "descriptive-statistics",
+      "name": "figure-2.svg",
+      "concept": "統計分析6手法の俯瞰。記述統計・推定検定・相関分析・回帰分析・ロジスティック回帰・クラスター分析を目的軸（要約→推測→関係→予測→分類）で並べた手法マップ",
+      "viewBox": "0 0 400 580",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/design-review/img/dr-stages.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "design-review",
+      "name": "dr-stages.svg",
+      "concept": "デザインレビューの 5 段階（DR0 企画〜DR4 量産移行）と各段階の審査対象、品質ゲートとして設計者以外の関係部門が多角的に審査する",
+      "viewBox": "0 0 400 440",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/design-thinking/img/5-steps-iterative-flow.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "design-thinking",
+      "name": "5-steps-iterative-flow.svg",
+      "concept": "デザイン思考の5ステップとイテレーティブフロー",
+      "viewBox": "0 0 600 200",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 6,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/digital-twin-cps/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "digital-twin-cps",
+      "name": "figure-1.svg",
+      "concept": "サイバーフィジカルシステムの双方向ループ。フィジカル空間のデータを IoT センサーでサイバー空間へ収集し、サイバー空間での分析・予測の結果をフィジカル空間へフィードバックする。",
+      "viewBox": "0 0 400 264",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/disclosure-standards/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "disclosure-standards",
+      "name": "figure-1.svg",
+      "concept": "情報公開法の不開示情報6類型。個人情報・法人情報・国家安全情報・公共安全情報・審議検討等情報・事務事業情報を縦に並べた図",
+      "viewBox": "0 0 400 584",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/ecological-footprint/img/overshoot-concept.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "ecological-footprint",
+      "name": "overshoot-concept.svg",
+      "concept": "世界平均エコロジカル・フットプリント 2.8 gha/人 は地球のバイオキャパシティ 1.6 gha/人 を超え、地球 1.7 個分の資源を消費しているオーバーシュート状態を示す横棒比較図",
+      "viewBox": "0 0 400 250",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/ecrs-principle/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "ecrs-principle",
+      "name": "figure-1.svg",
+      "concept": "改善活動の3手法。ECRS（排除・結合・交換・簡素化の優先順）・5S（整理整頓清掃清潔躾）・目で見る管理（可視化）を並列カードで示した図",
+      "viewBox": "0 0 400 540",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/edge-computing/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "edge-computing",
+      "name": "figure-1.svg",
+      "concept": "エッジコンピューティングの階層構造。IoT デバイスが取得した全データをエッジが現場近傍でリアルタイム処理し、必要なデータのみをクラウドへ送信して帯域を節約する。",
+      "viewBox": "0 0 380 368",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/energy/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "energy",
+      "name": "figure-1.svg",
+      "concept": "エネルギー政策の基本視点 S＋3E。安全性を大前提とし、安定供給・経済効率性・環境適合の3Eを優先順位順に示した図",
+      "viewBox": "0 0 400 500",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/environmental-accounting/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "environmental-accounting",
+      "name": "figure-1.svg",
+      "concept": "環境の経済価値評価5手法。顕示選好型（代替法・トラベルコスト法・ヘドニック法）と表明選好型（仮想評価法CVM・コンジョイント分析）を2カラムで対比した図",
+      "viewBox": "0 0 480 505",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/environmental-basic-act/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "environmental-basic-act",
+      "name": "figure-1.svg",
+      "concept": "環境保全の基本7原則。EPR・PPPの経済系2原則、予防的措置・順応的取組の予防系2原則、源流対策・協働・補完性の実施系3原則をカード縦並びで示した図",
+      "viewBox": "0 0 400 620",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/environmental-basic-plan/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "environmental-basic-plan",
+      "name": "figure-1.svg",
+      "concept": "環境政策の実施手法7類型。規制的・枠組規制的・経済的・自主的取組・情報的・手続的・事業的の各手法を定義と代表例とともに縦並びで示した図",
+      "viewBox": "0 0 400 620",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/environmental-impact-assessment/img/eia-target-categories.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "environmental-impact-assessment",
+      "name": "eia-target-categories.svg",
+      "concept": "環境影響評価法の対象 13 事業を 5 カテゴリに分類した図：交通インフラ（道路・鉄道・飛行場）、河川・水（ダム/堰・埋立て干拓）、エネルギー（発電所 6 種）、廃棄物（最終処分場）、面的開発（土地区画整理など 6 事業）",
+      "viewBox": "0 0 640 440",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 5,
+        "low": 13
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/erp/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "erp",
+      "name": "figure-1.svg",
+      "concept": "ERP による業務統合。財務会計・管理会計・人事・販売・購買・生産の各業務モジュールが、単一の統合データベースを共有して部門横断でデータを一元管理する。",
+      "viewBox": "0 0 400 188",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/esg-investment/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "esg-investment",
+      "name": "figure-1.svg",
+      "concept": "ISO26000 社会的責任の7原則。説明責任・透明性・倫理的な行動・ステークホルダーの利害の尊重・法の支配の尊重・国際行動規範の尊重・人権の尊重をカード縦並びで示した図",
+      "viewBox": "0 0 400 560",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/esg-investment/img/figure-2.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "esg-investment",
+      "name": "figure-2.svg",
+      "concept": "TCFD提言の4要求項目。ガバナンス・戦略・リスク管理・指標と目標の2×2マトリクスと、移行リスク・物理的リスクの2分類補足帯",
+      "viewBox": "0 0 400 460",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/essay-exam-strategy/img/figure-4-02.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "essay-exam-strategy",
+      "name": "figure-4-02.svg",
+      "concept": "前文分析で抽出すべき 4 要素（テーマ・設定条件・要求事項・評価項目）の関係図",
+      "viewBox": "0 0 500 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/essay-exam-strategy/img/figure-4-15-three-layer-structure.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "essay-exam-strategy",
+      "name": "figure-4-15-three-layer-structure.svg",
+      "concept": "総監論文の三層構造：Ⅰ管理対象と前提条件→Ⅱ施策（効果＋トレードオフ）→Ⅲ将来展望と最大リスク（管理行為で克服）の因果連鎖",
+      "viewBox": "0 0 560 600",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/eta/img/eta-gas-leak-example.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "eta",
+      "name": "eta-gas-leak-example.svg",
+      "concept": "ETA（イベントツリー分析）の例：初期事象「ガス漏れ」から早期発見・計器による発見・検査による発見・着火しないの 4 つのセーフガードに分岐。各分岐で成功（確率上、上方向）と失敗（確率下、下方向）に分かれ、すべての層で失敗するとガス爆発（確率 0.0005）に至る",
+      "viewBox": "0 0 400 290",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 21
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/exam-application-guide/img/figure-2-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "exam-application-guide",
+      "name": "figure-2-1.svg",
+      "concept": "出願段階の業務経歴票が筆記試験の骨子と口頭試験の質問ベースに直結することを示す縦フロー図",
+      "viewBox": "0 0 400 540",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/exam-application-guide/img/figure-2-2.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "exam-application-guide",
+      "name": "figure-2-2.svg",
+      "concept": "業務経歴作成の5ステップ（書き出し→5管理整理→最重点特定→トレードオフ描出→絞り込み）の縦フロー図",
+      "viewBox": "0 0 380 470",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/exam-application-guide/img/figure-2-4.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "exam-application-guide",
+      "name": "figure-2-4.svg",
+      "concept": "業務内容の詳細の記載項目（総監背景・最重点管理項目→管理間のトレードオフ→改善案→成果）の縦フロー図",
+      "viewBox": "0 0 400 460",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/exam-passing-strategy/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "exam-passing-strategy",
+      "name": "figure-1.svg",
+      "concept": "日常業務での5管理マッピングフロー",
+      "viewBox": "0 0 380 430",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/exam-passing-strategy/img/figure-2.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "exam-passing-strategy",
+      "name": "figure-2.svg",
+      "concept": "4フェーズ学習計画（試験前6〜7ヶ月の標準スケジュール）",
+      "viewBox": "0 0 380 370",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/exam-passing-strategy/img/figure-score-balance.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "exam-passing-strategy",
+      "name": "figure-score-balance.svg",
+      "concept": "択一式と記述式の得点バランス3パターン比較。理想型は両式60%、記述式偏重は択一45%・記述75%、択一式偏重は択一75%・記述45%。両式とも60%に届くバランス型が最も安全。",
+      "viewBox": "0 0 400 258",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/fail-safe/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "fail-safe",
+      "name": "figure-1.svg",
+      "concept": "システムの高信頼化6方策。左=フォールトアボイダンス（故障させない）、右=フォルトトレランス・フェールソフト・フェールセーフ・フールプルーフ・インターロック（故障や誤操作を前提に安全側へ制御）",
+      "viewBox": "0 0 460 480",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/five-s/img/5s-quality-map.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "five-s",
+      "name": "5s-quality-map.svg",
+      "concept": "5Sと品質・安全・納期の関連図",
+      "viewBox": "0 0 360 360",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 10
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/fmea/img/fmea-rpn-flow.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "fmea",
+      "name": "fmea-rpn-flow.svg",
+      "concept": "FMEA の手順とリスク優先数 RPN：構成要素から故障モード・影響・原因を分析し、影響度 S・発生頻度 O・検出難易度 D の積で RPN を算出して対策優先度を決定する",
+      "viewBox": "0 0 380 360",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/four-e-countermeasures/img/four-e-overview.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "four-e-countermeasures",
+      "name": "four-e-overview.svg",
+      "concept": "事故の4E対策の4要素 — Education(教育)・Engineering(技術)・Enforcement(徹底)・Example(模範)を2×2グリッドで配置",
+      "viewBox": "0 0 420 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 11,
+        "low": 1
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/four-m-analysis/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "four-m-analysis",
+      "name": "figure-1.svg",
+      "concept": "事故の4M要因分析。Man・Machine・Media・Managementの4視点で事故原因を分類する手法の概念図",
+      "viewBox": "0 0 400 460",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/four-p-analysis/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "four-p-analysis",
+      "name": "figure-1.svg",
+      "concept": "4P分析（売り手視点）と4C分析（買い手視点）の4要素対応関係を2カラムで並べた図",
+      "viewBox": "0 0 480 500",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/front-loading/img/front-loading-comparison.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "front-loading",
+      "name": "front-loading-comparison.svg",
+      "concept": "フロントローディングの本質：従来型は後工程に手戻りコストが集中するのに対し、フロントローディングは初期段階に投入リソースを集中させ後工程のコストを抑制する",
+      "viewBox": "0 0 380 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/fta/img/fault-tree-diagram.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "fta",
+      "name": "fault-tree-diagram.svg",
+      "concept": "FTA フォールトツリー解析の例：頂上事象 T を AND ゲートで A1・A2 に分解し、A1 を AND で X1・X2、A2 を OR で X3 と OR(X4・X5) に分解した木構造",
+      "viewBox": "0 0 400 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/fta/img/or-and-gates.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "fta",
+      "name": "or-and-gates.svg",
+      "concept": "FTA で用いる OR ゲートと AND ゲートの記号と真理値表。OR は X+Y=Z（X か Y のいずれかが 1 なら Z=1）、AND は X·Y=Z（X と Y の両方が 1 のとき Z=1）",
+      "viewBox": "0 0 400 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/functional-organization/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "functional-organization",
+      "name": "figure-1.svg",
+      "concept": "組織構造7形態の比較。職能別・事業部制・マトリクス・ネットワーク・ピラミッド・ティール・達成型それぞれのメリットとリスクを一覧できるカード図",
+      "viewBox": "0 0 400 890",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/gantt-chart/img/gantt-chart-example.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "gantt-chart",
+      "name": "gantt-chart-example.svg",
+      "concept": "ガントチャートの構成例：横軸に時間、縦軸に作業項目を配置し、計画バー（薄色）と実績バー（濃色）を重ねて進捗を可視化、現在日ラインで遅れを把握する",
+      "viewBox": "0 0 380 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/generative-ai/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "generative-ai",
+      "name": "figure-1.svg",
+      "concept": "生成 AI の技術的位置づけ。人工知能（AI）の中に機械学習、その中にディープラーニング、さらにその中に生成 AI が含まれる入れ子構造を示す。",
+      "viewBox": "0 0 380 332",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/groupware/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "groupware",
+      "name": "figure-1.svg",
+      "concept": "デジタルコミュニケーションツール5分類。テレビ会議・ファイル共有・ビジネスチャット・社内SNS・グループウェアの機能定義を縦に並べた図",
+      "viewBox": "0 0 400 540",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/affinity-diagram-ii-1-3.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "affinity-diagram-ii-1-3.svg",
+      "concept": "親和図",
+      "viewBox": "0 0 480 300",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 18
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/bpt-distribution-known-ii-1-28.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "bpt-distribution-known-ii-1-28.svg",
+      "concept": "BPT分布による地震発生確率（活動時期が明らかな場合）",
+      "viewBox": "0 0 580 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 5,
+        "low": 16
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/bpt-distribution-unknown-ii-1-28.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "bpt-distribution-unknown-ii-1-28.svg",
+      "concept": "BPT分布による地震発生確率（活動時期が不明な場合）",
+      "viewBox": "0 0 580 270",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 3,
+        "low": 18
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/cause-effect-diagram-ii-1-3.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "cause-effect-diagram-ii-1-3.svg",
+      "concept": "特性要因図（フィッシュボーン図）",
+      "viewBox": "0 0 600 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 9
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/eia-procedure-ii-1-38.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "eia-procedure-ii-1-38.svg",
+      "concept": "環境影響評価の手続きフロー",
+      "viewBox": "0 0 560 600",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 5,
+        "low": 7
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/flextime-ii-1-11.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "flextime-ii-1-11.svg",
+      "concept": "変形労働時間制の概要",
+      "viewBox": "0 0 580 240",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 9,
+        "low": 8
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/interrelation-diagram-ii-1-3.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "interrelation-diagram-ii-1-3.svg",
+      "concept": "連関図",
+      "viewBox": "0 0 500 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 1
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/kj-method-ii-1-3.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "kj-method-ii-1-3.svg",
+      "concept": "集団情報構造化法（KJ法）の4段階",
+      "viewBox": "0 0 700 220",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 7
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/labor-dispute-resolution-ii-1-15.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "labor-dispute-resolution-ii-1-15.svg",
+      "concept": "労働関係紛争の解決手段（あっせん・調停・仲裁の一覧）",
+      "viewBox": "0 0 680 310",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 11
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/pdpc-diagram-ii-1-3.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "pdpc-diagram-ii-1-3.svg",
+      "concept": "過程決定計画図（PDPC）",
+      "viewBox": "0 0 500 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/safety-org-structure-ii-1-29.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "safety-org-structure-ii-1-29.svg",
+      "concept": "総括安全衛生管理者等の選任業務（業種×事業場規模マトリクス）",
+      "viewBox": "0 0 760 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 4,
+        "low": 20
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/voc-regulation-ii-1-37.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "voc-regulation-ii-1-37.svg",
+      "concept": "VOC排出規制の対象施設と排出基準",
+      "viewBox": "0 0 680 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 5
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h24-primary/img/xy-theory-ii-1-9.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h24-primary",
+      "name": "xy-theory-ii-1-9.svg",
+      "concept": "マグレガーのX理論・Y理論 比較表",
+      "viewBox": "0 0 680 420",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 39
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h25-primary/img/fault-tree-i-1-27.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h25-primary",
+      "name": "fault-tree-i-1-27.svg",
+      "concept": "フォールトツリー図（電源システムの停電確率）",
+      "viewBox": "0 0 520 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 8
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/h26-primary/img/event-tree-i-1-32.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "h26-primary",
+      "name": "event-tree-i-1-32.svg",
+      "concept": "イベントツリー図（可燃性液体の漏洩事故）",
+      "viewBox": "0 0 680 340",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 29
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/halo-effect-errors/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "halo-effect-errors",
+      "name": "figure-1.svg",
+      "concept": "人事評価の6つの評価バイアス。ハロー効果・中心化傾向・寛大化（厳格化）傾向・対比誤差・論理的誤差・遠近効果の定義を縦に並べた図",
+      "viewBox": "0 0 400 620",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/hazop/img/hazop-guidewords.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "hazop",
+      "name": "hazop-guidewords.svg",
+      "concept": "HAZOP の 7 ガイドワード：プロセスパラメータ（例: 流量）に No / More / Less / As Well As / Part Of / Reverse / Other Than の 7 ガイドワードを掛け合わせて逸脱シナリオを網羅的に導出する",
+      "viewBox": "0 0 380 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/heinrich-law/img/heinrich-pyramid.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "heinrich-law",
+      "name": "heinrich-pyramid.svg",
+      "concept": "ハインリッヒの法則ピラミッド：1 件の重大事故、29 件の軽微な事故、300 件のヒヤリハット（無傷災害）の比率を三角形で示す",
+      "viewBox": "0 0 400 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/herzberg-two-factor-theory/img/herzberg-two-factor.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "herzberg-two-factor-theory",
+      "name": "herzberg-two-factor.svg",
+      "concept": "ハーズバーグの二要因理論：動機づけ要因（仕事の内容）は満足をもたらし、衛生要因（仕事の環境）は不満足を防止する別々の軸で構成される",
+      "viewBox": "0 0 380 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/incentive/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "incentive",
+      "name": "figure-1.svg",
+      "concept": "5つのインセンティブと3つの行動パターンの対応。物質的・評価的・人的・理念的・自己実現の5分類と、経済的・情緒的・管理的行動パターンとの関係を示す図",
+      "viewBox": "0 0 400 560",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/income-statement/img/breakeven-point.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "income-statement",
+      "name": "breakeven-point.svg",
+      "concept": "損益分岐点図：縦軸に売上高・費用、横軸に売上高をとり、固定費と変動費の合計線と売上高線の交点で利益ゼロとなる位置を示す",
+      "viewBox": "0 0 380 260",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 6
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/industrial-property-rights/img/ip-laws-system.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "industrial-property-rights",
+      "name": "ip-laws-system.svg",
+      "concept": "知的財産権関連法規の体系：知的創作物（発明・考案・意匠・著作物等）と営業上の標識（商標・商号等）の二大区分。産業財産権法 4 法（特許・実用新案・意匠・商標）を ★ で示す",
+      "viewBox": "0 0 400 540",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/inherent-safety/img/three-step-method.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "inherent-safety",
+      "name": "three-step-method.svg",
+      "concept": "本質的安全設計の 3 ステップ方策：危険源の除去・低減（最高優先）→ ガード・保護装置（中優先）→ 使用上の情報・教育（最低優先）の段階的安全方策",
+      "viewBox": "0 0 400 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/iot/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "iot",
+      "name": "figure-1.svg",
+      "concept": "IoT システムの 4 層アーキテクチャ。下からデバイス層・ネットワーク層・プラットフォーム層・アプリケーション層の順に積層し、物理世界で取得したデータが上位層へ流れる構造を示す。",
+      "viewBox": "0 0 380 446",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/iso-26000/img/iso-26000-7-core-subjects.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "iso-26000",
+      "name": "iso-26000-7-core-subjects.svg",
+      "concept": "ISO 26000 の 7 つの中核主題のホイール図：組織統治を中心に、人権・労働慣行・環境・公正な事業慣行・消費者課題・コミュニティへの参画が取り囲む",
+      "viewBox": "0 0 580 520",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 4,
+        "low": 8
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/jit-production/img/kanban-two-types-flow.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "jit-production",
+      "name": "kanban-two-types-flow.svg",
+      "concept": "かんばん 2 種類の流れ（前工程と後工程の間）",
+      "viewBox": "0 0 500 230",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 4
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/job-design/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "job-design",
+      "name": "figure-1.svg",
+      "concept": "職務設計の5つの中核的職務特性。技能の多様性・仕事の一貫性・仕事の有意味性・自律性・フィードバックの各特性と動機付け効果を示したカード縦並び図",
+      "viewBox": "0 0 400 580",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/job-grade-system/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "job-grade-system",
+      "name": "figure-1.svg",
+      "concept": "社員格付制度3類型の比較。職能資格制度・職務等級制度・役割等級制度を能力評価・降格・人件費・職務記述書・柔軟性の軸で比較したマトリクス表",
+      "viewBox": "0 0 480 500",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/knowledge-sharing/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "knowledge-sharing",
+      "name": "figure-1.svg",
+      "concept": "ナレッジマネジメント：形式知と暗黙知の対比、活用基盤としてデータウェアハウス・BIツール・集合知の3要素を図示",
+      "viewBox": "0 0 440 490",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/kyt/img/kyt-four-rounds.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "kyt",
+      "name": "kyt-four-rounds.svg",
+      "concept": "KYT 4 ラウンド法：現状把握・本質追究・対策樹立・目標設定の 4 段階と各ラウンドで問う質問",
+      "viewBox": "0 0 400 180",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/labor-relations-adjustment-act/img/labor-dispute-resolution-flow.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "labor-relations-adjustment-act",
+      "name": "labor-dispute-resolution-flow.svg",
+      "concept": "労働関係調整法の 3 つの調整制度：あっせん・調停・仲裁の各 4 ステップ（開始 → 調査 → 調整方法 → 終結）と委員構成・拘束力の比較",
+      "viewBox": "0 0 400 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/labor-union-act/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "labor-union-act",
+      "name": "figure-1.svg",
+      "concept": "労働三権の構造図。憲法第28条が根拠。団結権・団体交渉権・団体行動権（争議権）の3権を縦に並べたカード形式で示す",
+      "viewBox": "0 0 400 530",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/lifecycle-assessment/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "lifecycle-assessment",
+      "name": "figure-1.svg",
+      "concept": "LCAの4プロセスと反復構造。目的及び調査範囲の設定・インベントリ分析・影響評価の3段を解釈が横断し、製品改善・戦略立案・政策立案・マーケ等の直接の用途へつながる図",
+      "viewBox": "0 0 400 480",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/linear-programming/img/lp-graphical-method.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "linear-programming",
+      "name": "lp-graphical-method.svg",
+      "concept": "線形計画法の図解法",
+      "viewBox": "0 0 400 340",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 18
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/logistic-regression/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "logistic-regression",
+      "name": "figure-1.svg",
+      "concept": "線形回帰とロジスティック回帰の出力範囲と関数形を左右に並べた比較図",
+      "viewBox": "0 0 400 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/logistic-regression/img/figure-2.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "logistic-regression",
+      "name": "figure-2.svg",
+      "concept": "シグモイド関数と閾値0.5による陽性・陰性の分類境界を示す図",
+      "viewBox": "0 0 380 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/machine-learning/img/ml-workflow.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "machine-learning",
+      "name": "ml-workflow.svg",
+      "concept": "機械学習のワークフロー：学習プロセス（データ収集→前処理→学習→学習済みモデル）と推論プロセス（データ収集→前処理→推論→活用）の 2 段構成、学習済みモデルが推論に渡される",
+      "viewBox": "0 0 400 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/management-tradeoffs/img/tradeoff-frequency-matrix.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "management-tradeoffs",
+      "name": "tradeoff-frequency-matrix.svg",
+      "concept": "5管理10ペアの出題頻度マトリクス（S=最頻出、A=頻出、B=中、C=低）",
+      "viewBox": "0 0 400 340",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/maslow-hierarchy-of-needs/img/maslow-pyramid.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "maslow-hierarchy-of-needs",
+      "name": "maslow-pyramid.svg",
+      "concept": "マズローの欲求 5 段階説のピラミッド図。底辺から順に生理的欲求・安全欲求・社会的欲求・尊厳欲求（承認欲求）・自己実現欲求が積み上がり、低次欲求が満たされると高次欲求が動機づけの源泉となることを示す",
+      "viewBox": "0 0 400 340",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/mcgregor-xy-theory/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "mcgregor-xy-theory",
+      "name": "figure-1.svg",
+      "concept": "マグレガーのX理論とY理論の2カラム比較。X理論は仕事嫌い・強制命令・責任回避・安全志向、Y理論は自律・目標で率先・自ら責任を特徴とする",
+      "viewBox": "0 0 500 480",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/monte-carlo-simulation/img/monte-carlo-s-curve.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "monte-carlo-simulation",
+      "name": "monte-carlo-s-curve.svg",
+      "concept": "モンテカルロシミュレーション結果の S 字累積確率カーブ。横軸が作業完了日数、縦軸が累積完了可能性（0〜100%）。試行回数を増やすほど滑らかな S 字曲線に収束し、特定日数までに完了する確率を読み取れる",
+      "viewBox": "0 0 400 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/npv-net-present-value/img/normal-distribution-sigma.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "npv-net-present-value",
+      "name": "normal-distribution-sigma.svg",
+      "concept": "normal distribution sigma",
+      "viewBox": "0 0 440 200",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 12
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/occupational-accident-prevention-plan/img/accident-factors.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "occupational-accident-prevention-plan",
+      "name": "accident-factors.svg",
+      "concept": "労働災害の発生要因：事故の型は人・物・環境を経由して不安全な状態と不安全な行動から発生。平成 26 年統計では不安全行動のみが 92% を占め、行動への対策が最重要",
+      "viewBox": "0 0 400 290",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/occupational-accident-prevention-plan/img/unskilled-worker-accident-types.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "occupational-accident-prevention-plan",
+      "name": "unskilled-worker-accident-types.svg",
+      "concept": "未熟練労働者の事故種別",
+      "viewBox": "0 0 380 220",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 2
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/occupational-safety-act/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "occupational-safety-act",
+      "name": "figure-1.svg",
+      "concept": "労働安全衛生法の安全衛生管理体制：管理者・委員会ごとの選任規模要件と根拠条文を示すマトリクス表",
+      "viewBox": "0 0 480 560",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/organizational-commitment/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "organizational-commitment",
+      "name": "figure-1.svg",
+      "concept": "組織コミットメント3要素：情緒的・功利的・規範的の定義と、功利を抑え情緒・規範を高めると有益な従業員が定着するという方向性を示す図",
+      "viewBox": "0 0 400 510",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/oshms/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "oshms",
+      "name": "figure-1.svg",
+      "concept": "OSHMSのPDCAサイクル。安全衛生方針を出発点に計画・実施・評価点検・改善を時計回りに循環させ、中央に継続的改善、外周にシステム監査とトップによる見直しを配置した図",
+      "viewBox": "0 0 400 430",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/outcome-indicators/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "outcome-indicators",
+      "name": "figure-1.svg",
+      "concept": "事業評価の3指標。インプット（投入資源量）からアウトプット（活動量）を経てアウトカム（成果）へと連鎖する因果フローを示した図",
+      "viewBox": "0 0 400 480",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/password-security/img/wifi-encryption-strength.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "password-security",
+      "name": "wifi-encryption-strength.svg",
+      "concept": "Wi-Fi の暗号化強度比較：WPA2（強・推奨）→ WPA（中）→ WEP（弱・非推奨）→ 暗号化なし（危険）の 4 段階と各方式の表示・推奨度",
+      "viewBox": "0 0 400 220",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/patent-rights/img/patent-application-flow.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "patent-rights",
+      "name": "patent-application-flow.svg",
+      "concept": "出願から特許取得までのフロー：特許出願 → 方式審査 → 出願公開（1.5 年後）→ 出願審査請求（3 年以内）→ 実体審査の後、拒絶経路（拒絶理由通知 → 意見書・補正書 → 拒絶査定 → 不服審判）と取得経路（特許査定 → 特許料納付 → 登録）に分岐",
+      "viewBox": "0 0 400 540",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/payback-period-method/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "payback-period-method",
+      "name": "figure-1.svg",
+      "concept": "事業投資評価3手法の比較：NPV法・回収期間法・ROIの判定基準・時間価値考慮・長所短所を横並びで対比",
+      "viewBox": "0 0 480 520",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/pdca-cycle/img/pdca-cycle.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "pdca-cycle",
+      "name": "pdca-cycle.svg",
+      "concept": "PDCAサイクル：Plan 計画→Do 実行→Check 検証→Act 改善の 4 段階を循環させる継続的改善手法",
+      "viewBox": "0 0 380 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/personal-communication/img/push-pull-communication.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "personal-communication",
+      "name": "push-pull-communication.svg",
+      "concept": "プッシュ型とプル型コミュニケーションの対比：プッシュ型は送信者がイニシアチブを持って情報を発信（電子メール・手紙）、プル型は受信者がイニシアチブを持って情報にアクセス（ポータル・イントラネット・e ラーニング）",
+      "viewBox": "0 0 400 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/personnel-management/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "personnel-management",
+      "name": "figure-1.svg",
+      "concept": "ジョブ型（職務主義）とメンバーシップ型（属人主義）の雇用形態を6項目で左右比較した図",
+      "viewBox": "0 0 440 380",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/pert-cpm/img/pert-network-diagram.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "pert-cpm",
+      "name": "pert-network-diagram.svg",
+      "concept": "PERT ネットワーク図",
+      "viewBox": "0 0 380 160",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/pfi/img/pfi-four-types.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "pfi",
+      "name": "pfi-four-types.svg",
+      "concept": "PFI 事業の 4 つの方式：BOO（建設→所有→運営）、BTO（建設→移転→運営）、BOT（建設→運営→移転）、RO（改修→運営）。所有権の移転タイミングが各方式の違い",
+      "viewBox": "0 0 400 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/planetary-boundaries/img/nine-boundaries-status.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "planetary-boundaries",
+      "name": "nine-boundaries-status.svg",
+      "concept": "プラネタリー・バウンダリー 9 領域の現状一覧（2025年評価）。7 領域が超過（気候変動・生物多様性・土地利用変化・淡水利用・窒素リン循環・新規化学物質・海洋酸性化）。大気エアロゾルは評価中。成層圏オゾン層のみ境界内",
+      "viewBox": "0 0 400 320",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/pm-theory/img/pm-quadrant.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "pm-theory",
+      "name": "pm-quadrant.svg",
+      "concept": "PM 理論の 4 象限図。縦軸が P 機能（目標達成機能）、横軸が M 機能（集団維持機能）。右上が PM 型（両機能強・最も効果的）、左上が Pm 型（成果重視・人望薄）、右下が pM 型（人望厚・成果弱）、左下が pm 型（両機能弱）",
+      "viewBox": "0 0 400 340",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/power-harassment/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "power-harassment",
+      "name": "figure-1.svg",
+      "concept": "パワーハラスメントの6類型と成立3要素。成立には優越的関係・業務逸脱・就業環境悪化の3要素を全て満たす必要がある",
+      "viewBox": "0 0 400 620",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/ppm-analysis/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "ppm-analysis",
+      "name": "figure-1.svg",
+      "concept": "PPM分析マトリクス。縦軸が市場成長率、横軸が相対的市場占有率。花形・問題児・金のなる木・負け犬の4象限と各打ち手を示す図",
+      "viewBox": "0 0 420 420",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/preventive-maintenance/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "preventive-maintenance",
+      "name": "figure-1.svg",
+      "concept": "設備保全の全体体系：維持活動（予防保全・事後保全）と改善活動（改良保全・保全予防）の4分類",
+      "viewBox": "0 0 380 520",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/preventive-maintenance/img/figure-2.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "preventive-maintenance",
+      "name": "figure-2.svg",
+      "concept": "TBM（時間基準保全）とCBM（状態基準保全）の比較：契機・特徴・長所・短所",
+      "viewBox": "0 0 400 375",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/process-capability-index/img/normal-distribution-3sigma.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "process-capability-index",
+      "name": "normal-distribution-3sigma.svg",
+      "concept": "正規分布と 3σ 則",
+      "viewBox": "0 0 480 260",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 1
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/progress-management/img/banana-curve.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "progress-management",
+      "name": "banana-curve.svg",
+      "concept": "バナナ曲線（工程管理曲線）— 上方許容限界・予定工程・下方許容限界と実績曲線の関係",
+      "viewBox": "0 0 440 290",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 10
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/progress-management/img/evm-chart.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "progress-management",
+      "name": "evm-chart.svg",
+      "concept": "EVM の基本グラフ — PV・EV・AC と SV・CV の関係",
+      "viewBox": "0 0 460 310",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 2,
+        "low": 14
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/qc-circle/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "qc-circle",
+      "name": "figure-1.svg",
+      "concept": "QCサークル活動の3つの基本理念。自分のため・仲間のため・会社のため の3理念と、上位概念TQMの関係を示した図",
+      "viewBox": "0 0 400 480",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/quality-control/img/qc-seven-tools.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "quality-control",
+      "name": "qc-seven-tools.svg",
+      "concept": "QC 七つ道具：パレート図・特性要因図・ヒストグラム・管理図・散布図・チェックシート・層別の 7 種を 2 列 4 行で配置し、各図の用途と簡易ビジュアルを示す",
+      "viewBox": "0 0 400 500",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/r05-secondary/img/figure-1-swot-framework.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "r05-secondary",
+      "name": "figure-1-swot-framework.svg",
+      "concept": "図1 SWOT分析の枠組み。強み(S)・弱み(W)の列は内部環境、機会(O)・脅威(T)の行は外部環境。両者を掛け合わせる2×2マトリクスで、強み×機会＝パターンA（拡大・進出戦略）、弱み×機会＝パターンB（改善・補強・提携戦略）、強み×脅威＝パターンC（差別化戦略）、弱み×脅威＝パターンD（撤退・縮小戦略）。",
+      "viewBox": "0 0 400 308",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/r05-secondary/img/figure-2-swot-cross-example.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "r05-secondary",
+      "name": "figure-2-swot-cross-example.svg",
+      "concept": "図2 SWOT項目の組合せを選定した例。強み(S)はS1=知名度が高い・S2=従業員の技術力が高い、弱み(W)はW1=販売コストが高い・W2=人材確保が困難、機会(O)はO1=地域の急激な発展・O2=特定分野のニーズの増大、脅威(T)はT1=競合他社の出現・T2=特定素材の価格高騰。パターンAは例としてS2×O1、パターンBはW2×O2、パターンCはS1×T1、パターンDはW1・W2×T1の組合せをベースにした戦略。",
+      "viewBox": "0 0 400 424",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/redundancy-safety/img/redundancy-types.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "redundancy-safety",
+      "name": "redundancy-types.svg",
+      "concept": "冗長化の 3 種類：待機冗長は主系故障時に予備が切替、並列冗長は常時並列稼働で一方の故障でも機能維持、多数決冗長は複数出力を多数決で判定する",
+      "viewBox": "0 0 380 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/risk-assessment/img/chemical-ra-flow.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "risk-assessment",
+      "name": "chemical-ra-flow.svg",
+      "concept": "化学物質のリスクアセスメント 5 段階フロー：①危険性・有害性の特定→②リスクの見積もり→③リスク低減措置の内容検討→④リスク低減措置の実施→⑤労働者への結果周知。労働安全衛生法（平成 28 年改正）に基づく義務手順",
+      "viewBox": "0 0 400 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/risk-assessment/img/risk-matrix.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "risk-assessment",
+      "name": "risk-matrix.svg",
+      "concept": "リスクマトリクス：縦軸が生起確率（低・中・高）、横軸が影響度（小・中・大）の 3×3 マトリクス。右上ほどリスクが高く（赤）、左下ほど低い（緑）。点線矢印は右上から左下へのリスク低減方向を示す",
+      "viewBox": "0 0 400 280",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/risk-perception/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "risk-perception",
+      "name": "figure-1.svg",
+      "concept": "リスク認知の5バイアス。正常性・楽観主義・カタストロフィー・ベテラン・バージンの各バイアスを定義とともに縦並びカードで示した図",
+      "viewBox": "0 0 400 570",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/risk-treatment/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "risk-treatment",
+      "name": "figure-1.svg",
+      "concept": "リスク対応の4方針。低減・移転・回避・保有の各方針と手段、ALARP原則・絶対安全は不可を示した図",
+      "viewBox": "0 0 400 520",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/risk-treatment/img/figure-2.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "risk-treatment",
+      "name": "figure-2.svg",
+      "concept": "リスクマトリクス：縦軸が影響度（大小）、横軸が発生確率（低高）の2×2マトリクスで、右上を最優先で低減し左下へ持っていく対応方針を示す図",
+      "viewBox": "0 0 400 460",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/rpa/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "rpa",
+      "name": "figure-1.svg",
+      "concept": "RPA の 3 つの自動化レベル。クラス 1（定型業務）が現在の主流で、クラス 2・クラス 3 へ進むほど AI 活用度と自律性が高まる。",
+      "viewBox": "0 0 380 296",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/safety-culture/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "safety-culture",
+      "name": "figure-1.svg",
+      "concept": "安全文化を支える4つの文化（J.リーズン）。報告する文化・正義の文化・柔軟な文化・学習する文化の2×2マトリクス",
+      "viewBox": "0 0 400 440",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/sdgs/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "sdgs",
+      "name": "figure-1.svg",
+      "concept": "持続可能な開発 5つのP。People・Prosperity・Planet・Peace・Partnershipの各カードに日本語訳・意味・該当目標範囲を示し、上部帯で経済・社会・環境の三側面調和を表す",
+      "viewBox": "0 0 400 560",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/species-preservation-act/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "species-preservation-act",
+      "name": "figure-1.svg",
+      "concept": "レッドリストカテゴリ階層。絶滅から情報不足・地域個体群まで9区分を危険度の高い順に上から示した図",
+      "viewBox": "0 0 400 580",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/swot-analysis/img/swot-matrix.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "swot-analysis",
+      "name": "swot-matrix.svg",
+      "concept": "SWOT 分析の 2 軸 4 象限：内部環境（強み Strengths・弱み Weaknesses）と外部環境（機会 Opportunities・脅威 Threats）をプラス/マイナスで整理する",
+      "viewBox": "0 0 380 380",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/system-reliability/img/series-parallel-configuration.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "system-reliability",
+      "name": "series-parallel-configuration.svg",
+      "concept": "システム構成図（直列・並列）",
+      "viewBox": "0 0 420 180",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 6
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/system-reliability/img/series-parallel-formulas.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "system-reliability",
+      "name": "series-parallel-formulas.svg",
+      "concept": "直列・並列信頼度の計算式",
+      "viewBox": "0 0 400 120",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 4,
+        "low": 2
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/value-engineering/img/ve-basic-steps.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "value-engineering",
+      "name": "ve-basic-steps.svg",
+      "concept": "VE の基本 3 ステップ：機能定義 → 機能評価 → 代替案作成",
+      "viewBox": "0 0 400 210",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/value-engineering/img/ve-function-tree.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "value-engineering",
+      "name": "ve-function-tree.svg",
+      "concept": "機能系統図（FAST ダイアグラム）：目的機能から手段機能への階層分解（Why/How の階層）",
+      "viewBox": "0 0 400 260",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/vpn/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "vpn",
+      "name": "figure-1.svg",
+      "concept": "VPN のトンネリングの概念図。拠点 A と拠点 B が、公衆ネットワークであるインターネット上に構築された暗号化トンネルを通じて安全に接続される。",
+      "viewBox": "0 0 400 212",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/waste-management-act/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "waste-management-act",
+      "name": "figure-1.svg",
+      "concept": "廃棄物処理法に基づく廃棄物の区分。一般廃棄物（市町村責任）と産業廃棄物（事業者責任）の2系統に分類し、各枝の特別管理区分をwarnで強調した縦フロー図",
+      "viewBox": "0 0 400 560",
+      "embedded": false,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/waterfall/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "waterfall",
+      "name": "figure-1.svg",
+      "concept": "V モデル。左側の設計工程（要件定義・基本設計・詳細設計・実装）を上から下へ進め、右側のテスト工程（単体・結合・システム・受入）を下から上へ進める。同じ高さの設計工程とテスト工程が対応する。",
+      "viewBox": "0 0 400 288",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/work-planning/img/standard-time-tree.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "work-planning",
+      "name": "standard-time-tree.svg",
+      "concept": "標準時間の構成ツリー",
+      "viewBox": "0 0 500 190",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 1,
+        "low": 0
+      }
+    },
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/zero-trust/img/figure-1.svg",
+      "category": "pe-comprehensive-management",
+      "slug": "zero-trust",
+      "name": "figure-1.svg",
+      "concept": "境界型防御とゼロトラストの考え方の比較。境界型防御は境界で 1 回だけ認証し内部を信頼領域とするのに対し、ゼロトラストは信頼領域を作らずアクセスのたびに認証する。",
+      "viewBox": "0 0 400 296",
+      "embedded": true,
+      "audit": {
+        "high": 0,
+        "medium": 0,
+        "low": 0
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ogp-backgrounds": "node scripts/generate-ogp-backgrounds.mjs",
     "ogp-gallery": "node scripts/ogp-gallery.mjs",
     "svg-gallery": "node scripts/svg-gallery.mjs",
+    "build-svg-catalog": "node .claude/scripts/build-svg-catalog.mjs",
     "start": "next start -p 3020",
     "lint": "eslint src/",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
## 目的
図版SVGの「コレクション台帳」が無かったギャップを解消。どの概念→どのファイル→埋込/監査状態を一元管理するSSOTを派生生成する。

## 変更
- `.claude/scripts/build-svg-catalog.mjs` 新規（`.local/r2/posts/**/img/*.svg` 走査）
- `npm run build-svg-catalog` 追加
- 出力 `.claude/state/svg-catalog.json`（concept/viewBox/category/slug/embedded/audit を join、再生成でdrift防止）

## 初回生成
191図版 / embedded 142 / orphan 49（orphan=未埋込、総監5管理の新規47点を含む。Phase4埋め込みで解消）/ concept欠落0 / HIGH監査0

## 位置づけ
svg-gallery（目視ビュー）・svg-audit.json（監査結果）を補完する図版コレクションのSSOT。

🤖 Generated with [Claude Code](https://claude.com/claude-code)