### PR TITLE
chore(home): ヒーローの資格列挙文と articles/更新 メタ行を削除

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -118,18 +118,13 @@ export default async function HomePage() {
   const allMeta = getAllDocsMeta();
   const exams = buildExamCards();
 
-  const articleCount = allMeta.filter((m) => m.published !== false).length;
-
   const latest = pickRecent(allMeta, 4);
-  const lastUpdated = latest[0]?.date
-    ? new Date(latest[0].date).toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" }).replace(/\//g, ".")
-    : undefined;
 
   return (
     <div className="min-h-screen flex flex-col bg-[var(--bg)] transition-colors duration-300">
       <Header />
       <main className="flex-grow">
-        <Hero articleCount={articleCount} lastUpdated={lastUpdated} />
+        <Hero />
         <ExamCards exams={exams} />
         <LatestArticles articles={latest} />
         <AboutSection />

--- a/src/components/home/ExamCards.tsx
+++ b/src/components/home/ExamCards.tsx
@@ -59,9 +59,7 @@ export default function ExamCards({ exams }: ExamCardsProps) {
   return (
     <section id="exams" className="scroll-mt-24 max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 py-8 sm:py-10">
       <div className="mb-6 sm:mb-8">
-        <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-[var(--ink-muted)] mb-3">Exams</div>
         <h2 className="font-serif text-2xl sm:text-3xl font-black text-[var(--ink)]">対応する資格・試験</h2>
-        <p className="text-[14px] text-[var(--ink-muted)] mt-1.5">現場と試験を往復する、体系的な学習コンテンツ</p>
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         {exams.map((e) => (

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,15 +1,8 @@
-import { NotebookPen, ArrowRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 
 export default function Hero() {
   return (
     <section className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 pt-16 sm:pt-24 pb-10 sm:pb-16 text-center">
-      <div className="flex items-center justify-center gap-2 mb-7 flex-wrap">
-        <span className="inline-flex items-center gap-1.5 font-mono text-[11px] tracking-wider uppercase text-[var(--accent)] px-2.5 py-1 bg-[var(--accent-fill)] rounded-full">
-          <NotebookPen className="w-3 h-3" strokeWidth={1.75} />
-          doboku-note
-        </span>
-        <span className="font-mono text-[11px] text-[var(--ink-muted)]">土木系資格試験 対策ノート</span>
-      </div>
       <h1 className="font-serif font-black tracking-tight leading-[1.18] text-[var(--ink)] text-[36px] sm:text-[52px] md:text-[64px] lg:text-[72px] mx-auto max-w-[18ch] text-balance">
         土木の試験対策を、ひとつに。
       </h1>

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -14,7 +14,9 @@ export default function Hero() {
         土木の試験対策を、ひとつに。
       </h1>
       <p className="mt-6 sm:mt-7 text-[15px] sm:text-[18px] leading-[1.9] text-[var(--ink-body)] mx-auto max-w-[56ch]">
-        土木・建設系の実務資格を、合格者が体系化した試験対策サイト。ここだけで合格を目指せます。
+        土木・建設系の実務資格を、合格者が体系化した試験対策サイト。
+        <br />
+        ここだけで合格を目指せます。
       </p>
       <div className="mt-8 sm:mt-9 flex items-center justify-center">
         <a

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,11 +1,6 @@
-import { NotebookPen, FileText, Calendar, ArrowRight } from "lucide-react";
+import { NotebookPen, ArrowRight } from "lucide-react";
 
-interface HeroProps {
-  articleCount: number;
-  lastUpdated?: string | undefined;
-}
-
-export default function Hero({ articleCount, lastUpdated }: HeroProps) {
+export default function Hero() {
   return (
     <section className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 pt-16 sm:pt-24 pb-10 sm:pb-16 text-center">
       <div className="flex items-center justify-center gap-2 mb-7 flex-wrap">
@@ -19,7 +14,7 @@ export default function Hero({ articleCount, lastUpdated }: HeroProps) {
         土木の試験対策を、ひとつに。
       </h1>
       <p className="mt-6 sm:mt-7 text-[15px] sm:text-[18px] leading-[1.9] text-[var(--ink-body)] mx-auto max-w-[56ch]">
-        1級・2級土木施工管理技士、技術士（第一次試験・建設部門・総合技術監理部門）、コンクリート主任技師。土木・建設系の実務資格を現場目線で体系的に学べる試験対策ハブ。
+        土木・建設系の実務資格を現場目線で体系的に学べる試験対策ハブ。
       </p>
       <div className="mt-8 sm:mt-9 flex items-center justify-center">
         <a
@@ -29,21 +24,6 @@ export default function Hero({ articleCount, lastUpdated }: HeroProps) {
           <span>資格を選んで学ぶ</span>
           <ArrowRight className="w-4 h-4" strokeWidth={2} />
         </a>
-      </div>
-      <div className="mt-6 flex items-center justify-center gap-5 flex-wrap font-mono text-[11px] text-[var(--ink-muted)] tabular-nums">
-        <span className="flex items-center gap-1.5">
-          <FileText className="w-3 h-3" />
-          {articleCount.toLocaleString()} articles
-        </span>
-        {lastUpdated && (
-          <>
-            <span aria-hidden>·</span>
-            <span className="flex items-center gap-1.5">
-              <Calendar className="w-3 h-3" />
-              更新 {lastUpdated}
-            </span>
-          </>
-        )}
       </div>
     </section>
   );

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -14,7 +14,7 @@ export default function Hero() {
         土木の試験対策を、ひとつに。
       </h1>
       <p className="mt-6 sm:mt-7 text-[15px] sm:text-[18px] leading-[1.9] text-[var(--ink-body)] mx-auto max-w-[56ch]">
-        土木・建設系の実務資格を現場目線で体系的に学べる試験対策ハブ。
+        土木・建設系の実務資格を、合格者が体系化した試験対策サイト。ここだけで合格を目指せます。
       </p>
       <div className="mt-8 sm:mt-9 flex items-center justify-center">
         <a


### PR DESCRIPTION
## 変更内容
トップページのヒーローを簡素化。

- サブタイトルから資格名の列挙（`1級・2級土木施工管理技士、技術士（…）、コンクリート主任技師。`）を削除し、価値訴求の一文のみに
- ヒーロー下部の `N articles ・ 更新 YYYY.MM.DD` メタ行を撤去
- 未使用化した `articleCount` / `lastUpdated` と Hero の props・lucide アイコン（FileText/Calendar）を整理

## 確認
- `npm run type-check` 通過
- preview(:3020) で SSR を確認：ヒーローは「土木の試験対策を、ひとつに。」→ 価値訴求文 → CTA「資格を選んで学ぶ」のみ。articles/更新 行は消失。資格の網羅は下の資格カードで担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)