### PR TITLE
revert(category): ガイドカードのカバー写真表示を撤回

### DIFF
--- a/src/components/category/CategorySections.tsx
+++ b/src/components/category/CategorySections.tsx
@@ -1,8 +1,6 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import { type DocMeta } from '@/lib/docs';
 import { type DocGroup } from '@/lib/category-groups';
-import { guideCoverFor } from '@/lib/guide-cover';
 
 /** カード表示用の更新日を YYYY.MM.DD で返す（取れなければ null）。LatestArticles と同じ整形。 */
 function cardDate(doc: DocMeta): string | null {
@@ -17,28 +15,14 @@ export function DocCard({ doc }: { doc: DocMeta }) {
   const displayTitle = doc.shortTitle || doc.title;
   const excerpt = doc.subtitle || doc.description;
   const date = cardDate(doc);
-  const cover = guideCoverFor(doc);
   return (
     <Link
       href={`/docs/${doc.slug}`}
       className="group relative flex flex-col overflow-hidden rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] hover:border-[var(--accent)] hover:shadow-soft transition-all"
     >
-      {/* ガイド記事は AI 生成のカバー写真（資格別プールから slug ハッシュで選択）。
-          非ガイド／プール未設定はブランド色の上端アクセント（mono バンド）に fallback。 */}
-      {cover ? (
-        <div className="relative w-full aspect-[16/9] overflow-hidden bg-[var(--accent-fill)]">
-          <Image
-            src={cover}
-            alt=""
-            fill
-            unoptimized
-            sizes="(max-width: 768px) 100vw, 360px"
-            className="object-cover group-hover:scale-105 transition-transform duration-300"
-          />
-        </div>
-      ) : (
-        <span aria-hidden className="block h-[3px] w-full bg-[var(--color-brand)] opacity-70 group-hover:opacity-100 transition-opacity" />
-      )}
+      {/* ブランド色の上端アクセント（mockup の category band を mono 化＝硬質エディトリアル維持）。
+          ガイドカバー写真（guide-cover.ts）は dormant: メタガイドに literal 機械写真が不一致のため撤回（PR #276→revert）。 */}
+      <span aria-hidden className="block h-[3px] w-full bg-[var(--color-brand)] opacity-70 group-hover:opacity-100 transition-opacity" />
       <div className="flex flex-1 flex-col gap-1.5 p-5">
         <h3 className="font-serif text-lg font-bold text-[var(--ink)] group-hover:text-[var(--accent)] line-clamp-2 transition-colors">
           {displayTitle}


### PR DESCRIPTION
PR #276 で入れたガイドカードのカバー写真を**表示だけ撤回**し、テキストカード（ブランド色バンド＋タイトル＋抜粋＋更新日）に戻す。

## 理由
civil-1 等のガイドは大半が**メタ記事**（キャリア/合格率/勉強法/参考書/級の違い）で、literal な建設機械写真が記事トピックと不一致 →「記事と無関係な画像」に見えた（ユーザー指摘・ライブ確認）。資格テーマには合うが記事トピックには合わない＝category-pool 方式がメタガイド主体のガイド群に不適合だった。

## 変更
- `DocCard`（`CategorySections.tsx`）: カバー写真表示を削除し band fallback に統一（差分は3+/19-）。

## 保持（dormant・再課金不要で再利用可）
`scripts/generate-guide-covers.mjs`（npm `guide-covers`）・`src/config/guide-cover-photos.json`・`src/lib/guide-cover.ts`・`public/images/guide-covers/`（35枚）はそのまま残す。再有効化は DocCard に `guideCoverFor` を再配線（ただし**記事トピック整合の改善**＝トピック特化ガイド限定 or 抽象イメージ等が前提）。

## 検証
- `type-check` ✓ / `eslint` ✓ / pre-commit 通過
- preview（:3020）`civil-construction-1`：guide-cover 参照 0・テキストカード（band）復帰を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)