### PR TITLE
feat(ci): affiliate-career-only 違反 prose の検知ガード

### DIFF
--- a/.github/workflows/r2-audit.yml
+++ b/.github/workflows/r2-audit.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Check guide article length (published guide >= 3000 chars)
         run: npm run check-guide-length
 
+      # affiliate-career-only 違反 prose（添削サービス/講座ブランド等の再提案）の全量 backstop。
+      # pre-commit はローカル限定でクラウドルーティンの自動生成を守れないため CI で全 .local/r2/posts を検査。
+      - name: Check affiliate-career-only prose (no abolished course/添削 re-proposals)
+        run: npm run check-affiliate-prose
+
       - name: Diff local (main) vs R2 — images only
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/project/04_運営/02_アフィリエイト提携状況.md
+++ b/docs/project/04_運営/02_アフィリエイト提携状況.md
@@ -16,6 +16,7 @@ doboku-note で扱うアフィリエイト案件の提携・申請状況・運�
 - **学習・受験意図 → note（自社・高粗利）が独占。** 学習スパンドの導線は note CTA に一本化する。
 - **キャリア意図 → 転職アフィリ（唯一の稼働アフィリ）。** 建設・施工管理特化の転職エージェント/サイト。会員登録・無料相談などの低ハードル成果で **¥25,000〜¥50,000/件**。受験者＝資格でキャリアアップを狙う層と一致し、note と財布が別なので競合しない。年収・キャリア・転職を扱うガイド記事との相性が最も高い。配置は `CareerAffiliate`（記事末・本文インライン）と `SidebarAdBanner`（PC サイドバー）。
 - **撤去済みの構成要素**: `CourseAffiliate` / `SchoolAffiliate` / `DokugakuBanner` / `SatTextLink` / `DokugakuKeikenLink` / `BookCard` / `BookSection` の各コンポーネント、`SCHOOL_SAT` / `HOME_AFFILIATE` creative、`affiliate-flags.ts` / `affiliate-books.json`、SAT・独学サポート系の全 mat。MDX 本文の該当タグ（DokugakuBanner 110 / CourseAffiliate 10 / BOOKCARD-TODO / インライン DokugakuKeikenLink）も全除去。
+- **prose ガード（2026-06-27 新設）**: PR #272 は上記コンポーネント撤去のみで、本文 prose の「添削サービスも選択肢」「スタディング/アガルート」「対策手段の選び方＝3手段」等の再提案を 7 ページ取りこぼしていた（同日 sweep で全除去）。再発防止に `npm run check-affiliate-prose`（SSOT=`src/config/affiliate-prose-denylist.json`、pre-commit に配線）で本文 MDX の廃止アフィリ推奨 prose を機械検知する。`通信講座/講座/添削` 単体は試験コンテンツ（自己啓発分類等）でも正当に登場するため deny せず、高精度な廃止サービス名・講座ブランド名・代行語に絞る。正当な出典引用・試験コンテンツは denylist の `allow`（{file, term, reason}）で除外（例: vta-method の studying.jp 引用）。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "check-ogp-coverage": "node scripts/check-ogp-coverage.mjs",
     "check-home-exam-coverage": "node scripts/check-home-exam-coverage.mjs",
     "check-affiliate-mats": "node scripts/check-affiliate-mats.mjs",
+    "check-affiliate-prose": "node scripts/check-affiliate-prose.mjs",
     "fetch-gsc-data": "node .claude/skills/analytics/fetch-gsc-data/scripts/fetch-gsc-data.mjs",
     "fetch-ga4-data": "node .claude/scripts/fetch-ga4-data.mjs",
     "fetch-ga4-cta-clicks": "node .claude/scripts/fetch-ga4-cta-clicks.mjs",

