### PR TITLE
design: Phase 3 /links を PageShell へ統合

### DIFF
--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -1,5 +1,4 @@
-import Header from "@/components/layout/Header";
-import Footer from "@/components/layout/Footer";
+import PageShell from "@/components/layout/PageShell";
 import Link from "next/link";
 import {
   ExternalLink,
@@ -415,10 +414,7 @@ export default function LinksPage() {
   const chips = HERO_CHIPS.filter((c) => sectionHasContent(byExam, c.key));
 
   return (
-    <div className="min-h-screen flex flex-col bg-[var(--bg)] transition-colors duration-300">
-      <Header />
-
-      <main className="flex-grow py-10 sm:py-14">
+    <PageShell variant="default" className="py-10 sm:py-14">
         <div className="max-w-5xl mx-auto px-4 sm:px-6">
           {/* Hero band: アバター + 名乗り + キャッチ + 試験チップ（ジャンプ） */}
           <section className="mb-8 rounded-card-section border border-[var(--rule-soft)] bg-[var(--paper)] p-6 sm:p-8">
@@ -580,9 +576,6 @@ export default function LinksPage() {
             </div>
           </section>
         </div>
-      </main>
-
-      <Footer />
-    </div>
+    </PageShell>
   );
 }


### PR DESCRIPTION
## 概要

デザイン改善ロードマップ **Phase 3**（/links Exam Action Hub）。Phase 2(#286) の上に積む stacked PR。

## 現物確認に基づく scope（§8）

`/links` は **2026-06-26 改訂で既に Exam Action Hub** になっていた：
- 試験チップ付きヒーロー → 価値3本柱 → `ExamSections`（試験別パネル＝無料入口＋note教材＝**ExamActionGrid 相当**）→ `essay-complete-pack` の accent カード（**FeaturedProduct 相当**）→ 運営者+SNS（**SupportLinks 相当**）。

よって Plan が想定した「リンク集→Action Hub 化」の中身は実装済み。**残差は構造の唯一の holdout = PageShell 未使用** のみ。

## 変更
- `/links` を `PageShell variant="default"` へ移行。Header/Footer の直 import を撤去し chrome を集約（重複描画の余地を排除、全ページ統一の完了）。
- 内側コンテンツは不変。

## やらなかった判断
- **lucide-react 維持**: home/Hero・ExamCards・Callout・Header 等 20 ファイル共通の標準アイコン。/links だけ inline SVG 化は不整合・churn（§7）。Phase 0 の「Header nav に lucide 足さない」は局所方針でグローバル禁止ではない。
- **ヒーローの著者要素は維持**: /links は SNS bio の着地点（links-hub.md）で bio アイデンティティが適切。試験チップで exam-first 導線は既に確保。
- **UTM リネーム見送り**: utm_content 変更は分析継続性を壊す。Plan も「既存維持」方針。

## 検証
- `type-check` / `lint` クリーン、pre-commit/pre-push 全ゲート通過。
- dev smoke（webpack）: `/links` で HTTP200・`<main>` 1個・header/footer 各1（重複なし）・試験別パネル4・featured バッジ描画を確認。

Vercel check は stale 統合（本番=Cloudflare・GH Actions build=正）のため無視可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)