### PR TITLE
design: Phase 1 ArticleHeader（記事冒頭に description リード集約）

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { getDoc, getAllDocSlugs, getDocsMetaByCategory, type DocMeta } from '@/lib/docs';
 import PageShell from '@/components/layout/PageShell';
+import ArticleHeader from '@/components/ui/ArticleHeader/ArticleHeader';
 import { getAllComponents } from '@/lib/component-loader';
 import { getCategoryLabel } from '@/lib/categories';
 import { classifyDoc, getGroupLabel } from '@/lib/doc-classifier';
@@ -26,7 +27,6 @@ import { getMagazine, type NoteMagazine } from '@/lib/note-magazines';
 import MetaRow from '@/components/ui/MetaRow/MetaRow';
 import ArticleFooter from '@/components/ui/ArticleFooter/ArticleFooter';
 import ArticleSidebar from '@/components/ui/ArticleSidebar/ArticleSidebar';
-import { generateHeadingId } from '@/lib/toc';
 import { extractReferencesSection } from '@/lib/extract-references';
 import type { Pluggable } from 'unified';
 import { resolveDocsCareerSidebarAd } from '@/config/affiliate-creatives';
@@ -300,32 +300,13 @@ export default async function DocPage({
           <main className="flex-1 min-w-0 py-10">
             {/* Editorial article card: 12px radius, soft border + shadow。1280 化に伴い desktop は px-16 で本文行長を抑える */}
             <article className="bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section shadow-soft py-12 px-12 zenn-desktop:px-16 overflow-hidden transition-colors duration-300 max-zenn-sp:rounded-none max-zenn-sp:border-x-0 max-zenn-sp:py-[35px] max-zenn-sp:px-5 max-zenn-tiny:px-[14px]">
-              {/* パンくず（カード内、タイトル上）: mono uppercase tracking-widest */}
-              {category && (
-                <nav aria-label="breadcrumb" className="mb-6 font-mono text-[11px] text-[var(--ink-muted)] uppercase tracking-widest flex items-center gap-2">
-                  <a
-                    href={`/category/${category}`}
-                    className="hover:text-[var(--accent)] transition-colors"
-                  >
-                    {getCategoryLabel(category)}
-                  </a>
-                  <span aria-hidden className="opacity-60">›</span>
-                  <span>{getGroupLabel(category, docGroup)}</span>
-                </nav>
-              )}
-              {/* タイトル: frontmatter から server-side で描画。MDX 内 H1 は下で strip する */}
-              <h1
-                id={generateHeadingId(doc.meta.title)}
-                className="font-sans font-bold text-[24px] text-[var(--ink)] leading-[1.4] tracking-tight text-balance [word-break:auto-phrase] m-0 mb-0"
-                style={{
-                  letterSpacing: '-0.01em',
-                }}
-              >
-                {doc.meta.title}
-              </h1>
-              {/* タイトル直下 byline: 日付 + 読了時間（タグなし） */}
-              <MetaRow
-                variant="byline"
+              {/* 記事ヘッダー: breadcrumb + H1 + description リード + byline を集約 */}
+              <ArticleHeader
+                title={doc.meta.title}
+                category={category}
+                categoryLabel={category ? getCategoryLabel(category) : null}
+                groupLabel={category ? getGroupLabel(category, docGroup) : null}
+                description={doc.meta.description}
                 publishedAt={doc.meta.publishedAt || doc.meta.created}
                 updatedAt={doc.meta.updatedAt || doc.meta.dateModified}
               />

--- a/src/components/ui/ArticleHeader/ArticleHeader.tsx
+++ b/src/components/ui/ArticleHeader/ArticleHeader.tsx
@@ -1,0 +1,75 @@
+/**
+ * 記事冒頭ヘッダー（docs/[...slug] のカード内）。
+ *
+ * これまで page.tsx に散っていた breadcrumb + H1 + byline を 1 コンポーネントに集約し、
+ * frontmatter の description を 1 文リードとして H1 直下に出して
+ * 「どの試験・どの分類・何を解決するか」をファーストビューで判断しやすくする。
+ *
+ * 注: category/group は breadcrumb、updated は byline(MetaRow) が担うため、
+ * 重複するメタチップ行は置かない（リード文を主役にする）。
+ */
+
+import Link from 'next/link';
+import { generateHeadingId } from '@/lib/toc';
+import MetaRow from '@/components/ui/MetaRow/MetaRow';
+
+interface ArticleHeaderProps {
+  title: string;
+  /** カテゴリ slug（breadcrumb のリンク先） */
+  category?: string | null | undefined;
+  /** カテゴリ表示名 */
+  categoryLabel?: string | null | undefined;
+  /** グループ表示名（過去問/ガイド 等） */
+  groupLabel?: string | null | undefined;
+  /** frontmatter description（1 文リード） */
+  description?: string | null | undefined;
+  publishedAt?: string | undefined;
+  updatedAt?: string | undefined;
+}
+
+export default function ArticleHeader({
+  title,
+  category,
+  categoryLabel,
+  groupLabel,
+  description,
+  publishedAt,
+  updatedAt,
+}: ArticleHeaderProps) {
+  return (
+    <header>
+      {category && categoryLabel && (
+        <nav
+          aria-label="breadcrumb"
+          className="mb-6 font-mono text-[11px] text-[var(--ink-muted)] uppercase tracking-widest flex items-center gap-2"
+        >
+          <Link href={`/category/${category}`} className="hover:text-[var(--accent)] transition-colors">
+            {categoryLabel}
+          </Link>
+          {groupLabel && (
+            <>
+              <span aria-hidden className="opacity-60">›</span>
+              <span>{groupLabel}</span>
+            </>
+          )}
+        </nav>
+      )}
+
+      <h1
+        id={generateHeadingId(title)}
+        className="font-sans font-bold text-[24px] text-[var(--ink)] leading-[1.4] tracking-tight text-balance [word-break:auto-phrase] m-0"
+        style={{ letterSpacing: '-0.01em' }}
+      >
+        {title}
+      </h1>
+
+      {description && (
+        <p className="mt-3 text-[15px] leading-[1.85] text-[var(--ink-body)]">
+          {description}
+        </p>
+      )}
+
+      <MetaRow variant="byline" publishedAt={publishedAt} updatedAt={updatedAt} />
+    </header>
+  );
+}


### PR DESCRIPTION
デザイン改善ロードマップ Phase 1 のうち **ArticleHeader** を実装。Phase 0（PR #284）の共通基盤上に乗る。

## 変更
- `src/components/ui/ArticleHeader/ArticleHeader.tsx` 新設 = breadcrumb + H1 + **description リード** + byline を集約。
- `docs/[...slug]/page.tsx` のカード冒頭（散在していた breadcrumb / H1 / byline）を ArticleHeader に置換。`generateHeadingId` 参照も移管。
- 記事冒頭で「どの試験・どの分類・何を解決するか」をファーストビューで判断できるよう、frontmatter `description` を H1 直下の 1 文リードとして surface。category/group は breadcrumb、updated は byline が担うため重複メタチップは置かない。

## 検証
- `npm run type-check` ✓ / `npm run lint` ✓
- guide・pillar ページ目視（リードは本文 intro と別内容＝重複なし）

## Phase 1 のうち未実施分（現物確認による方針変更）
記事末フッター（ArticleFooter）と右サイドバーは、現物確認の結果 **既に自己完結した MetaCard の積層（各ブロックが固有見出し＋自己非表示を持つ）** で、note 教材ブロックは方針として画像オンリー。提案の「区画化（セクション見出し追加）」は既存見出しの重複・空罫線・画像オンリー方針違反になるため見送り。サイドバーの並びも収益ピクセル/E-E-A-T の意図的順序のため変更せず。詳細はレビュー時に相談。

🤖 Generated with [Claude Code](https://claude.com/claude-code)