### PR TITLE
design: Phase 2 Category + Search (token化 + 検索ゼロステート)

### DIFF
--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -144,7 +144,7 @@ export default async function CategoryPage({
           )}
           {docs.length === 0 ? (
             <div className="text-center py-12">
-              <p className="text-gray-500 text-lg">
+              <p className="text-[var(--ink-muted)] text-lg">
                 このカテゴリにはまだコンテンツがありません。
               </p>
             </div>

--- a/src/app/search/SearchPageClient.tsx
+++ b/src/app/search/SearchPageClient.tsx
@@ -7,8 +7,16 @@ import { SearchBox } from "@/components/search/SearchBox";
 import { SearchResults } from "@/components/search/SearchResults";
 import { SearchFilters } from "@/components/search/SearchFilters";
 import { SearchPagination } from "@/components/search/SearchPagination";
+import { SearchZeroState } from "@/components/search/SearchZeroState";
+import { type CategoryDef } from "@/lib/categories";
+import { type PopularDoc } from "@/lib/popular";
 
-export default function SearchPageClient() {
+interface SearchPageClientProps {
+  categories: CategoryDef[];
+  popular: PopularDoc[];
+}
+
+export default function SearchPageClient({ categories, popular }: SearchPageClientProps) {
   const searchParams = useSearchParams();
   const {
     query,
@@ -69,20 +77,26 @@ export default function SearchPageClient() {
         </div>
       )}
 
-      <SearchResults
-        results={results}
-        isLoading={isLoading}
-        error={error}
-        query={query}
-      />
+      {query.trim() ? (
+        <>
+          <SearchResults
+            results={results}
+            isLoading={isLoading}
+            error={error}
+            query={query}
+          />
 
-      {/* ページネーション */}
-      {results.totalPages > 1 && (
-        <SearchPagination
-          currentPage={results.page}
-          totalPages={results.totalPages}
-          onPageChange={changePage}
-        />
+          {/* ページネーション */}
+          {results.totalPages > 1 && (
+            <SearchPagination
+              currentPage={results.page}
+              totalPages={results.totalPages}
+              onPageChange={changePage}
+            />
+          )}
+        </>
+      ) : (
+        <SearchZeroState categories={categories} popular={popular} />
       )}
     </>
   );

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,9 +1,17 @@
 import { Suspense } from "react";
 import PageShell from "@/components/layout/PageShell";
 import PageHeader from "@/components/layout/PageHeader";
+import { getAllCategories } from "@/lib/categories";
+import { getAllDocsMeta } from "@/lib/docs";
+import { getPopularDocs } from "@/lib/popular";
 import SearchPageClient from "./SearchPageClient";
 
 export default function SearchPage() {
+  // ゼロステート（検索語未入力時）の回遊導線用データを server で用意。
+  // 試験別入口 = 全カテゴリ、よく読まれている記事 = GA4 上位（データ無しは graceful 非表示）。
+  const categories = getAllCategories();
+  const popular = getPopularDocs(getAllDocsMeta(), 6);
+
   return (
     <PageShell variant="content" rail="860">
       <PageHeader
@@ -19,7 +27,7 @@ export default function SearchPage() {
           <p className="font-mono text-[12px] text-[var(--ink-muted)]">Loading…</p>
         }
       >
-        <SearchPageClient />
+        <SearchPageClient categories={categories} popular={popular} />
       </Suspense>
     </PageShell>
   );

--- a/src/components/category/CategorySections.tsx
+++ b/src/components/category/CategorySections.tsx
@@ -95,12 +95,12 @@ function PrimaryExamTable2({ docs, secondaryDocs = [] }: { docs: DocMeta[]; seco
     <div className="overflow-x-auto">
       <table className="w-full text-base border-collapse">
         <thead>
-          <tr className="border-b-2 border-gray-200 dark:border-gray-700">
-            <th className="text-left py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">年度</th>
-            <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">第1次 前期（6月）</th>
-            <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">第1次 後期（10月）</th>
+          <tr className="border-b-2 border-[var(--rule-soft)]">
+            <th className="text-left py-3 px-4 font-semibold text-[var(--ink-body)]">年度</th>
+            <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">第1次 前期（6月）</th>
+            <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">第1次 後期（10月）</th>
             {hasSecondary && (
-              <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">第2次検定</th>
+              <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">第2次検定</th>
             )}
           </tr>
         </thead>
@@ -109,29 +109,29 @@ function PrimaryExamTable2({ docs, secondaryDocs = [] }: { docs: DocMeta[]; seco
             const pair = yearMap.get(yearCode)!;
             const secondary = secondaryMap.get(yearCode);
             return (
-              <tr key={yearCode} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                <td className="py-3 px-4 font-medium text-gray-900 dark:text-gray-100">{yearLabel(yearCode)}</td>
+              <tr key={yearCode} className="border-b border-[var(--rule-soft)] hover:bg-[var(--accent-fill)] transition-colors">
+                <td className="py-3 px-4 font-medium text-[var(--ink)]">{yearLabel(yearCode)}</td>
                 <td className="py-3 px-4 text-center">
                   {pair.zenki ? (
-                    <Link href={`/docs/${pair.zenki.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                    <Link href={`/docs/${pair.zenki.slug}`} className="text-[var(--accent)] hover:underline">
                       前期
                     </Link>
-                  ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                  ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                 </td>
                 <td className="py-3 px-4 text-center">
                   {pair.kouki ? (
-                    <Link href={`/docs/${pair.kouki.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                    <Link href={`/docs/${pair.kouki.slug}`} className="text-[var(--accent)] hover:underline">
                       後期
                     </Link>
-                  ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                  ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                 </td>
                 {hasSecondary && (
                   <td className="py-3 px-4 text-center">
                     {secondary ? (
-                      <Link href={`/docs/${secondary.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                      <Link href={`/docs/${secondary.slug}`} className="text-[var(--accent)] hover:underline">
                         第2次
                       </Link>
-                    ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                    ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                   </td>
                 )}
               </tr>
@@ -183,12 +183,12 @@ function PrimaryExamTable({ docs, secondaryDocs = [] }: { docs: DocMeta[]; secon
     <div className="overflow-x-auto">
       <table className="w-full text-base border-collapse">
         <thead>
-          <tr className="border-b-2 border-gray-200 dark:border-gray-700">
-            <th className="text-left py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">年度</th>
-            <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">第1次 問題A</th>
-            <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">第1次 問題B</th>
+          <tr className="border-b-2 border-[var(--rule-soft)]">
+            <th className="text-left py-3 px-4 font-semibold text-[var(--ink-body)]">年度</th>
+            <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">第1次 問題A</th>
+            <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">第1次 問題B</th>
             {hasSecondary && (
-              <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">第2次検定</th>
+              <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">第2次検定</th>
             )}
           </tr>
         </thead>
@@ -197,29 +197,29 @@ function PrimaryExamTable({ docs, secondaryDocs = [] }: { docs: DocMeta[]; secon
             const pair = yearMap.get(yearCode)!;
             const secondary = secondaryMap.get(yearCode);
             return (
-              <tr key={yearCode} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                <td className="py-3 px-4 font-medium text-gray-900 dark:text-gray-100">{yearLabel(yearCode)}</td>
+              <tr key={yearCode} className="border-b border-[var(--rule-soft)] hover:bg-[var(--accent-fill)] transition-colors">
+                <td className="py-3 px-4 font-medium text-[var(--ink)]">{yearLabel(yearCode)}</td>
                 <td className="py-3 px-4 text-center">
                   {pair.a ? (
-                    <Link href={`/docs/${pair.a.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                    <Link href={`/docs/${pair.a.slug}`} className="text-[var(--accent)] hover:underline">
                       問題A
                     </Link>
-                  ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                  ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                 </td>
                 <td className="py-3 px-4 text-center">
                   {pair.b ? (
-                    <Link href={`/docs/${pair.b.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                    <Link href={`/docs/${pair.b.slug}`} className="text-[var(--accent)] hover:underline">
                       問題B
                     </Link>
-                  ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                  ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                 </td>
                 {hasSecondary && (
                   <td className="py-3 px-4 text-center">
                     {secondary ? (
-                      <Link href={`/docs/${secondary.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                      <Link href={`/docs/${secondary.slug}`} className="text-[var(--accent)] hover:underline">
                         第2次
                       </Link>
-                    ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                    ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                   </td>
                 )}
               </tr>
@@ -260,10 +260,10 @@ function PeExamTable({ docs }: { docs: DocMeta[] }) {
     <div className="overflow-x-auto">
       <table className="w-full text-base border-collapse">
         <thead>
-          <tr className="border-b-2 border-gray-200 dark:border-gray-700">
-            <th className="text-left py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">年度</th>
-            <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">択一式</th>
-            <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">記述式</th>
+          <tr className="border-b-2 border-[var(--rule-soft)]">
+            <th className="text-left py-3 px-4 font-semibold text-[var(--ink-body)]">年度</th>
+            <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">択一式</th>
+            <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">記述式</th>
           </tr>
         </thead>
         <tbody>
@@ -275,21 +275,21 @@ function PeExamTable({ docs }: { docs: DocMeta[] }) {
               ? (yearNum === 1 ? '令和元年度' : `令和${yearNum}年度`)
               : `平成${yearNum}年度`;
             return (
-              <tr key={yearCode} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                <td className="py-3 px-4 font-medium text-gray-900 dark:text-gray-100">{label}</td>
+              <tr key={yearCode} className="border-b border-[var(--rule-soft)] hover:bg-[var(--accent-fill)] transition-colors">
+                <td className="py-3 px-4 font-medium text-[var(--ink)]">{label}</td>
                 <td className="py-3 px-4 text-center">
                   {pair.primary ? (
-                    <Link href={`/docs/${pair.primary.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                    <Link href={`/docs/${pair.primary.slug}`} className="text-[var(--accent)] hover:underline">
                       択一式
                     </Link>
-                  ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                  ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                 </td>
                 <td className="py-3 px-4 text-center">
                   {pair.secondary ? (
-                    <Link href={`/docs/${pair.secondary.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                    <Link href={`/docs/${pair.secondary.slug}`} className="text-[var(--accent)] hover:underline">
                       記述式
                     </Link>
-                  ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                  ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                 </td>
               </tr>
             );
@@ -325,39 +325,39 @@ function PeFirstStageExamTable({ docs }: { docs: DocMeta[] }) {
     <div className="overflow-x-auto">
       <table className="w-full text-base border-collapse">
         <thead>
-          <tr className="border-b-2 border-gray-200 dark:border-gray-700">
-            <th className="text-left py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">年度</th>
-            <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">適性科目</th>
-            <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">基礎科目</th>
-            <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">専門科目（建設）</th>
+          <tr className="border-b-2 border-[var(--rule-soft)]">
+            <th className="text-left py-3 px-4 font-semibold text-[var(--ink-body)]">年度</th>
+            <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">適性科目</th>
+            <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">基礎科目</th>
+            <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">専門科目（建設）</th>
           </tr>
         </thead>
         <tbody>
           {years.map(yearCode => {
             const row = yearMap.get(yearCode)!;
             return (
-              <tr key={yearCode} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                <td className="py-3 px-4 font-medium text-gray-900 dark:text-gray-100">{yearLabel(yearCode)}</td>
+              <tr key={yearCode} className="border-b border-[var(--rule-soft)] hover:bg-[var(--accent-fill)] transition-colors">
+                <td className="py-3 px-4 font-medium text-[var(--ink)]">{yearLabel(yearCode)}</td>
                 <td className="py-3 px-4 text-center">
                   {row.aptitude ? (
-                    <Link href={`/docs/${row.aptitude.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                    <Link href={`/docs/${row.aptitude.slug}`} className="text-[var(--accent)] hover:underline">
                       適性科目
                     </Link>
-                  ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                  ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                 </td>
                 <td className="py-3 px-4 text-center">
                   {row.basic ? (
-                    <Link href={`/docs/${row.basic.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                    <Link href={`/docs/${row.basic.slug}`} className="text-[var(--accent)] hover:underline">
                       基礎科目
                     </Link>
-                  ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                  ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                 </td>
                 <td className="py-3 px-4 text-center">
                   {row.construction ? (
-                    <Link href={`/docs/${row.construction.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">
+                    <Link href={`/docs/${row.construction.slug}`} className="text-[var(--accent)] hover:underline">
                       専門科目
                     </Link>
-                  ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                  ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                 </td>
               </tr>
             );
@@ -419,8 +419,8 @@ function PeConstructionExamTable({ docs }: { docs: DocMeta[] }) {
         {rows.map(subject => {
           const yearMap = map.get(subject.key)!;
           return (
-            <div key={subject.key} className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-              <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-3">{subject.label}</h4>
+            <div key={subject.key} className="rounded-card-content border border-[var(--rule-soft)] p-4">
+              <h4 className="font-semibold text-[var(--ink)] mb-3">{subject.label}</h4>
               <div className="flex flex-wrap gap-2">
                 {years.map(y => {
                   const doc = yearMap.get(y);
@@ -428,7 +428,7 @@ function PeConstructionExamTable({ docs }: { docs: DocMeta[] }) {
                     <Link
                       key={y}
                       href={`/docs/${doc.slug}`}
-                      className="inline-flex items-center rounded-md border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 px-3 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors"
+                      className="inline-flex items-center rounded-card-inline border border-[var(--rule-soft)] bg-[var(--accent-fill)] px-3 py-2 text-sm font-medium text-[var(--accent)] hover:border-[var(--accent)] transition-colors"
                     >
                       {colLabel(y)}
                     </Link>
@@ -443,10 +443,10 @@ function PeConstructionExamTable({ docs }: { docs: DocMeta[] }) {
       <div className="hidden zenn-desktop:block overflow-x-auto">
         <table className="w-full text-base border-collapse">
           <thead>
-            <tr className="border-b-2 border-gray-200 dark:border-gray-700">
-              <th className="text-left py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">科目</th>
+            <tr className="border-b-2 border-[var(--rule-soft)]">
+              <th className="text-left py-3 px-4 font-semibold text-[var(--ink-body)]">科目</th>
               {years.map(y => (
-                <th key={y} className="text-center py-3 px-3 font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">{colLabel(y)}</th>
+                <th key={y} className="text-center py-3 px-3 font-semibold text-[var(--ink-body)] whitespace-nowrap">{colLabel(y)}</th>
               ))}
             </tr>
           </thead>
@@ -454,15 +454,15 @@ function PeConstructionExamTable({ docs }: { docs: DocMeta[] }) {
             {rows.map(subject => {
               const yearMap = map.get(subject.key)!;
               return (
-                <tr key={subject.key} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-                  <td className="py-3 px-4 font-medium text-gray-900 dark:text-gray-100">{subject.label}</td>
+                <tr key={subject.key} className="border-b border-[var(--rule-soft)] hover:bg-[var(--accent-fill)] transition-colors">
+                  <td className="py-3 px-4 font-medium text-[var(--ink)]">{subject.label}</td>
                   {years.map(y => {
                     const doc = yearMap.get(y);
                     return (
                       <td key={y} className="py-3 px-3 text-center">
                         {doc ? (
-                          <Link href={`/docs/${doc.slug}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline">問題</Link>
-                        ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                          <Link href={`/docs/${doc.slug}`} className="text-[var(--accent)] hover:underline">問題</Link>
+                        ) : <span className="text-[var(--ink-muted)] opacity-50">—</span>}
                       </td>
                     );
                   })}

--- a/src/components/category/CategoryViews.tsx
+++ b/src/components/category/CategoryViews.tsx
@@ -44,14 +44,16 @@ export function CivilConstruction1View({ groups, mobileCareerAd }: { groups: Doc
       {textbookGroup && (
         <section>
           <div className="mb-6">
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{textbookGroup.title}</h2>
-            <p className="text-base text-gray-500 dark:text-gray-400 mt-1">{textbookGroup.description}</p>
-            <span className="text-sm text-gray-400 dark:text-gray-500">{textbookGroup.docs.length} 件</span>
+            <div className="flex items-baseline justify-between gap-2 flex-wrap">
+              <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">{textbookGroup.title}</h2>
+              <span className="font-mono text-[11px] text-[var(--ink-muted)]">{textbookGroup.docs.length} docs</span>
+            </div>
+            <p className="text-[14px] text-[var(--ink-muted)] mt-1">{textbookGroup.description}</p>
           </div>
           <div className="space-y-8">
             {textbookAreas.map(area => (
               <div key={area.label}>
-                <h3 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-3 border-b border-gray-200 dark:border-gray-700 pb-2">{area.label}</h3>
+                <h3 className="font-serif text-lg font-bold text-[var(--ink)] mb-3 border-b border-[var(--rule-soft)] pb-2">{area.label}</h3>
                 <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                   {area.docs.map(doc => (
                     <DocCard key={doc.slug} doc={doc} />
@@ -171,20 +173,20 @@ export function PeComprehensiveView({ groups, mobileCareerAd }: { groups: DocGro
           </div>
           <Link
             href="/sitemap-keywords"
-            className="group flex items-center gap-4 p-5 rounded-card-content border-2 border-blue-200 dark:border-blue-800 bg-blue-50/50 dark:bg-blue-900/20 hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-card-hover transition-all"
+            className="group flex items-center gap-4 p-5 rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] hover:border-[var(--accent)] hover:shadow-card-hover transition-all"
           >
-            <div className="flex-shrink-0 w-10 h-10 rounded-sm bg-blue-600 dark:bg-blue-500 flex items-center justify-center text-white font-bold text-lg">
+            <div className="flex-shrink-0 w-10 h-10 rounded-sm bg-[var(--accent)] flex items-center justify-center text-white font-bold text-lg">
               ≡
             </div>
             <div className="flex-1">
-              <div className="font-bold text-lg text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400">
+              <div className="font-bold text-lg text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors">
                 キーワードを全件見る（{keywordCount} 件）
               </div>
-              <div className="text-sm text-gray-500 dark:text-gray-400">
+              <div className="text-sm text-[var(--ink-muted)]">
                 文部科学省「総合技術監理 キーワード集 2026」に基づくセクション別索引へ
               </div>
             </div>
-            <span className="text-blue-600 dark:text-blue-400 group-hover:translate-x-1 transition-transform" aria-hidden>›</span>
+            <span className="text-[var(--accent)] group-hover:translate-x-1 transition-transform" aria-hidden>›</span>
           </Link>
         </section>
       )}

--- a/src/components/search/SearchBox.tsx
+++ b/src/components/search/SearchBox.tsx
@@ -119,7 +119,7 @@ export function SearchBox({
           )}
         >
           <svg
-            className={cn("text-gray-400", compact ? "h-4 w-4" : "h-5 w-5")}
+            className={cn("text-[var(--ink-muted)]", compact ? "h-4 w-4" : "h-5 w-5")}
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -146,10 +146,9 @@ export function SearchBox({
           onBlur={onBlur}
           placeholder={placeholder}
           className={cn(
-            "block w-full border border-gray-300 rounded-sm",
-            "focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
-            "dark:bg-gray-700 dark:border-gray-600 dark:text-white",
-            "dark:focus:ring-primary-400 dark:focus:border-primary-400",
+            "block w-full bg-[var(--paper)] text-[var(--ink)] border border-[var(--rule-soft)] rounded-card-content",
+            "focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:border-[var(--accent)]",
+            "placeholder:text-[var(--ink-muted)]",
             "transition-colors duration-200",
             compact ? "pl-8 pr-8 py-2 text-sm" : "pl-10 pr-10 py-2"
           )}
@@ -165,7 +164,7 @@ export function SearchBox({
           >
             <svg
               className={cn(
-                "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors",
+                "text-[var(--ink-muted)] hover:text-[var(--ink)] transition-colors",
                 compact ? "h-4 w-4" : "h-5 w-5"
               )}
               fill="none"
@@ -187,7 +186,7 @@ export function SearchBox({
       {showSuggestions && suggestions.length > 0 && (
         <div
           ref={suggestionsRef}
-          className="absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-sm shadow-lg"
+          className="absolute z-50 w-full mt-1 bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-content shadow-lift"
         >
           <ul className="py-1">
             {suggestions.map((suggestion, index) => (
@@ -195,15 +194,15 @@ export function SearchBox({
                 <button
                   onClick={() => handleSuggestionClick(suggestion)}
                   className={cn(
-                    "w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300",
-                    "hover:bg-gray-100 dark:hover:bg-gray-700",
-                    "focus:bg-gray-100 dark:focus:bg-gray-700 focus:outline-none",
+                    "w-full px-4 py-2 text-left text-sm text-[var(--ink-body)]",
+                    "hover:bg-[var(--accent-fill)] hover:text-[var(--accent)]",
+                    "focus:bg-[var(--accent-fill)] focus:outline-none",
                     "transition-colors duration-150"
                   )}
                 >
                   <div className="flex items-center">
                     <svg
-                      className="h-4 w-4 text-gray-400 mr-2"
+                      className="h-4 w-4 text-[var(--ink-muted)] mr-2"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"

--- a/src/components/search/SearchFilters.tsx
+++ b/src/components/search/SearchFilters.tsx
@@ -28,8 +28,8 @@ export function SearchFilters({
         className={cn(
           "px-3 py-1.5 text-sm rounded-full border transition-colors",
           !category
-            ? "bg-primary-500 text-white border-primary-500"
-            : "bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600"
+            ? "bg-[var(--accent)] text-white border-[var(--accent)]"
+            : "bg-[var(--paper)] text-[var(--ink-body)] border-[var(--rule-soft)] hover:bg-[var(--accent-fill)] hover:text-[var(--accent)]"
         )}
       >
         すべて
@@ -41,8 +41,8 @@ export function SearchFilters({
           className={cn(
             "px-3 py-1.5 text-sm rounded-full border transition-colors",
             category === cat.value
-              ? "bg-primary-500 text-white border-primary-500"
-              : "bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600"
+              ? "bg-[var(--accent)] text-white border-[var(--accent)]"
+              : "bg-[var(--paper)] text-[var(--ink-body)] border-[var(--rule-soft)] hover:bg-[var(--accent-fill)] hover:text-[var(--accent)]"
           )}
         >
           {cat.label}
@@ -51,7 +51,7 @@ export function SearchFilters({
       {category && (
         <button
           onClick={onReset}
-          className="px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          className="px-3 py-1.5 text-sm text-[var(--ink-muted)] hover:text-[var(--ink)] transition-colors"
         >
           リセット
         </button>

--- a/src/components/search/SearchPagination.tsx
+++ b/src/components/search/SearchPagination.tsx
@@ -8,6 +8,12 @@ interface SearchPaginationProps {
   onPageChange: (page: number) => void;
 }
 
+const BTN_BASE = "px-3 py-2 text-sm font-medium rounded-card-inline border transition-colors";
+const BTN_INACTIVE =
+  "text-[var(--ink-body)] border-[var(--rule-soft)] hover:bg-[var(--accent-fill)] hover:text-[var(--accent)]";
+const BTN_ACTIVE = "bg-[var(--accent)] text-white border-[var(--accent)]";
+const BTN_DISABLED = "text-[var(--ink-muted)] opacity-50 border-[var(--rule-soft)] cursor-not-allowed";
+
 export function SearchPagination({
   currentPage,
   totalPages,
@@ -52,12 +58,7 @@ export function SearchPagination({
       <button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
-        className={cn(
-          "px-3 py-2 text-sm font-medium rounded-sm border transition-colors",
-          currentPage === 1
-            ? "text-gray-400 dark:text-gray-600 border-gray-200 dark:border-gray-700 cursor-not-allowed"
-            : "text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-        )}
+        className={cn(BTN_BASE, currentPage === 1 ? BTN_DISABLED : BTN_INACTIVE)}
       >
         前へ
       </button>
@@ -65,16 +66,11 @@ export function SearchPagination({
       {/* 最初のページ */}
       {pageNumbers[0] && pageNumbers[0] > 1 && (
         <>
-          <button
-            onClick={() => onPageChange(1)}
-            className="px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-sm hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white transition-colors"
-          >
+          <button onClick={() => onPageChange(1)} className={cn(BTN_BASE, BTN_INACTIVE)}>
             1
           </button>
           {pageNumbers[0] && pageNumbers[0] > 2 && (
-            <span className="px-2 py-2 text-gray-500 dark:text-gray-400">
-              ...
-            </span>
+            <span className="px-2 py-2 text-[var(--ink-muted)]">...</span>
           )}
         </>
       )}
@@ -84,12 +80,7 @@ export function SearchPagination({
         <button
           key={page}
           onClick={() => onPageChange(page)}
-          className={cn(
-            "px-3 py-2 text-sm font-medium rounded-sm border transition-colors",
-            page === currentPage
-                              ? "bg-primary-500 text-white border-primary-500"
-              : "text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-          )}
+          className={cn(BTN_BASE, page === currentPage ? BTN_ACTIVE : BTN_INACTIVE)}
         >
           {page}
         </button>
@@ -101,14 +92,9 @@ export function SearchPagination({
         return lastPage && lastPage < totalPages ? (
           <>
             {lastPage < totalPages - 1 && (
-              <span className="px-2 py-2 text-gray-500 dark:text-gray-400">
-                ...
-              </span>
+              <span className="px-2 py-2 text-[var(--ink-muted)]">...</span>
             )}
-            <button
-              onClick={() => onPageChange(totalPages)}
-              className="px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-sm hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white transition-colors"
-            >
+            <button onClick={() => onPageChange(totalPages)} className={cn(BTN_BASE, BTN_INACTIVE)}>
               {totalPages}
             </button>
           </>
@@ -119,12 +105,7 @@ export function SearchPagination({
       <button
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
-        className={cn(
-          "px-3 py-2 text-sm font-medium rounded-sm border transition-colors",
-          currentPage === totalPages
-            ? "text-gray-400 dark:text-gray-600 border-gray-200 dark:border-gray-700 cursor-not-allowed"
-            : "text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
-        )}
+        className={cn(BTN_BASE, currentPage === totalPages ? BTN_DISABLED : BTN_INACTIVE)}
       >
         次へ
       </button>

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -19,7 +19,7 @@ export function SearchResults({
   if (isLoading) {
     return (
       <div className="flex justify-center items-center py-12">
-        <div className="animate-spin rounded-sm h-8 w-8 border-b-2 border-primary-500"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--accent)]"></div>
       </div>
     );
   }
@@ -32,7 +32,7 @@ export function SearchResults({
         </p>
         <button
           onClick={() => window.location.reload()}
-          className="px-4 py-2 bg-primary-500 text-white rounded-sm hover:bg-primary-600 transition-colors"
+          className="px-4 py-2 bg-[var(--accent)] text-white rounded-card-content hover:opacity-90 transition-opacity"
         >
           再試行
         </button>
@@ -43,7 +43,7 @@ export function SearchResults({
   if (!query.trim()) {
     return (
       <div className="text-center py-12">
-        <p className="text-gray-600 dark:text-gray-400">
+        <p className="text-[var(--ink-muted)]">
           キーワードを入力して検索してください
         </p>
       </div>
@@ -53,10 +53,10 @@ export function SearchResults({
   if (results.posts.length === 0) {
     return (
       <div className="text-center py-12">
-        <p className="text-gray-600 dark:text-gray-400 mb-2">
+        <p className="text-[var(--ink-body)] mb-2">
           「{query}」に一致する記事が見つかりませんでした
         </p>
-        <p className="text-sm text-gray-500 dark:text-gray-500">
+        <p className="text-sm text-[var(--ink-muted)]">
           別のキーワードで検索してみてください
         </p>
       </div>
@@ -66,25 +66,25 @@ export function SearchResults({
   return (
     <div className="space-y-6">
       <div className="mb-4">
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+        <p className="text-sm text-[var(--ink-muted)]">
           「{query}」の検索結果: {results.total}件
         </p>
       </div>
 
-      <div className="grid gap-6">
+      <div className="grid gap-4">
         {results.posts.map((post) => (
           <article
             key={post.id}
-            className="border border-gray-200 dark:border-gray-700 rounded-sm p-6 hover:shadow-md transition-shadow"
+            className="bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section shadow-soft p-6 hover:border-[var(--accent)] hover:shadow-card-hover transition-all"
           >
             <div className="flex-1 min-w-0">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2 hover:text-primary-600 dark:hover:text-primary-400">
+              <h3 className="text-lg font-bold text-[var(--ink)] mb-2 hover:text-[var(--accent)] transition-colors">
                 <Link href={post.path}>{post.title}</Link>
               </h3>
 
               {post.excerpt && (
                 <p
-                  className="text-gray-600 dark:text-gray-400 text-sm mb-3 line-clamp-2 [&_mark]:bg-yellow-200 [&_mark]:dark:bg-yellow-800/60 [&_mark]:rounded-sm [&_mark]:px-0.5"
+                  className="text-[var(--ink-body)] text-sm mb-3 line-clamp-2 leading-relaxed [&_mark]:bg-yellow-200 [&_mark]:dark:bg-yellow-800/60 [&_mark]:rounded-sm [&_mark]:px-0.5"
                   dangerouslySetInnerHTML={{ __html: post.excerpt }}
                 />
               )}
@@ -94,9 +94,9 @@ export function SearchResults({
                   {post.tags.slice(0, 4).map((tag) => (
                     <span
                       key={tag}
-                      className="px-2 py-1 text-xs bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300 rounded-sm"
+                      className="font-mono text-[11px] text-[var(--accent)] bg-[var(--accent-fill)] px-2.5 py-0.5 rounded-full"
                     >
-                      {tag}
+                      #{tag}
                     </span>
                   ))}
                 </div>

--- a/src/components/search/SearchZeroState.tsx
+++ b/src/components/search/SearchZeroState.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { type CategoryDef } from "@/lib/categories";
+import { type PopularDoc } from "@/lib/popular";
+
+interface SearchZeroStateProps {
+  categories: CategoryDef[];
+  popular: PopularDoc[];
+}
+
+/**
+ * 検索クエリ未入力時のゼロステート。空のプレースホルダ文だけで終わらせず、
+ * 「試験から探す」(全資格カテゴリ) と「よく読まれている記事」(GA4 上位) の 2 導線を提示して
+ * 検索語を思いつかないユーザーを回遊させる。popular はデータ無しなら graceful 非表示。
+ */
+export function SearchZeroState({ categories, popular }: SearchZeroStateProps) {
+  return (
+    <div className="space-y-10">
+      <section>
+        <h2 className="font-serif text-lg font-bold text-[var(--ink)] mb-1">試験から探す</h2>
+        <p className="text-sm text-[var(--ink-muted)] mb-4">資格ごとのまとめページへ</p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {categories.map((cat) => (
+            <Link
+              key={cat.slug}
+              href={`/category/${cat.slug}`}
+              className="group flex flex-col gap-1 rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] p-4 hover:border-[var(--accent)] hover:shadow-soft transition-all"
+            >
+              <span className="font-serif font-bold text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors">
+                {cat.label}
+              </span>
+              <span className="text-sm text-[var(--ink-muted)] line-clamp-1">{cat.subtitle}</span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {popular.length > 0 && (
+        <section>
+          <h2 className="font-serif text-lg font-bold text-[var(--ink)] mb-1">よく読まれている記事</h2>
+          <p className="text-sm text-[var(--ink-muted)] mb-4">アクセスの多い記事から</p>
+          <ol className="rounded-card-content border border-[var(--rule-soft)] overflow-hidden">
+            {popular.map((item) => (
+              <li key={item.doc.slug}>
+                <Link
+                  href={`/docs/${item.doc.slug}`}
+                  className="group flex gap-3 px-4 py-3 border-b border-[var(--rule-soft)] last:border-b-0 hover:bg-[var(--accent-fill)] transition-colors"
+                >
+                  <span className="shrink-0 w-6 h-6 flex items-center justify-center font-mono text-xs font-bold text-[var(--accent)] bg-[var(--accent-fill)] rounded-sm">
+                    {item.rank}
+                  </span>
+                  <span className="font-serif text-[14px] font-bold leading-tight text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors line-clamp-2">
+                    {item.doc.shortTitle || item.doc.title}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

デザイン改善ロードマップ **Phase 2**（Category + Search）。Phase 0(共通PageShell, #284)・Phase 1(ArticleHeader, #285) の上に積む stacked PR。

実装プラン: `docs/design-system/proposals/2026-06-27-*` の実行版。

## 変更

### 2a 検索コンポーネント token 化（既 push 分）
- `SearchResults` / `SearchBox` / `SearchFilters` / `SearchPagination` を editorial token へ統一。結果カードを editorial 化。意味色(error red / mark yellow)は保持。

### 2b カテゴリ token 化 + 検索ゼロステート（本コミット）
- **CategorySections.tsx**: 5 過去問テーブル（択一 / 前後期 / PE択一記述 / 一次マトリクス / 建設科目×年度）の `gray/blue` 直指定を token へ（`border-gray`→`rule-soft`, `text-blue`リンク→`accent`, hover→`accent-fill`, 欠落セル→`ink-muted`）。`DocCard`/`DocSection` は移行済。
- **CategoryViews.tsx**: textbook セクション見出しを `DocSection` 文法へ統一、キーワード索引 CTA を 2色 blue カード → editorial accent カードへ。
- **category/[slug]/page.tsx**: 空カテゴリ fallback の `gray-500` を `ink-muted` へ。
- **検索ゼロステート新設（SearchZeroState）**: 検索語未入力時に「試験から探す」(全カテゴリ) +「よく読まれている記事」(GA4 上位6) の回遊導線を提示。server(`page.tsx`)で `getAllCategories`/`getPopularDocs` を取得し client へ配線。

## 判断（現物確認に基づく scope）
- **カテゴリの Header/Content/Sidebar 分割は見送り**: 単一利用箇所かつ既に token clean で、ArticleHeader と違い再利用先が無く churn のみ（§2）。
- **「人気記事＝はじめに読む」差別化は実装済み**: `PopularShowcase`（lead カード + ランクバッジ + 専用見出し）が既にこの役割（§8 現物確認）。
- **「人気キーワード」専用リストは作らず**「よく読まれている記事」(キーワードページ含む)に集約（人気度の真実源が無いため捏造回避・§8）。
- 残る `border-gray-*` はサイドバー chrome（MetaCard 系・別トラック）由来で Phase 2 スコープ外。

## 検証
- `npm run type-check` / `npm run lint` クリーン。
- dev smoke（webpack）: `/search`・`/category/pe-comprehensive-management`・`/category/civil-construction-1` で HTTP 200・`<main>` 1個・breadcrumb・token テーブル描画（`border-[var(--rule-soft)]` 404箇所）を確認。
- pre-commit / pre-push 全ゲート通過。

Vercel check は stale 統合（本番=Cloudflare・GH Actions build=pass）のため無視可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)