--- a/scripts/check-affiliate-prose.mjs
+++ b/scripts/check-affiliate-prose.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// affiliate-career-only の prose ゲート。
+//
+// 背景: 2026-06-25 に講座/教材/添削アフィリを完全廃止（PR #272）したが、
+// PR #272 はコンポーネント撤去のみで「添削サービスも選択肢」「スタディング/アガルート」
+// 等の本文 prose の再提案を 7 ページ取りこぼしていた（2026-06-27 発見・sweep 済）。
+// 機械ガード（check-affiliate-mats は a8mat creative 専用で prose を見ない）が無いと
+// 再発するため、本文 MDX に廃止アフィリの推奨 prose が混入していないかを SSOT
+// 許可リスト src/config/affiliate-prose-denylist.json と突合する。
+//
+// 判定:
+//   - denyTerms のいずれかが本文に出現し、allow 例外でない → ERROR（exit 1）。
+//   - allow（{file, term}）に列挙された正当ケース（出典引用・試験コンテンツ）は除外。
+//
+// 設計方針: 通信講座/講座/添削 の語は試験コンテンツでも正当に出るため denyTerms に
+// 入れない。廃止サービス名・講座ブランド名・代行語など高精度語に絞り誤検知を避ける。
+//
+// 使い方:
+//   node scripts/check-affiliate-prose.mjs            # .local/r2/posts 全体
+//   node scripts/check-affiliate-prose.mjs --staged   # git staged の該当ファイルのみ（pre-commit 用）
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const STAGED = process.argv.includes('--staged');
+const CONFIG = 'src/config/affiliate-prose-denylist.json';
+const SCAN_DIR = '.local/r2/posts';
+const SCAN_EXT = /\.mdx?$/;
+
+if (!existsSync(CONFIG)) {
+  console.error(`[check-affiliate-prose] ${CONFIG} が無いため検証をスキップ`);
+  process.exit(0);
+}
+
+const config = JSON.parse(readFileSync(CONFIG, 'utf8'));
+const denyTerms = config.denyTerms || [];
+// allow: (file, term) ペアの集合。term 省略時はそのファイルの全 denyTerms を許可。
+const allow = new Set((config.allow || []).map((a) => `${a.file}::${a.term || '*'}`));
+
+function isAllowed(file, term) {
+  return allow.has(`${file}::${term}`) || allow.has(`${file}::*`);
+}
+
+function walk(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (SCAN_EXT.test(p)) out.push(p);
+  }
+  return out;
+}
+
+function stagedFiles() {
+  try {
+    const out = execFileSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACM'], {
+      encoding: 'utf8',
+    });
+    return out
+      .split('\n')
+      .map((s) => s.trim())
+      .filter((s) => s.startsWith(SCAN_DIR + '/') && SCAN_EXT.test(s) && existsSync(s));
+  } catch {
+    return [];
+  }
+}
+
+const files = STAGED ? stagedFiles() : walk(SCAN_DIR);
+
+const violations = [];
+for (const file of files) {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    for (const term of denyTerms) {
+      if (line.includes(term) && !isAllowed(file, term)) {
+        violations.push({ file, line: i + 1, term, text: line.trim().slice(0, 100) });
+      }
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error(
+    `[check-affiliate-prose] ✗ 廃止アフィリの推奨 prose を ${violations.length} 件検出（affiliate-career-only 違反）`,
+  );
+  console.error('  真実源: docs/project/04_運営/02_アフィリエイト提携状況.md / memory affiliate-career-only');
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}  「${v.term}」  ${v.text}`);
+  }
+  console.error(
+    '  → 講座/添削の推奨を除去し、穴は note 模範論文・完成答案＋勉強仲間/職場の有資格者の目で埋める表現へ。',
+  );
+  console.error(
+    `  → 正当な出典引用・試験コンテンツなら ${CONFIG} の allow に {file, term, reason} を追記。`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[check-affiliate-prose] ✓ ${files.length} ファイルに廃止アフィリ推奨 prose は無し（deny ${denyTerms.length} 語）`,
+);

--- a/scripts/install-pre-commit.mjs
+++ b/scripts/install-pre-commit.mjs
@@ -77,6 +77,12 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# affiliate-career-only 違反 prose（添削サービス/講座ブランド等の再提案）を検知（PR#272 取りこぼしの再発防止）
+node scripts/check-affiliate-prose.mjs --staged
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 # ポリシークラスタ（決定が複数文書に散在）の横展開もれリマインダ＋台帳 rot 検出（意味的ドリフトの再発防止）
 # クラスタ提示は advisory（exit 0）。台帳の files/anchor が実在しない場合のみ exit 1 でブロック。
 node scripts/check-policy-anchors.mjs --staged

--- a/src/config/affiliate-prose-denylist.json
+++ b/src/config/affiliate-prose-denylist.json
@@ -1,0 +1,18 @@
+{
+  "description": "affiliate-career-only(2026-06-25) 違反の prose を検知する SSOT 許可リスト。講座/教材/添削アフィリは完全廃止・学習導線に再提案しない。本文(.local/r2/posts/**)に廃止アフィリの推奨 prose が混入していないかを check-affiliate-prose.mjs が突合する。真実源: docs/project/04_運営/02_アフィリエイト提携状況.md / memory affiliate-career-only。通信講座/講座/添削 の語は試験コンテンツ(自己啓発分類等)でも正当に登場するため denyTerms には入れず、高精度な廃止サービス名・ブランド名・代行語に絞る。",
+  "denyTerms": [
+    "添削サービス",
+    "スタディング",
+    "アガルート",
+    "独学サポート",
+    "作文代行",
+    "受験対策スクール"
+  ],
+  "allow": [
+    {
+      "file": ".local/r2/posts/pe-comprehensive-management/vta-method/article.mdx",
+      "term": "スタディング",
+      "reason": "VTA法の出典引用（studying.jp 技術士応援ブログへの参考リンク）。講座の推奨ではない"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

`affiliate-career-only`（2026-06-25 講座/教材/添削/書籍アフィリ完全廃止）の **prose レベル機械ガード**を新設。PR #272 はコンポーネント撤去のみで本文 prose の再提案（「添削サービスも選択肢」「スタディング/アガルート」「対策手段の選び方＝3手段」等）を **7ページ取りこぼし**ており、2026-06-27 に sweep で是正済み。その再発防止。

## 変更

- `scripts/check-affiliate-prose.mjs` — `.local/r2/posts/**` を SSOT denylist と突合し違反で exit 1（`--staged` で pre-commit 用）
- `src/config/affiliate-prose-denylist.json` — denyTerms（添削サービス/スタディング/アガルート/独学サポート/作文代行/受験対策スクール）＋ `allow` 例外（vta-method の studying.jp 出典引用）
- `scripts/install-pre-commit.mjs` — pre-commit に配線
- `package.json` — `npm run check-affiliate-prose`
- affiliate SSOT doc に新ガードを記載（discoverability）

## 設計

- `通信講座/講座/添削` 単体は試験コンテンツ（自己啓発分類等）でも正当に登場するため **deny せず**、高精度な廃止サービス名・講座ブランド名・代行語に絞り誤検知を回避
- 正当な出典引用・試験コンテンツは denylist の `allow`（{file, term, reason}）で除外

## 検証

- full スキャン: ✓ 1075 ファイル 0 件（vta-method の studying.jp 引用は allowlist 通過）
- 注入テスト: `添削サービス` を一時追記 → 検知して exit 1 を確認・復元済み
- pre-commit: 本 PR の commit 時に新ガード自身が ✓ で通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)