### PR TITLE
design: Phase 4+5 About/Legal token化 + 404 導線

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -69,29 +69,29 @@ export default function AboutPage() {
               alt={`${AUTHOR.name}のプロフィール画像`}
               width={120}
               height={120}
-              className="w-28 h-28 rounded-full border-2 border-primary-200 dark:border-primary-800 mx-auto sm:mx-0"
+              className="w-28 h-28 rounded-full border-2 border-[var(--rule-soft)] mx-auto sm:mx-0"
             />
             <div className="flex-1 min-w-0">
-              <h3 className="text-xl font-bold text-neutral-900 dark:text-gray-100">
+              <h3 className="text-xl font-bold text-[var(--ink)]">
                 {AUTHOR.name}
               </h3>
-              <p className="text-sm text-primary-600 dark:text-primary-400 mt-1">
+              <p className="text-sm text-[var(--accent)] mt-1">
                 {AUTHOR.jobTitle}
               </p>
-              <p className="mt-4 text-neutral-700 dark:text-gray-300 leading-relaxed">
+              <p className="mt-4 text-[var(--ink-body)] leading-relaxed">
                 {AUTHOR.bio}
               </p>
               <div className="mt-4">
-                <h4 className="text-sm font-bold text-neutral-700 dark:text-gray-300 mb-2">
+                <h4 className="text-sm font-bold text-[var(--ink-body)] mb-2">
                   保有資格
                 </h4>
                 <ul className="space-y-1">
                   {AUTHOR.qualifications.map((q) => (
                     <li
                       key={q}
-                      className="text-sm text-neutral-600 dark:text-gray-400 flex items-start gap-2"
+                      className="text-sm text-[var(--ink-muted)] flex items-start gap-2"
                     >
-                      <CheckCircle className="w-4 h-4 text-primary-600 dark:text-primary-400 mt-0.5 shrink-0" />
+                      <CheckCircle className="w-4 h-4 text-[var(--accent)] mt-0.5 shrink-0" />
                       <span>{q}</span>
                     </li>
                   ))}
@@ -99,11 +99,11 @@ export default function AboutPage() {
               </div>
             </div>
           </div>
-          <div className="mt-6 pt-6 border-t border-neutral-200 dark:border-gray-700">
-            <h4 className="text-sm font-bold text-neutral-700 dark:text-gray-300 mb-2">
+          <div className="mt-6 pt-6 border-t border-[var(--rule-soft)]">
+            <h4 className="text-sm font-bold text-[var(--ink-body)] mb-2">
               編集方針
             </h4>
-            <ul className="text-sm text-neutral-600 dark:text-gray-400 space-y-2">
+            <ul className="text-sm text-[var(--ink-muted)] space-y-2">
               <li>
                 ・出題範囲を体系的に整理し、実務での適用例を必ず併記する
               </li>
@@ -118,43 +118,43 @@ export default function AboutPage() {
               </li>
             </ul>
           </div>
-          <div className="mt-6 pt-6 border-t border-neutral-200 dark:border-gray-700">
-            <h4 className="text-sm font-bold text-neutral-700 dark:text-gray-300 mb-2">
+          <div className="mt-6 pt-6 border-t border-[var(--rule-soft)]">
+            <h4 className="text-sm font-bold text-[var(--ink-body)] mb-2">
               今後の展開
             </h4>
-            <p className="text-sm text-neutral-600 dark:text-gray-400 leading-relaxed">
+            <p className="text-sm text-[var(--ink-muted)] leading-relaxed">
               現在は<strong>1級土木施工管理技士</strong>・<strong>技術士（総合技術監理部門）</strong>を中心にコンテンツを整備していますが、運営者が取得してきた<strong>技術士（建設部門）・コンクリート主任技士・コンクリート診断士・1級舗装施工管理技術者・行政書士・応用情報技術者</strong>などの受験経験を活かし、土木・建設・法務・IT にまたがる多様な資格試験の対策コンテンツを順次展開していく予定です。
             </p>
           </div>
         </SectionCard>
       </SectionBlock>
 
-      {/* Mission Section（内部 palette は後続フェーズで token 化） */}
-      <section className="py-12 bg-white dark:bg-gray-800">
+      {/* Mission Section */}
+      <section className="py-12 bg-[var(--paper)] border-y border-[var(--rule-soft)]">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-2xl font-bold text-neutral-900 dark:text-gray-100 mb-6">
+          <h2 className="text-2xl font-bold text-[var(--ink)] mb-6">
             サイトコンセプト
           </h2>
-          <div className="bg-neutral-50 dark:bg-gray-800 border border-neutral-200 dark:border-gray-600 p-6">
-            <p className="text-xl font-bold text-primary-600 dark:text-primary-400 mb-4">
+          <div className="bg-[var(--bg)] border border-[var(--rule-soft)] rounded-card-content p-6">
+            <p className="text-xl font-bold text-[var(--accent)] mb-4">
               「ここだけで合格できる」体験を
             </p>
             <div className="space-y-3 text-left max-w-2xl mx-auto">
               <div className="flex items-start gap-2">
-                <CheckCircle className="w-5 h-5 text-primary-600 dark:text-primary-400 shrink-0 mt-1" />
-                <p className="text-neutral-700 dark:text-gray-300">
+                <CheckCircle className="w-5 h-5 text-[var(--accent)] shrink-0 mt-1" />
+                <p className="text-[var(--ink-body)]">
                   <strong>体系的</strong> → 試験範囲を網羅した技術解説
                 </p>
               </div>
               <div className="flex items-start gap-2">
-                <CheckCircle className="w-5 h-5 text-primary-600 dark:text-primary-400 shrink-0 mt-1" />
-                <p className="text-neutral-700 dark:text-gray-300">
+                <CheckCircle className="w-5 h-5 text-[var(--accent)] shrink-0 mt-1" />
+                <p className="text-[var(--ink-body)]">
                   <strong>実践的</strong> → 過去問の傾向分析と得点戦略
                 </p>
               </div>
               <div className="flex items-start gap-2">
-                <CheckCircle className="w-5 h-5 text-primary-600 dark:text-primary-400 shrink-0 mt-1" />
-                <p className="text-neutral-700 dark:text-gray-300">
+                <CheckCircle className="w-5 h-5 text-[var(--accent)] shrink-0 mt-1" />
+                <p className="text-[var(--ink-body)]">
                   <strong>効率的</strong> → 忙しい実務者でも合格できる学習法
                 </p>
               </div>
@@ -163,63 +163,63 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* Content Categories Section（内部 palette は後続フェーズで token 化） */}
-      <section className="py-16 bg-white dark:bg-gray-800">
+      {/* Content Categories Section */}
+      <section className="py-16 bg-[var(--paper)] border-y border-[var(--rule-soft)]">
         <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-bold text-neutral-900 dark:text-gray-100 text-center mb-2">
+          <h2 className="text-2xl font-bold text-[var(--ink)] text-center mb-2">
             対応試験
           </h2>
-          <p className="text-neutral-600 dark:text-gray-400 text-center mb-12">
+          <p className="text-[var(--ink-muted)] text-center mb-12">
             土木系の主要資格試験をカバー
           </p>
 
           <div className="grid lg:grid-cols-2 gap-8">
             {/* 1級土木施工管理技士 */}
             <div>
-              <h3 className="text-xl font-bold text-primary-600 dark:text-primary-400 text-center mb-6">
+              <h3 className="text-xl font-bold text-[var(--accent)] text-center mb-6">
                 1級土木施工管理技士
               </h3>
               <div className="space-y-4">
-                <div className="bg-neutral-50 dark:bg-gray-800 border border-neutral-200 dark:border-gray-600 p-4">
+                <div className="bg-[var(--bg)] border border-[var(--rule-soft)] rounded-card-content p-4">
                   <div className="flex items-center gap-4">
-                    <div className="bg-primary-600 dark:bg-primary-500 w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
+                    <div className="bg-[var(--accent)] w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
                       <BookOpen className="w-6 h-6 text-white" />
                     </div>
                     <div>
-                      <h4 className="font-bold text-neutral-900 dark:text-gray-100 mb-1">
+                      <h4 className="font-bold text-[var(--ink)] mb-1">
                         試験ガイド・勉強法
                       </h4>
-                      <p className="text-sm text-neutral-600 dark:text-gray-400">
+                      <p className="text-sm text-[var(--ink-muted)]">
                         出題傾向、得点戦略、学習スケジュール
                       </p>
                     </div>
                   </div>
                 </div>
-                <div className="bg-neutral-50 dark:bg-gray-800 border border-neutral-200 dark:border-gray-600 p-4">
+                <div className="bg-[var(--bg)] border border-[var(--rule-soft)] rounded-card-content p-4">
                   <div className="flex items-center gap-4">
-                    <div className="bg-primary-600 dark:bg-primary-500 w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
+                    <div className="bg-[var(--accent)] w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
                       <FileText className="w-6 h-6 text-white" />
                     </div>
                     <div>
-                      <h4 className="font-bold text-neutral-900 dark:text-gray-100 mb-1">
+                      <h4 className="font-bold text-[var(--ink)] mb-1">
                         過去問解説
                       </h4>
-                      <p className="text-sm text-neutral-600 dark:text-gray-400">
+                      <p className="text-sm text-[var(--ink-muted)]">
                         第1次・第2次検定の過去問を詳細解説
                       </p>
                     </div>
                   </div>
                 </div>
-                <div className="bg-neutral-50 dark:bg-gray-800 border border-neutral-200 dark:border-gray-600 p-4">
+                <div className="bg-[var(--bg)] border border-[var(--rule-soft)] rounded-card-content p-4">
                   <div className="flex items-center gap-4">
-                    <div className="bg-primary-600 dark:bg-primary-500 w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
+                    <div className="bg-[var(--accent)] w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
                       <GraduationCap className="w-6 h-6 text-white" />
                     </div>
                     <div>
-                      <h4 className="font-bold text-neutral-900 dark:text-gray-100 mb-1">
+                      <h4 className="font-bold text-[var(--ink)] mb-1">
                         技術解説
                       </h4>
-                      <p className="text-sm text-neutral-600 dark:text-gray-400">
+                      <p className="text-sm text-[var(--ink-muted)]">
                         土工・コンクリート・基礎工・施工管理
                       </p>
                     </div>
@@ -230,50 +230,50 @@ export default function AboutPage() {
 
             {/* 技術士 */}
             <div>
-              <h3 className="text-xl font-bold text-cyan-600 dark:text-cyan-400 text-center mb-6">
+              <h3 className="text-xl font-bold text-[var(--accent)] text-center mb-6">
                 技術士（総合技術監理部門）
               </h3>
               <div className="space-y-4">
-                <div className="bg-neutral-50 dark:bg-gray-800 border border-neutral-200 dark:border-gray-600 p-4">
+                <div className="bg-[var(--bg)] border border-[var(--rule-soft)] rounded-card-content p-4">
                   <div className="flex items-center gap-4">
-                    <div className="bg-cyan-600 dark:bg-cyan-500 w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
+                    <div className="bg-[var(--accent)] w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
                       <Target className="w-6 h-6 text-white" />
                     </div>
                     <div>
-                      <h4 className="font-bold text-neutral-900 dark:text-gray-100 mb-1">
+                      <h4 className="font-bold text-[var(--ink)] mb-1">
                         5つの管理分野
                       </h4>
-                      <p className="text-sm text-neutral-600 dark:text-gray-400">
+                      <p className="text-sm text-[var(--ink-muted)]">
                         経済性管理・人的資源管理・情報管理・安全管理・社会環境管理
                       </p>
                     </div>
                   </div>
                 </div>
-                <div className="bg-neutral-50 dark:bg-gray-800 border border-neutral-200 dark:border-gray-600 p-4">
+                <div className="bg-[var(--bg)] border border-[var(--rule-soft)] rounded-card-content p-4">
                   <div className="flex items-center gap-4">
-                    <div className="bg-cyan-600 dark:bg-cyan-500 w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
+                    <div className="bg-[var(--accent)] w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
                       <Search className="w-6 h-6 text-white" />
                     </div>
                     <div>
-                      <h4 className="font-bold text-neutral-900 dark:text-gray-100 mb-1">
+                      <h4 className="font-bold text-[var(--ink)] mb-1">
                         キーワード解説
                       </h4>
-                      <p className="text-sm text-neutral-600 dark:text-gray-400">
+                      <p className="text-sm text-[var(--ink-muted)]">
                         試験頻出キーワードを体系的に整理
                       </p>
                     </div>
                   </div>
                 </div>
-                <div className="bg-neutral-50 dark:bg-gray-800 border border-neutral-200 dark:border-gray-600 p-4">
+                <div className="bg-[var(--bg)] border border-[var(--rule-soft)] rounded-card-content p-4">
                   <div className="flex items-center gap-4">
-                    <div className="bg-cyan-600 dark:bg-cyan-500 w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
+                    <div className="bg-[var(--accent)] w-12 h-12 rounded-sm flex items-center justify-center flex-shrink-0">
                       <CheckCircle className="w-6 h-6 text-white" />
                     </div>
                     <div>
-                      <h4 className="font-bold text-neutral-900 dark:text-gray-100 mb-1">
+                      <h4 className="font-bold text-[var(--ink)] mb-1">
                         過去問・模擬問題
                       </h4>
-                      <p className="text-sm text-neutral-600 dark:text-gray-400">
+                      <p className="text-sm text-[var(--ink-muted)]">
                         択一式・記述式の過去問を年度別に解説
                       </p>
                     </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -11,13 +11,21 @@ export default function NotFound() {
       <p className="text-[var(--ink-muted)] mt-2 text-sm">
         お探しのページは移動または削除された可能性があります。
       </p>
-      <Link
-        href="/"
-        className="mt-6 inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-widest text-[var(--accent)] hover:underline"
-      >
-        <span>Back to home</span>
-        <span aria-hidden>→</span>
-      </Link>
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <Link
+          href="/search"
+          className="inline-flex items-center gap-2 rounded-card-inline border border-[var(--rule-soft)] px-4 py-2 text-sm font-bold text-[var(--ink-body)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
+        >
+          記事を検索
+        </Link>
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 rounded-card-inline bg-[var(--accent)] px-4 py-2 text-sm font-bold text-white hover:opacity-90 transition-opacity"
+        >
+          <span>ホーム（資格一覧）へ</span>
+          <span aria-hidden>→</span>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -42,7 +42,7 @@ type PolicyCardProps = {
   children: React.ReactNode;
 };
 
-// 共通 SectionCard へ委譲（chrome の二重管理を解消）。内部 palette は後続フェーズで token 化。
+// 共通 SectionCard へ委譲（chrome の二重管理を解消）。
 function PolicyCard({ icon, title, children }: PolicyCardProps) {
   return (
     <SectionCard interactive icon={icon} title={title}>
@@ -66,7 +66,7 @@ export default function PrivacyPage() {
         <div className="space-y-6">
           {/* 1. はじめに */}
           <PolicyCard
-            icon={<Shield className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+            icon={<Shield className="w-5 h-5 text-[var(--accent)]" />}
             title="はじめに"
           >
             <p>
@@ -76,26 +76,26 @@ export default function PrivacyPage() {
 
           {/* 2. 収集する情報 */}
           <PolicyCard
-            icon={<Database className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+            icon={<Database className="w-5 h-5 text-[var(--accent)]" />}
             title="収集する情報"
           >
             <div className="grid sm:grid-cols-2 gap-4">
-              <div className="bg-gray-50 dark:bg-gray-700/50 rounded-sm p-4">
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-2 text-sm">自動的に収集される情報</h3>
+              <div className="bg-[var(--bg)] rounded-sm p-4">
+                <h3 className="font-semibold text-[var(--ink)] mb-2 text-sm">自動的に収集される情報</h3>
                 <ul className="space-y-1 text-sm">
-                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-primary-400 rounded-full flex-shrink-0" />IPアドレス</li>
-                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-primary-400 rounded-full flex-shrink-0" />ブラウザの種類とバージョン</li>
-                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-primary-400 rounded-full flex-shrink-0" />アクセス日時</li>
-                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-primary-400 rounded-full flex-shrink-0" />参照元のURL</li>
-                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-primary-400 rounded-full flex-shrink-0" />デバイスの種類</li>
+                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-[var(--accent)] rounded-full flex-shrink-0" />IPアドレス</li>
+                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-[var(--accent)] rounded-full flex-shrink-0" />ブラウザの種類とバージョン</li>
+                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-[var(--accent)] rounded-full flex-shrink-0" />アクセス日時</li>
+                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-[var(--accent)] rounded-full flex-shrink-0" />参照元のURL</li>
+                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-[var(--accent)] rounded-full flex-shrink-0" />デバイスの種類</li>
                 </ul>
               </div>
-              <div className="bg-gray-50 dark:bg-gray-700/50 rounded-sm p-4">
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-2 text-sm">ユーザーが提供する情報</h3>
+              <div className="bg-[var(--bg)] rounded-sm p-4">
+                <h3 className="font-semibold text-[var(--ink)] mb-2 text-sm">ユーザーが提供する情報</h3>
                 <ul className="space-y-1 text-sm">
-                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-primary-400 rounded-full flex-shrink-0" />お問い合わせフォームからの情報</li>
-                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-primary-400 rounded-full flex-shrink-0" />コメントやフィードバック</li>
-                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-primary-400 rounded-full flex-shrink-0" />メール配信の登録情報</li>
+                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-[var(--accent)] rounded-full flex-shrink-0" />お問い合わせフォームからの情報</li>
+                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-[var(--accent)] rounded-full flex-shrink-0" />コメントやフィードバック</li>
+                  <li className="flex items-center gap-2"><span className="w-1 h-1 bg-[var(--accent)] rounded-full flex-shrink-0" />メール配信の登録情報</li>
                 </ul>
               </div>
             </div>
@@ -103,7 +103,7 @@ export default function PrivacyPage() {
 
           {/* 3. 情報の利用目的 */}
           <PolicyCard
-            icon={<Target className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+            icon={<Target className="w-5 h-5 text-[var(--accent)]" />}
             title="情報の利用目的"
           >
             <p className="mb-3">収集した情報は以下の目的で利用します：</p>
@@ -116,8 +116,8 @@ export default function PrivacyPage() {
                 '統計データの作成（個人を特定できない形式）',
                 '法的義務の履行',
               ].map((item) => (
-                <div key={item} className="flex items-center gap-2 bg-gray-50 dark:bg-gray-700/50 rounded-sm px-3 py-2 text-sm">
-                  <span className="w-1.5 h-1.5 bg-primary-500 rounded-full flex-shrink-0" />
+                <div key={item} className="flex items-center gap-2 bg-[var(--bg)] rounded-sm px-3 py-2 text-sm">
+                  <span className="w-1.5 h-1.5 bg-[var(--accent)] rounded-full flex-shrink-0" />
                   {item}
                 </div>
               ))}
@@ -126,7 +126,7 @@ export default function PrivacyPage() {
 
           {/* 4. 第三者との情報共有 */}
           <PolicyCard
-            icon={<Users className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+            icon={<Users className="w-5 h-5 text-[var(--accent)]" />}
             title="第三者との情報共有"
           >
             <p className="mb-3">以下の場合を除き、個人情報を第三者と共有することはありません：</p>
@@ -138,7 +138,7 @@ export default function PrivacyPage() {
                 '公衆衛生の向上または児童の健全な育成の推進のために特に必要な場合',
               ].map((item) => (
                 <li key={item} className="flex items-start gap-2 text-sm">
-                  <span className="w-1.5 h-1.5 bg-primary-500 rounded-full flex-shrink-0 mt-1.5" />
+                  <span className="w-1.5 h-1.5 bg-[var(--accent)] rounded-full flex-shrink-0 mt-1.5" />
                   {item}
                 </li>
               ))}
@@ -147,7 +147,7 @@ export default function PrivacyPage() {
 
           {/* 5. クッキー */}
           <PolicyCard
-            icon={<Cookie className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+            icon={<Cookie className="w-5 h-5 text-[var(--accent)]" />}
             title="クッキー（Cookie）について"
           >
             <p className="mb-4">
@@ -161,27 +161,27 @@ export default function PrivacyPage() {
                 { label: '分析クッキー', desc: 'サイトの利用状況を分析' },
                 { label: '機能クッキー', desc: 'ユーザーの設定を記憶' },
               ].map((cookie) => (
-                <div key={cookie.label} className="bg-gray-50 dark:bg-gray-700/50 rounded-sm p-3 text-center">
-                  <div className="font-semibold text-sm text-gray-900 dark:text-gray-100">{cookie.label}</div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">{cookie.desc}</div>
+                <div key={cookie.label} className="bg-[var(--bg)] rounded-sm p-3 text-center">
+                  <div className="font-semibold text-sm text-[var(--ink)]">{cookie.label}</div>
+                  <div className="text-xs text-[var(--ink-muted)] mt-1">{cookie.desc}</div>
                 </div>
               ))}
             </div>
 
-            <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-sm p-4">
-              <h3 className="font-semibold text-amber-800 dark:text-amber-300 text-sm mb-2">広告配信におけるクッキーの使用</h3>
+            <div className="bg-[var(--accent-fill)] border border-[var(--rule-soft)] rounded-sm p-4">
+              <h3 className="font-semibold text-[var(--ink)] text-sm mb-2">広告配信におけるクッキーの使用</h3>
               <p className="text-sm mb-2">
                 当サイトでは、第三者配信の広告サービス「Google AdSense」を利用しています。
                 Google などの第三者広告配信事業者は、ユーザーの興味に応じた広告を表示するために Cookie を使用することがあります。
               </p>
               <div className="flex flex-wrap gap-2 mt-3">
-                <a href="https://adssettings.google.com/authenticated" target="_blank" rel="noopener noreferrer" className="inline-flex items-center text-xs bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-full px-3 py-1 text-primary-600 dark:text-primary-400 hover:border-primary-400 transition-colors">
+                <a href="https://adssettings.google.com/authenticated" target="_blank" rel="noopener noreferrer" className="inline-flex items-center text-xs bg-[var(--paper)] border border-[var(--rule-soft)] rounded-full px-3 py-1 text-[var(--accent)] hover:border-[var(--accent)] transition-colors">
                   広告設定
                 </a>
-                <a href="http://www.aboutads.info/choices/" target="_blank" rel="noopener noreferrer" className="inline-flex items-center text-xs bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-full px-3 py-1 text-primary-600 dark:text-primary-400 hover:border-primary-400 transition-colors">
+                <a href="http://www.aboutads.info/choices/" target="_blank" rel="noopener noreferrer" className="inline-flex items-center text-xs bg-[var(--paper)] border border-[var(--rule-soft)] rounded-full px-3 py-1 text-[var(--accent)] hover:border-[var(--accent)] transition-colors">
                   広告Cookie無効化
                 </a>
-                <a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener noreferrer" className="inline-flex items-center text-xs bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-full px-3 py-1 text-primary-600 dark:text-primary-400 hover:border-primary-400 transition-colors">
+                <a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener noreferrer" className="inline-flex items-center text-xs bg-[var(--paper)] border border-[var(--rule-soft)] rounded-full px-3 py-1 text-[var(--accent)] hover:border-[var(--accent)] transition-colors">
                   Google AdSense 詳細
                 </a>
               </div>
@@ -190,7 +190,7 @@ export default function PrivacyPage() {
 
           {/* 5b. アフィリエイトプログラム */}
           <PolicyCard
-            icon={<ShoppingBag className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+            icon={<ShoppingBag className="w-5 h-5 text-[var(--accent)]" />}
             title="アフィリエイトプログラムについて"
           >
             <p className="mb-4">
@@ -206,7 +206,7 @@ export default function PrivacyPage() {
           {/* 6 & 7: 2カラム */}
           <div className="grid sm:grid-cols-2 gap-6">
             <PolicyCard
-              icon={<Clock className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+              icon={<Clock className="w-5 h-5 text-[var(--accent)]" />}
               title="データの保存期間"
             >
               <p>
@@ -216,7 +216,7 @@ export default function PrivacyPage() {
             </PolicyCard>
 
             <PolicyCard
-              icon={<Lock className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+              icon={<Lock className="w-5 h-5 text-[var(--accent)]" />}
               title="データの保護"
             >
               <p>
@@ -228,7 +228,7 @@ export default function PrivacyPage() {
 
           {/* 8. ユーザーの権利 */}
           <PolicyCard
-            icon={<UserCheck className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+            icon={<UserCheck className="w-5 h-5 text-[var(--accent)]" />}
             title="ユーザーの権利"
           >
             <p className="mb-3">ユーザーは以下の権利を有します：</p>
@@ -239,8 +239,8 @@ export default function PrivacyPage() {
                 '個人情報の利用停止・消去請求',
                 '個人情報の第三者提供の停止請求',
               ].map((item) => (
-                <div key={item} className="flex items-center gap-2 bg-gray-50 dark:bg-gray-700/50 rounded-sm px-3 py-2 text-sm">
-                  <span className="w-1.5 h-1.5 bg-primary-500 rounded-full flex-shrink-0" />
+                <div key={item} className="flex items-center gap-2 bg-[var(--bg)] rounded-sm px-3 py-2 text-sm">
+                  <span className="w-1.5 h-1.5 bg-[var(--accent)] rounded-full flex-shrink-0" />
                   {item}
                 </div>
               ))}
@@ -249,7 +249,7 @@ export default function PrivacyPage() {
 
           {/* 9. ポリシーの変更 */}
           <PolicyCard
-            icon={<RefreshCw className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+            icon={<RefreshCw className="w-5 h-5 text-[var(--accent)]" />}
             title="プライバシーポリシーの変更"
           >
             <p>
@@ -260,20 +260,20 @@ export default function PrivacyPage() {
 
           {/* 10. お問い合わせ */}
           <PolicyCard
-            icon={<Mail className="w-5 h-5 text-primary-600 dark:text-primary-400" />}
+            icon={<Mail className="w-5 h-5 text-[var(--accent)]" />}
             title="お問い合わせ"
           >
             <p className="mb-4">
               本プライバシーポリシーに関するお問い合わせは、以下の方法でお願いします：
             </p>
-            <div className="bg-gray-50 dark:bg-gray-700/50 rounded-sm p-4 flex items-center gap-4">
-              <div className="bg-primary-600 dark:bg-primary-500 w-10 h-10 rounded-sm flex items-center justify-center flex-shrink-0">
+            <div className="bg-[var(--bg)] rounded-sm p-4 flex items-center gap-4">
+              <div className="bg-[var(--accent)] w-10 h-10 rounded-sm flex items-center justify-center flex-shrink-0">
                 <Mail className="w-5 h-5 text-white" />
               </div>
               <div>
-                <p className="font-semibold text-gray-900 dark:text-gray-100 text-sm">doboku-note 運営事務局</p>
+                <p className="font-semibold text-[var(--ink)] text-sm">doboku-note 運営事務局</p>
                 <p className="text-sm">privacy@doboku-note.com</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                <p className="text-xs text-[var(--ink-muted)] mt-1">
                   件名に「プライバシーポリシーに関するお問い合わせ」と記載してください
                 </p>
               </div>

--- a/src/app/sitemap-keywords/page.tsx
+++ b/src/app/sitemap-keywords/page.tsx
@@ -48,7 +48,7 @@ function PeSectionTree({ keywordDocs }: { keywordDocs: DocMeta[] }) {
 
         return (
           <div key={chapter.id}>
-            <h2 className="text-lg font-bold text-gray-800 dark:text-gray-200 mb-4">
+            <h2 className="text-lg font-bold text-[var(--ink)] mb-4">
               {chapter.title}
             </h2>
             <div className="space-y-3 ml-2">
@@ -57,10 +57,10 @@ function PeSectionTree({ keywordDocs }: { keywordDocs: DocMeta[] }) {
                 if (keywords.length === 0) return null;
 
                 return (
-                  <div key={sec.id} className="border-l-2 border-gray-200 dark:border-gray-700 pl-4">
+                  <div key={sec.id} className="border-l-2 border-[var(--rule-soft)] pl-4">
                     <div className="flex items-center gap-2 mb-1">
-                      <span className="text-base font-semibold text-gray-700 dark:text-gray-300">{sec.title}</span>
-                      <span className="text-xs text-gray-500 dark:text-gray-500">({keywords.length} 件)</span>
+                      <span className="text-base font-semibold text-[var(--ink-body)]">{sec.title}</span>
+                      <span className="text-xs text-[var(--ink-muted)]">({keywords.length} 件)</span>
                     </div>
                     <div className="flex flex-wrap gap-2 ml-2 mt-2">
                       {keywords
@@ -69,7 +69,7 @@ function PeSectionTree({ keywordDocs }: { keywordDocs: DocMeta[] }) {
                           <Link
                             key={kw.slug}
                             href={`/docs/${kw.slug}`}
-                            className="text-base px-2.5 py-1 rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-blue-400 dark:hover:border-blue-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                            className="text-base px-2.5 py-1 rounded-full border border-[var(--rule-soft)] bg-[var(--paper)] text-[var(--ink-body)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
                           >
                             {kw.title}
                           </Link>
@@ -85,7 +85,7 @@ function PeSectionTree({ keywordDocs }: { keywordDocs: DocMeta[] }) {
 
       {unmapped.length > 0 && (
         <div>
-          <h2 className="text-lg font-bold text-gray-800 dark:text-gray-200 mb-4">その他</h2>
+          <h2 className="text-lg font-bold text-[var(--ink)] mb-4">その他</h2>
           <div className="flex flex-wrap gap-2 ml-2">
             {unmapped
               .sort((a, b) => (a.title || '').localeCompare(b.title || '', 'ja'))
@@ -93,7 +93,7 @@ function PeSectionTree({ keywordDocs }: { keywordDocs: DocMeta[] }) {
                 <Link
                   key={kw.slug}
                   href={`/docs/${kw.slug}`}
-                  className="text-base px-2.5 py-1 rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-blue-400 dark:hover:border-blue-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                  className="text-base px-2.5 py-1 rounded-full border border-[var(--rule-soft)] bg-[var(--paper)] text-[var(--ink-body)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
                 >
                   {kw.title}
                 </Link>


### PR DESCRIPTION
## 概要

デザイン改善ロードマップ **Phase 4+5**（Tools / About / Legal / 404）。Phase 3(#287) の上に積む stacked PR・ロードマップの最終フェーズ。

Phase 0 で全下層ページの構造（PageShell/PageHeader/SectionBlock）は移行済。本 PR は**内部に残った旧 Tailwind パレット**を editorial token へ統一し、404 に導線を足す。

## 変更
- **about**: プロフィールカード内部・サイトコンセプト・対応試験の 2色（primary/cyan）を accent へ mono 統一。内部ボックスを `bg`/`rule-soft` の inset カード化、全幅セクションを paper band 化。残 legacy 色 **0**。
- **privacy**: PolicyCard 内部（アイコン/inset box/箇条ドット/Mail チップ）を token 化。AdSense Cookie 注記の amber ボックスは「エラー/危険」でなく強調情報のため `accent-fill` 強調へ統一。残 legacy 色 **0**。
- **sitemap-keywords**: 章見出し・セクション罫線・キーワードチップを token 化。残 legacy 色 **0**。
- **404 (not-found)**: 「ホームへ戻る」単一リンクを「記事を検索」＋「ホーム（資格一覧）へ」の2アクションへ拡張（plan §404）。

## やらなかった判断
- **tools UX 拡張は deferred**（§2）: 「使うタイミング」追記・quiz 結果の次アクション・受験資格判定の segmented 化は content/挙動変更でコピー執筆を伴い、デザインシステム統一の射程外。tools は既に旧色0・PageShell 化済。
- **Terms 末尾 CTA は変更不要**（§8）: plan は /about→/contact を想定したが、現状すでに /contact を指していた。
- **対応試験の簡潔化は見送り**: content 削除を伴い「学習を始める」と一部重複だが削除はリスク。色 token 化に留め構造保持（§3）。
- **2色→mono 統一**: editorial は単一 accent 系。civil/技術士の primary/cyan 区別は見出しで担保済。

## 検証
- `type-check` / `lint` クリーン、pre-commit/pre-push 全ゲート通過。
- dev smoke（webpack）: `/about`・`/privacy`・`/sitemap-keywords` で HTTP200・`<main>`1・breadcrumb・legacy 色ゼロ（ThemeToggle skeleton 除く）、404 で HTTP404＋検索/資格一覧リンクを確認。

Vercel check は stale 統合（本番=Cloudflare・GH Actions build=正）のため無視可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)