### PR TITLE
design: UI コンポーネント層を editorial token へ全面統一

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -80,11 +80,11 @@ async function SafeMDXRemote({
     const message = error instanceof Error ? error.message : String(error);
     console.error('MDX compile error:', message.slice(0, 200));
     return (
-      <div className="p-4 border border-yellow-300 dark:border-yellow-700 rounded-sm bg-yellow-50 dark:bg-yellow-900/20">
-        <p className="text-yellow-700 dark:text-yellow-400 font-semibold">
+      <div className="p-4 border border-[var(--color-warn)] rounded-sm bg-[var(--color-warn-fill)]">
+        <p className="text-[var(--color-warn)] font-semibold">
           このページのコンテンツにフォーマットエラーがあります。
         </p>
-        <p className="text-yellow-600 dark:text-yellow-500 text-sm mt-1">
+        <p className="text-[var(--color-warn)] text-sm mt-1">
           管理者に報告してください。
         </p>
       </div>

--- a/src/app/search/SearchPageClient.tsx
+++ b/src/app/search/SearchPageClient.tsx
@@ -72,8 +72,8 @@ export default function SearchPageClient({ categories, popular }: SearchPageClie
 
       {/* 検索結果 */}
       {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-sm p-4 mb-6">
-          <p className="text-red-800 dark:text-red-200">{error}</p>
+        <div className="bg-[var(--color-danger-fill)] border border-[var(--color-danger)] rounded-sm p-4 mb-6">
+          <p className="text-[var(--color-danger)]">{error}</p>
         </div>
       )}
 

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -27,7 +27,7 @@ export function SearchResults({
   if (error) {
     return (
       <div className="text-center py-12">
-        <p className="text-red-600 dark:text-red-400 mb-4">
+        <p className="text-[var(--color-danger)] mb-4">
           検索中にエラーが発生しました: {error}
         </p>
         <button

--- a/src/components/ui/ArticleImage/ArticleImage.tsx
+++ b/src/components/ui/ArticleImage/ArticleImage.tsx
@@ -71,7 +71,7 @@ export default function ArticleImage({
         )}
       </div>
       {caption && (
-        <figcaption className="mt-3 text-center text-sm text-gray-600 italic px-4 sm:px-8">
+        <figcaption className="mt-3 text-center text-sm text-[var(--ink-body)] italic px-4 sm:px-8">
           {caption}
         </figcaption>
       )}

--- a/src/components/ui/AuthorCard/AuthorCard.tsx
+++ b/src/components/ui/AuthorCard/AuthorCard.tsx
@@ -30,7 +30,7 @@ export default function AuthorCard({
 
   return (
     <MetaCard as="aside" ariaLabel="執筆者情報" className="mt-10">
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">執筆者</h2>
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-4">執筆者</h2>
       <div className="flex items-start gap-4">
         <Link href="/about" className="shrink-0">
           <img
@@ -38,29 +38,29 @@ export default function AuthorCard({
             alt={`${AUTHOR.name}のプロフィール画像`}
             width={64}
             height={64}
-            className="w-16 h-16 rounded-full border border-gray-200 dark:border-gray-700"
+            className="w-16 h-16 rounded-full border border-[var(--rule-soft)]"
           />
         </Link>
         <div className="min-w-0 flex-1">
           <Link
             href="/about"
-            className="text-base font-bold text-gray-900 dark:text-gray-100 hover:text-primary-600 dark:hover:text-primary-400"
+            className="text-base font-bold text-[var(--ink)] hover:text-[var(--accent)]"
           >
             {AUTHOR.name}
           </Link>
-          <p className="mt-2 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+          <p className="mt-2 text-sm text-[var(--ink-body)] leading-relaxed">
             {AUTHOR.tagline}
           </p>
           <div className="mt-3">
-            <div className="text-[10px] font-mono uppercase tracking-widest text-gray-400 dark:text-gray-500 mb-1">
+            <div className="text-[10px] font-mono uppercase tracking-widest text-[var(--ink-muted)] mb-1">
               保有資格
             </div>
-            <p className="text-xs text-gray-600 dark:text-gray-400 leading-relaxed">
+            <p className="text-xs text-[var(--ink-body)] leading-relaxed">
               {AUTHOR.qualifications.join("・")}
             </p>
           </div>
           {(published || updated || lastReviewed) && (
-            <div className="mt-3 text-xs text-gray-500 dark:text-gray-400 flex flex-wrap gap-x-4 gap-y-1">
+            <div className="mt-3 text-xs text-[var(--ink-muted)] flex flex-wrap gap-x-4 gap-y-1">
               {published && <span>公開日: {published}</span>}
               {updated && updated !== published && <span>最終更新: {updated}</span>}
               {lastReviewed &&
@@ -74,13 +74,13 @@ export default function AuthorCard({
             href={AUTHOR.noteCta.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-4 inline-flex items-center gap-2 px-3.5 py-2 rounded-md bg-primary-600 dark:bg-primary-500 text-white text-sm font-bold shadow-sm hover:bg-primary-700 dark:hover:bg-primary-400 transition-colors"
+            className="mt-4 inline-flex items-center gap-2 px-3.5 py-2 rounded-md bg-[var(--accent)] text-white text-sm font-bold shadow-sm hover:bg-[var(--accent)] transition-colors"
           >
             {AUTHOR.noteCta.label}
           </a>
           <Link
             href="/about"
-            className="mt-2 block text-xs text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 hover:underline"
+            className="mt-2 block text-xs text-[var(--ink-muted)] hover:text-[var(--accent)] hover:underline"
           >
             運営者・編集方針について →
           </Link>

--- a/src/components/ui/BackToTopButton.tsx
+++ b/src/components/ui/BackToTopButton.tsx
@@ -18,7 +18,7 @@ export default function BackToTopButton() {
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
       aria-label="ページの先頭に戻る"
       title="トップに戻る"
-      className="fixed bottom-6 right-6 z-50 w-11 h-11 flex items-center justify-center rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 shadow-md text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-lg transition-all duration-200"
+      className="fixed bottom-6 right-6 z-50 w-11 h-11 flex items-center justify-center rounded-full bg-[var(--paper)] border border-[var(--rule-soft)] shadow-md text-[var(--ink-muted)] hover:text-[var(--accent)] hover:border-[var(--accent)] hover:shadow-lg transition-all duration-200"
     >
       <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
         <polyline points="18 15 12 9 6 15" />

--- a/src/components/ui/CareerAffiliate/CareerAffiliate.tsx
+++ b/src/components/ui/CareerAffiliate/CareerAffiliate.tsx
@@ -79,7 +79,7 @@ export default function CareerAffiliate({
         target="_blank"
         data-cta="affiliate"
         data-cta-label={service}
-        className="group relative flex flex-col sm:flex-row items-stretch gap-4 rounded-card-content border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
+        className="group relative flex flex-col sm:flex-row items-stretch gap-4 rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] p-4 shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
         style={{ textDecoration: "none" }}
       >
         <AffiliatePrBadge className="absolute right-3 top-3" />
@@ -99,11 +99,11 @@ export default function CareerAffiliate({
           <div className="text-[11px] font-bold tracking-wider text-brand-deep dark:text-brand uppercase">
             {category}
           </div>
-          <div className="mt-0.5 text-[15px] font-bold text-ink-strong dark:text-gray-100 group-hover:underline">
+          <div className="mt-0.5 text-[15px] font-bold text-ink-strong group-hover:underline">
             {service}
           </div>
           {description && (
-            <div className="mt-1.5 text-sm leading-6 text-ink-body dark:text-gray-400">
+            <div className="mt-1.5 text-sm leading-6 text-ink-body">
               {description}
             </div>
           )}
@@ -112,7 +112,7 @@ export default function CareerAffiliate({
               {points.map((point) => (
                 <li
                   key={point}
-                  className="flex items-start gap-1.5 text-sm leading-6 text-ink-body dark:text-gray-300"
+                  className="flex items-start gap-1.5 text-sm leading-6 text-ink-body"
                 >
                   <Check
                     className="mt-1 h-3.5 w-3.5 shrink-0 text-brand"

--- a/src/components/ui/CategoryNavCard/CategoryNavCard.tsx
+++ b/src/components/ui/CategoryNavCard/CategoryNavCard.tsx
@@ -23,8 +23,8 @@ interface CategoryNavCardProps {
 
 /* ─── 共通: セルリンク ─── */
 function CellLink({ slug, label, currentSlug }: { slug: string | undefined; label: string; currentSlug: string }) {
-  if (!slug) return <span className="text-gray-300 dark:text-gray-600">—</span>;
-  if (slug === currentSlug) return <span className="font-bold text-gray-900 dark:text-gray-100">{label}</span>;
+  if (!slug) return <span className="text-[var(--ink-muted)] opacity-50">—</span>;
+  if (slug === currentSlug) return <span className="font-bold text-[var(--ink)]">{label}</span>;
   return (
     <Link href={`/docs/${slug}`} className="text-brand hover:text-brand-deep hover:underline">
       {label}
@@ -49,9 +49,9 @@ function GuideCard({ variant, currentSlug, categoryArticles }: { variant: 'sideb
       <SidebarWrapper title="試験概要">
         <ul>
           {guides.map((g) => (
-            <li key={g.slug} className="border-b border-gray-200/60 dark:border-gray-700/60 last:border-b-0">
+            <li key={g.slug} className="border-b border-[var(--rule-soft)] last:border-b-0">
               {g.slug === currentSlug ? (
-                <span className="block py-2 text-sm font-bold text-gray-900 dark:text-gray-100">{g.sidebar_label || g.shortTitle || g.title}</span>
+                <span className="block py-2 text-sm font-bold text-[var(--ink)]">{g.sidebar_label || g.shortTitle || g.title}</span>
               ) : (
                 <Link href={`/docs/${g.slug}`} className="block py-2 text-sm text-brand underline decoration-brand/30 underline-offset-2 hover:text-brand-deep hover:decoration-brand transition-colors">
                   {g.sidebar_label || g.shortTitle || g.title}
@@ -68,9 +68,9 @@ function GuideCard({ variant, currentSlug, categoryArticles }: { variant: 'sideb
     <MobileWrapper title="試験概要">
       <ul className="space-y-2">
         {guides.map((g) => (
-          <li key={g.slug} className={`rounded-sm border px-4 py-3 transition-colors ${g.slug === currentSlug ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800' : 'border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-500'}`}>
+          <li key={g.slug} className={`rounded-sm border px-4 py-3 transition-colors ${g.slug === currentSlug ? 'bg-[var(--accent-fill)] border-[var(--accent)]' : 'border-[var(--rule-soft)] hover:border-[var(--accent)]'}`}>
             {g.slug === currentSlug ? (
-              <span className="text-sm font-bold text-gray-900 dark:text-gray-100">{g.title}</span>
+              <span className="text-sm font-bold text-[var(--ink)]">{g.title}</span>
             ) : (
               <Link href={`/docs/${g.slug}`} className="text-sm text-brand hover:underline">
                 {g.title}
@@ -100,9 +100,9 @@ function PillarCard({ variant, currentSlug, categoryArticles }: { variant: 'side
       <SidebarWrapper title="5 管理学習ガイド">
         <ul>
           {pillars.map((p) => (
-            <li key={p.slug} className="border-b border-gray-200/60 dark:border-gray-700/60 last:border-b-0">
+            <li key={p.slug} className="border-b border-[var(--rule-soft)] last:border-b-0">
               {p.slug === currentSlug ? (
-                <span className="block py-2 text-sm font-bold text-gray-900 dark:text-gray-100">{p.sidebar_label || p.shortTitle || p.title}</span>
+                <span className="block py-2 text-sm font-bold text-[var(--ink)]">{p.sidebar_label || p.shortTitle || p.title}</span>
               ) : (
                 <Link href={`/docs/${p.slug}`} className="block py-2 text-sm text-brand underline decoration-brand/30 underline-offset-2 hover:text-brand-deep hover:decoration-brand transition-colors">
                   {p.sidebar_label || p.shortTitle || p.title}
@@ -119,9 +119,9 @@ function PillarCard({ variant, currentSlug, categoryArticles }: { variant: 'side
     <MobileWrapper title="5 管理学習ガイド">
       <ul className="space-y-2">
         {pillars.map((p) => (
-          <li key={p.slug} className={`rounded-sm border px-4 py-3 transition-colors ${p.slug === currentSlug ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800' : 'border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-500'}`}>
+          <li key={p.slug} className={`rounded-sm border px-4 py-3 transition-colors ${p.slug === currentSlug ? 'bg-[var(--accent-fill)] border-[var(--accent)]' : 'border-[var(--rule-soft)] hover:border-[var(--accent)]'}`}>
             {p.slug === currentSlug ? (
-              <span className="text-sm font-bold text-gray-900 dark:text-gray-100">{p.sidebar_label || p.shortTitle || p.title}</span>
+              <span className="text-sm font-bold text-[var(--ink)]">{p.sidebar_label || p.shortTitle || p.title}</span>
             ) : (
               <Link href={`/docs/${p.slug}`} className="text-sm text-brand hover:underline">
                 {p.sidebar_label || p.shortTitle || p.title}
@@ -144,19 +144,19 @@ function PastExamCard({ variant, currentSlug, categoryArticles, category }: { va
       <SidebarWrapper title="過去問">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-200 dark:border-gray-700">
-              <th className="text-left py-1 pr-2 font-medium text-gray-500 dark:text-gray-400 text-xs" />
-              <th className="text-center py-1 px-1 font-medium text-gray-500 dark:text-gray-400 text-xs">{data.col1Header}</th>
-              <th className="text-center py-1 px-1 font-medium text-gray-500 dark:text-gray-400 text-xs">{data.col2Header}</th>
-              {data.col3Header && <th className="text-center py-1 px-1 font-medium text-gray-500 dark:text-gray-400 text-xs">{data.col3Header}</th>}
+            <tr className="border-b border-[var(--rule-soft)]">
+              <th className="text-left py-1 pr-2 font-medium text-[var(--ink-muted)] text-xs" />
+              <th className="text-center py-1 px-1 font-medium text-[var(--ink-muted)] text-xs">{data.col1Header}</th>
+              <th className="text-center py-1 px-1 font-medium text-[var(--ink-muted)] text-xs">{data.col2Header}</th>
+              {data.col3Header && <th className="text-center py-1 px-1 font-medium text-[var(--ink-muted)] text-xs">{data.col3Header}</th>}
             </tr>
           </thead>
           <tbody>
             {data.years.map((year) => {
               const isCurrent = year.col1?.slug === currentSlug || year.col2?.slug === currentSlug || year.col3?.slug === currentSlug;
               return (
-                <tr key={year.yearCode} className={isCurrent ? 'bg-blue-50/60 dark:bg-blue-900/20' : ''}>
-                  <td className="py-1.5 pr-2 text-gray-700 dark:text-gray-300 font-medium whitespace-nowrap">{year.label}</td>
+                <tr key={year.yearCode} className={isCurrent ? 'bg-[var(--accent-fill)]' : ''}>
+                  <td className="py-1.5 pr-2 text-[var(--ink-body)] font-medium whitespace-nowrap">{year.label}</td>
                   <td className="py-1.5 px-1 text-center"><CellLink slug={year.col1?.slug} label={data.col1Header} currentSlug={currentSlug} /></td>
                   <td className="py-1.5 px-1 text-center"><CellLink slug={year.col2?.slug} label={data.col2Header} currentSlug={currentSlug} /></td>
                   {data.col3Header && <td className="py-1.5 px-1 text-center"><CellLink slug={year.col3?.slug} label={data.col3Header} currentSlug={currentSlug} /></td>}
@@ -174,19 +174,19 @@ function PastExamCard({ variant, currentSlug, categoryArticles, category }: { va
       <div className="overflow-x-auto">
         <table className="w-full text-base border-collapse">
           <thead>
-            <tr className="border-b-2 border-gray-200 dark:border-gray-700">
-              <th className="text-left py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">年度</th>
-              <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">{data.col1Header === '択一' ? '択一式' : `問題${data.col1Header}`}</th>
-              <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">{data.col2Header === '記述' ? '記述式' : `問題${data.col2Header}`}</th>
-              {data.col3Header && <th className="text-center py-3 px-4 font-semibold text-gray-700 dark:text-gray-300">第2次検定</th>}
+            <tr className="border-b-2 border-[var(--rule-soft)]">
+              <th className="text-left py-3 px-4 font-semibold text-[var(--ink-body)]">年度</th>
+              <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">{data.col1Header === '択一' ? '択一式' : `問題${data.col1Header}`}</th>
+              <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">{data.col2Header === '記述' ? '記述式' : `問題${data.col2Header}`}</th>
+              {data.col3Header && <th className="text-center py-3 px-4 font-semibold text-[var(--ink-body)]">第2次検定</th>}
             </tr>
           </thead>
           <tbody>
             {data.years.map((year) => {
               const isCurrent = year.col1?.slug === currentSlug || year.col2?.slug === currentSlug || year.col3?.slug === currentSlug;
               return (
-                <tr key={year.yearCode} className={`border-b border-gray-100 dark:border-gray-800 transition-colors ${isCurrent ? 'bg-blue-50 dark:bg-blue-900/20' : 'hover:bg-gray-50 dark:hover:bg-gray-800/50'}`}>
-                  <td className={`py-3 px-4 text-gray-900 dark:text-gray-100 ${isCurrent ? 'font-bold' : 'font-medium'}`}>{year.label}</td>
+                <tr key={year.yearCode} className={`border-b border-[var(--rule-soft)] transition-colors ${isCurrent ? 'bg-[var(--accent-fill)]' : 'hover:bg-[var(--accent-fill)]'}`}>
+                  <td className={`py-3 px-4 text-[var(--ink)] ${isCurrent ? 'font-bold' : 'font-medium'}`}>{year.label}</td>
                   <td className="py-3 px-4 text-center"><CellLink slug={year.col1?.slug} label={data.col1Header === '択一' ? '択一式' : `問題${data.col1Header}`} currentSlug={currentSlug} /></td>
                   <td className="py-3 px-4 text-center"><CellLink slug={year.col2?.slug} label={data.col2Header === '記述' ? '記述式' : `問題${data.col2Header}`} currentSlug={currentSlug} /></td>
                   {data.col3Header && <td className="py-3 px-4 text-center"><CellLink slug={year.col3?.slug} label="第2次検定" currentSlug={currentSlug} /></td>}
@@ -215,14 +215,14 @@ function SectionCard({ variant, currentSlug, currentSection }: { variant: 'sideb
 
     return (
       <SidebarWrapper title="同セクションのキーワード">
-        <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+        <p className="text-xs text-[var(--ink-muted)] mb-2">
           {section.id} {section.title}
         </p>
         <ul className="max-h-[280px] overflow-y-auto toc-scroll">
           {keywords.map(kw => (
-            <li key={kw.slug} className="border-b border-gray-200/60 dark:border-gray-700/60 last:border-b-0">
+            <li key={kw.slug} className="border-b border-[var(--rule-soft)] last:border-b-0">
               {kw.slug === currentSuffix ? (
-                <span className="block text-sm py-2 font-bold text-gray-900 dark:text-gray-100">
+                <span className="block text-sm py-2 font-bold text-[var(--ink)]">
                   {kw.title}
                 </span>
               ) : (
@@ -247,7 +247,7 @@ function SectionCard({ variant, currentSlug, currentSection }: { variant: 'sideb
           const isCurrentChapter = ch.id === currentChapterId;
           return (
             <div key={ch.id}>
-              <h3 className={`text-sm font-bold mb-2 ${isCurrentChapter ? 'text-blue-600 dark:text-blue-400' : 'text-gray-700 dark:text-gray-300'}`}>
+              <h3 className={`text-sm font-bold mb-2 ${isCurrentChapter ? 'text-[var(--accent)]' : 'text-[var(--ink-body)]'}`}>
                 {ch.title}
               </h3>
               <div className="flex flex-wrap gap-1.5">
@@ -258,8 +258,8 @@ function SectionCard({ variant, currentSlug, currentSection }: { variant: 'sideb
                       key={sec.id}
                       className={`text-xs px-2.5 py-1 rounded-full border ${
                         isCurrentSection
-                          ? 'bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700 font-bold text-blue-700 dark:text-blue-300'
-                          : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400'
+                          ? 'bg-[var(--accent-fill)] border-[var(--accent)] font-bold text-[var(--accent)]'
+                          : 'border-[var(--rule-soft)] text-[var(--ink-body)]'
                       }`}
                     >
                       {sec.id} {sec.title}
@@ -280,7 +280,7 @@ function SidebarWrapper({ title, children }: { title: string; children: React.Re
   return (
     <MetaCard as="div" padding="compact">
       <div
-        className="nav-card-title text-gray-900 dark:text-white"
+        className="nav-card-title text-[var(--ink)]"
       >
         {title}
       </div>
@@ -292,7 +292,7 @@ function SidebarWrapper({ title, children }: { title: string; children: React.Re
 function MobileWrapper({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <MetaCard>
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">{title}</h2>
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-4">{title}</h2>
       {children}
     </MetaCard>
   );
@@ -307,9 +307,9 @@ function LinkListCard({ variant, title, currentSlug, docs }: { variant: 'sidebar
       <SidebarWrapper title={title}>
         <ul>
           {docs.map((d) => (
-            <li key={d.slug} className="border-b border-gray-200/60 dark:border-gray-700/60 last:border-b-0">
+            <li key={d.slug} className="border-b border-[var(--rule-soft)] last:border-b-0">
               {d.slug === currentSlug ? (
-                <span className="block py-2 text-sm font-bold text-gray-900 dark:text-gray-100">{d.sidebar_label || d.title}</span>
+                <span className="block py-2 text-sm font-bold text-[var(--ink)]">{d.sidebar_label || d.title}</span>
               ) : (
                 <Link href={`/docs/${d.slug}`} className="block py-2 text-sm text-brand underline decoration-brand/30 underline-offset-2 hover:text-brand-deep hover:decoration-brand transition-colors">
                   {d.sidebar_label || d.title}
@@ -326,9 +326,9 @@ function LinkListCard({ variant, title, currentSlug, docs }: { variant: 'sidebar
     <MobileWrapper title={title}>
       <ul className="space-y-2">
         {docs.map((d) => (
-          <li key={d.slug} className={`rounded-sm border px-4 py-3 transition-colors ${d.slug === currentSlug ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800' : 'border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-500'}`}>
+          <li key={d.slug} className={`rounded-sm border px-4 py-3 transition-colors ${d.slug === currentSlug ? 'bg-[var(--accent-fill)] border-[var(--accent)]' : 'border-[var(--rule-soft)] hover:border-[var(--accent)]'}`}>
             {d.slug === currentSlug ? (
-              <span className="text-sm font-bold text-gray-900 dark:text-gray-100">{d.title}</span>
+              <span className="text-sm font-bold text-[var(--ink)]">{d.title}</span>
             ) : (
               <Link href={`/docs/${d.slug}`} className="text-sm text-brand hover:underline">
                 {d.title}

--- a/src/components/ui/DataTable/DataTable.tsx
+++ b/src/components/ui/DataTable/DataTable.tsx
@@ -54,22 +54,22 @@ const DataTable: React.FC<DataTableProps> = ({
       {title && (
         <div className="mb-6">
           <div className={`${sizeStyles.title} font-bold text-center relative inline-block w-full`}>
-            <span className="relative z-10 bg-white px-6 py-2 text-[#4c9ac0] dark:bg-gray-900 dark:text-blue-400">
+            <span className="relative z-10 bg-[var(--paper)] px-6 py-2 text-[var(--accent)]">
               {title}
             </span>
-            <div className="absolute top-1/2 left-0 w-full h-0.5 bg-[#4c9ac0] dark:bg-blue-400 transform -translate-y-1/2"></div>
+            <div className="absolute top-1/2 left-0 w-full h-0.5 bg-[var(--accent)] transform -translate-y-1/2"></div>
           </div>
         </div>
       )}
 
       <div className="overflow-x-auto">
-        <table className="border border-gray-300 dark:border-gray-600 shadow-card-content w-full text-sm leading-5">
-          <thead className="bg-gray-100 dark:bg-gray-700">
+        <table className="border border-[var(--rule-soft)] shadow-card-content w-full text-sm leading-5">
+          <thead className="bg-[var(--accent-fill)]">
             <tr>
               {columns.map((column) => (
                 <th
                   key={column.key}
-                  className={`py-3 px-4 ${column.align === 'right' ? 'text-right' : column.align === 'center' ? 'text-center' : 'text-left'} font-medium text-gray-600 dark:text-gray-300`}
+                  className={`py-3 px-4 ${column.align === 'right' ? 'text-right' : column.align === 'center' ? 'text-center' : 'text-left'} font-medium text-[var(--ink-body)]`}
                 >
                   {column.label}
                 </th>
@@ -81,11 +81,11 @@ const DataTable: React.FC<DataTableProps> = ({
               const isTotal = isTotalRow(row);
               const isEvenRow = index % 2 === 0;
               return (
-                <tr key={index} className={isEvenRow ? 'bg-white dark:bg-gray-800' : 'bg-gray-50 dark:bg-gray-700'}>
+                <tr key={index} className={isEvenRow ? 'bg-[var(--paper)]' : 'bg-[var(--bg)]'}>
                   {columns.map((column) => (
                     <td
                       key={column.key}
-                      className={`py-3 px-4 ${column.align === 'right' ? 'text-right' : column.align === 'center' ? 'text-center' : 'text-left'} ${isTotal ? 'font-medium text-gray-600 dark:text-gray-300' : 'text-gray-900 dark:text-gray-100'} ${column.className || ''}`}
+                      className={`py-3 px-4 ${column.align === 'right' ? 'text-right' : column.align === 'center' ? 'text-center' : 'text-left'} ${isTotal ? 'font-medium text-[var(--ink-body)]' : 'text-[var(--ink)]'} ${column.className || ''}`}
                     >
                       {row[column.key]}
                     </td>

--- a/src/components/ui/ExamFields/ExamFields.tsx
+++ b/src/components/ui/ExamFields/ExamFields.tsx
@@ -2,6 +2,8 @@
  * 5管理分野カード（総合技術監理の骨格）
  * 経済性管理・人的資源管理・情報管理・安全管理・社会環境管理 を視覚的に表現。
  * 将来的に note・iOS アプリでも流用できるよう、データ駆動の構造を持つ。
+ * 注: 各管理の色分け（blue/emerald/amber/rose/teal）は 5 管理を識別する
+ * ドメイン意味色のため editorial mono へは平坦化せず保持する。default のみ token。
  */
 import Link from 'next/link';
 
@@ -23,7 +25,7 @@ const COLOR_CLASSES: Record<string, { border: string; bg: string; text: string }
   amber: { border: 'border-amber-400 dark:border-amber-500', bg: 'bg-amber-50 dark:bg-amber-900/20', text: 'text-amber-700 dark:text-amber-300' },
   rose: { border: 'border-rose-400 dark:border-rose-500', bg: 'bg-rose-50 dark:bg-rose-900/20', text: 'text-rose-700 dark:text-rose-300' },
   teal: { border: 'border-teal-400 dark:border-teal-500', bg: 'bg-teal-50 dark:bg-teal-900/20', text: 'text-teal-700 dark:text-teal-300' },
-  default: { border: 'border-gray-300 dark:border-gray-600', bg: 'bg-gray-50 dark:bg-gray-800', text: 'text-gray-700 dark:text-gray-300' },
+  default: { border: 'border-[var(--rule-soft)]', bg: 'bg-[var(--bg)]', text: 'text-[var(--ink-body)]' },
 };
 
 export default function ExamFields({ items }: ExamFieldsProps) {
@@ -36,14 +38,14 @@ export default function ExamFields({ items }: ExamFieldsProps) {
             <div className={`text-base font-bold mb-2 ${colors.text}`}>
               {field.name}
             </div>
-            <div className="text-sm text-gray-700 dark:text-gray-300 mb-3 leading-relaxed">
+            <div className="text-sm text-[var(--ink-body)] mb-3 leading-relaxed">
               {field.scope}
             </div>
             <div className="flex flex-wrap gap-1.5">
               {field.keywords.map((kw, i) => (
                 <span
                   key={i}
-                  className="text-xs px-2 py-0.5 rounded-full bg-white/80 dark:bg-gray-800/80 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400"
+                  className="text-xs px-2 py-0.5 rounded-full bg-[var(--paper)] border border-[var(--rule-soft)] text-[var(--ink-muted)]"
                 >
                   {kw}
                 </span>

--- a/src/components/ui/ExamQuestionNav/ExamQuestionNav.tsx
+++ b/src/components/ui/ExamQuestionNav/ExamQuestionNav.tsx
@@ -41,7 +41,7 @@ export default function ExamQuestionNav({ headings, variant = 'sidebar' }: ExamQ
         <a
           key={q.id}
           href={`#${q.id}`}
-          className="flex h-9 min-w-9 items-center justify-center rounded-sm border border-gray-200 px-2 text-sm tabular-nums text-brand transition-colors hover:border-brand hover:bg-brand-fill hover:text-brand-deep dark:border-gray-700 dark:hover:border-brand"
+          className="flex h-9 min-w-9 items-center justify-center rounded-sm border border-[var(--rule-soft)] px-2 text-sm tabular-nums text-brand transition-colors hover:border-brand hover:bg-brand-fill hover:text-brand-deep dark:hover:border-brand"
           aria-label={`問題 ${q.no} へ移動`}
         >
           {q.no}
@@ -53,7 +53,7 @@ export default function ExamQuestionNav({ headings, variant = 'sidebar' }: ExamQ
   if (variant === 'mobile') {
     return (
       <MetaCard>
-        <h2 className="mb-4 text-lg font-bold text-gray-900 dark:text-white">{title}</h2>
+        <h2 className="mb-4 text-lg font-bold text-[var(--ink)]">{title}</h2>
         {grid}
       </MetaCard>
     );
@@ -61,7 +61,7 @@ export default function ExamQuestionNav({ headings, variant = 'sidebar' }: ExamQ
 
   return (
     <MetaCard as="div" padding="compact">
-      <div className="nav-card-title text-gray-900 dark:text-white">{title}</div>
+      <div className="nav-card-title text-[var(--ink)]">{title}</div>
       {grid}
     </MetaCard>
   );

--- a/src/components/ui/ExternalReferences/ExternalReferences.tsx
+++ b/src/components/ui/ExternalReferences/ExternalReferences.tsx
@@ -22,8 +22,8 @@ export default function ExternalReferences({ references }: ExternalReferencesPro
 
   return (
     <MetaCard ariaLabel="参考資料">
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">参考資料</h2>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-1">参考資料</h2>
+      <p className="text-sm text-[var(--ink-muted)] mb-4">
         公的資料・解説記事への外部リンク（{references.length} 件）
       </p>
       <ul className="space-y-2">

--- a/src/components/ui/FAQCard/FAQCard.tsx
+++ b/src/components/ui/FAQCard/FAQCard.tsx
@@ -14,26 +14,26 @@ export default function FAQCard({ faqs }: FAQCardProps) {
 
   return (
     <MetaCard ariaLabel="よくある質問">
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-1">
         よくある質問
       </h2>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      <p className="text-sm text-[var(--ink-muted)] mb-4">
         この記事に関する Q&amp;A
       </p>
       <ul className="space-y-2">
         {faqs.map((entry, idx) => (
           <li key={idx}>
-            <details className="group rounded-sm border border-gray-200 dark:border-gray-700 px-4 py-3 open:border-blue-400 dark:open:border-blue-500 transition-colors">
-              <summary className="flex items-start gap-2 cursor-pointer list-none text-sm font-semibold text-gray-900 dark:text-gray-100 marker:hidden">
+            <details className="group rounded-sm border border-[var(--rule-soft)] px-4 py-3 open:border-[var(--accent)] transition-colors">
+              <summary className="flex items-start gap-2 cursor-pointer list-none text-sm font-semibold text-[var(--ink)] marker:hidden">
                 <span
                   aria-hidden="true"
-                  className="mt-0.5 inline-block w-4 h-4 shrink-0 transition-transform group-open:rotate-90 text-gray-400 dark:text-gray-500"
+                  className="mt-0.5 inline-block w-4 h-4 shrink-0 transition-transform group-open:rotate-90 text-[var(--ink-muted)]"
                 >
                   ▶
                 </span>
                 <span className="flex-1">{entry.q}</span>
               </summary>
-              <p className="mt-3 ml-6 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+              <p className="mt-3 ml-6 text-sm text-[var(--ink-body)] leading-relaxed">
                 {entry.a}
               </p>
             </details>

--- a/src/components/ui/LinkCard/LinkCardClient.tsx
+++ b/src/components/ui/LinkCard/LinkCardClient.tsx
@@ -27,7 +27,7 @@ export default function LinkCardClient({
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="group block w-full max-w-2xl cursor-pointer overflow-hidden rounded-card-content border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-card-content hover:shadow-card-hover transition-all duration-300"
+        className="group block w-full max-w-2xl cursor-pointer overflow-hidden rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] shadow-card-content hover:shadow-card-hover transition-all duration-300"
       >
         <span className="flex flex-col sm:flex-row sm:items-center">
           {imageUrl && (
@@ -45,18 +45,18 @@ export default function LinkCardClient({
           )}
 
           <span className="block min-w-0 flex-1 p-4">
-            <span className="linkcard-title mb-2 line-clamp-2 text-base font-semibold text-gray-900 transition-colors group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
+            <span className="linkcard-title mb-2 line-clamp-2 text-base font-semibold text-[var(--ink)] transition-colors group-hover:text-[var(--accent)]">
               {title}
             </span>
 
             {description && (
-              <span className="mb-2 line-clamp-2 text-sm text-gray-600 dark:text-gray-400">
+              <span className="mb-2 line-clamp-2 text-sm text-[var(--ink-body)]">
                 {description}
               </span>
             )}
 
             {siteName && (
-              <span className="block text-xs font-medium text-gray-500 dark:text-gray-400">
+              <span className="block text-xs font-medium text-[var(--ink-muted)]">
                 {siteName}
               </span>
             )}

--- a/src/components/ui/MagazineInlineCard/MagazineInlineCard.tsx
+++ b/src/components/ui/MagazineInlineCard/MagazineInlineCard.tsx
@@ -36,10 +36,10 @@ export default function MagazineInlineCard({
       rel="noopener noreferrer"
       data-cta="note"
       data-cta-label={trackLabel}
-      className="not-prose group my-6 block max-w-2xl rounded-card-content overflow-hidden border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
+      className="not-prose group my-6 block max-w-2xl rounded-card-content overflow-hidden border border-[var(--rule-soft)] bg-[var(--paper)] shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
     >
       <div className="flex flex-col sm:flex-row">
-        <div className="relative w-full sm:w-[240px] shrink-0 aspect-square bg-gray-100 dark:bg-gray-800">
+        <div className="relative w-full sm:w-[240px] shrink-0 aspect-square bg-[var(--bg)]">
           <Image
             src={imageUrl}
             alt={title}
@@ -51,10 +51,10 @@ export default function MagazineInlineCard({
           <MagazineBadge>{badge}</MagazineBadge>
         </div>
         <div className="min-w-0 flex-1 p-3 sm:p-4">
-          <div className="text-[14px] sm:text-[15px] font-bold text-ink-strong dark:text-gray-100 leading-tight group-hover:text-brand-deep dark:group-hover:text-brand transition-colors line-clamp-2">
+          <div className="text-[14px] sm:text-[15px] font-bold text-ink-strong leading-tight group-hover:text-brand-deep dark:group-hover:text-brand transition-colors line-clamp-2">
             {title}
           </div>
-          <p className="mt-1 text-[12px] sm:text-[13px] leading-snug text-ink-body dark:text-gray-400 line-clamp-2 sm:line-clamp-3">
+          <p className="mt-1 text-[12px] sm:text-[13px] leading-snug text-ink-body line-clamp-2 sm:line-clamp-3">
             {description}
           </p>
         </div>

--- a/src/components/ui/MagazineSidebarCard/MagazineSidebarCard.tsx
+++ b/src/components/ui/MagazineSidebarCard/MagazineSidebarCard.tsx
@@ -31,7 +31,7 @@ export default function MagazineSidebarCard({
       {...linkProps}
       data-cta="note"
       data-cta-label={trackLabel}
-      className="not-prose group block rounded-card-content overflow-hidden border border-gray-200 dark:border-gray-700 shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
+      className="not-prose group block rounded-card-content overflow-hidden border border-[var(--rule-soft)] shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
     >
       <Image
         src={imageUrl}

--- a/src/components/ui/MetaCard/MetaCard.tsx
+++ b/src/components/ui/MetaCard/MetaCard.tsx
@@ -2,8 +2,8 @@
  * 記事末尾・サイドバーの情報カード（rounded-card-section）の共通シェル。
  *
  * 12 箇所で literal にコピペされていた以下のクラス指定を 1 箇所に集約する:
- *   bg-white dark:bg-gray-800 rounded-card-section shadow-card-section
- *   border border-gray-200/60 dark:border-gray-700/60 p-{...}
+ *   bg-[var(--paper)] rounded-card-section shadow-card-section
+ *   border border-[var(--rule-soft)] p-{...}（editorial token・SectionCard と同一 chrome）
  *
  * 子要素（h2 タイトル / p サブタイトル / リスト 等）は呼び出し側の責務。
  * MetaCard は外枠のみを抽象化する純粋なシェル。
@@ -44,7 +44,7 @@ const PADDINGS: Record<NonNullable<MetaCardProps['padding']>, string> = {
 };
 
 const BASE_CLASSES =
-  'bg-white dark:bg-gray-800 rounded-card-section shadow-card-section border border-gray-200/60 dark:border-gray-700/60';
+  'bg-[var(--paper)] rounded-card-section shadow-card-section border border-[var(--rule-soft)]';
 
 export default function MetaCard({
   as = 'section',

--- a/src/components/ui/MetaListItem/MetaListItem.tsx
+++ b/src/components/ui/MetaListItem/MetaListItem.tsx
@@ -12,7 +12,7 @@
  * 利用例:
  *   // 内部リンク（過去問逆引き）
  *   <Link href={...} className="block group">
- *     <MetaListItem title={<>{year} <span className="text-gray-700 dark:text-gray-300">{question}</span></>} />
+ *     <MetaListItem title={<>{year} <span className="text-[var(--ink-body)]">{question}</span></>} />
  *   </Link>
  *
  *   // 外部リンク（参考資料）
@@ -38,18 +38,18 @@ interface MetaListItemProps {
 
 export default function MetaListItem({ title, source, plain = false }: MetaListItemProps) {
   const titleClassName = plain
-    ? 'text-gray-700 dark:text-gray-300'
-    : 'text-blue-600 dark:text-blue-400 group-hover:text-blue-800 dark:group-hover:text-blue-300 group-hover:underline';
+    ? 'text-[var(--ink-body)]'
+    : 'text-[var(--accent)] group-hover:text-[var(--accent)] group-hover:underline';
 
   return (
     <div className="flex items-baseline gap-2 text-sm">
-      <span className="text-gray-500 dark:text-gray-400 shrink-0 leading-tight">→</span>
+      <span className="text-[var(--ink-muted)] shrink-0 leading-tight">→</span>
       <span className="min-w-0">
         <span className={titleClassName}>{title}</span>
         {source && (
           <>
             {' '}
-            <span className="text-xs text-gray-500 dark:text-gray-400">{source}</span>
+            <span className="text-xs text-[var(--ink-muted)]">{source}</span>
           </>
         )}
       </span>

--- a/src/components/ui/NoteLink/NoteLink.tsx
+++ b/src/components/ui/NoteLink/NoteLink.tsx
@@ -61,11 +61,11 @@ export default function NoteLink({
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="not-prose group my-6 block max-w-2xl rounded-card-content overflow-hidden border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
+      className="not-prose group my-6 block max-w-2xl rounded-card-content overflow-hidden border border-[var(--rule-soft)] bg-[var(--paper)] shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
     >
       <div className="flex flex-col sm:flex-row">
         {imageUrl && (
-          <div className="relative w-full sm:w-[240px] shrink-0 aspect-square bg-gray-100 dark:bg-gray-800">
+          <div className="relative w-full sm:w-[240px] shrink-0 aspect-square bg-[var(--bg)]">
             <Image
               src={imageUrl}
               alt={title}
@@ -84,16 +84,16 @@ export default function NoteLink({
         )}
         <div className="min-w-0 flex-1 p-3 sm:p-4">
           <div className="flex items-start justify-between gap-2 mb-1.5">
-            <span className="text-[11px] text-ink-muted dark:text-gray-500 font-medium">
+            <span className="text-[11px] text-ink-muted font-medium">
               note（dobokunote）
             </span>
-            <ExternalLink className="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 group-hover:text-brand dark:group-hover:text-brand transition-colors shrink-0" />
+            <ExternalLink className="w-3.5 h-3.5 text-[var(--ink-muted)] group-hover:text-brand dark:group-hover:text-brand transition-colors shrink-0" />
           </div>
-          <div className="text-[14px] sm:text-[15px] font-bold text-ink-strong dark:text-gray-100 leading-tight group-hover:text-brand-deep dark:group-hover:text-brand transition-colors line-clamp-2">
+          <div className="text-[14px] sm:text-[15px] font-bold text-ink-strong leading-tight group-hover:text-brand-deep dark:group-hover:text-brand transition-colors line-clamp-2">
             {title}
           </div>
           {description && (
-            <p className="mt-1.5 text-[12px] sm:text-[13px] leading-snug text-ink-body dark:text-gray-400 line-clamp-2 sm:line-clamp-3">
+            <p className="mt-1.5 text-[12px] sm:text-[13px] leading-snug text-ink-body line-clamp-2 sm:line-clamp-3">
               {description}
             </p>
           )}

--- a/src/components/ui/PastExamBacklinks/PastExamBacklinks.tsx
+++ b/src/components/ui/PastExamBacklinks/PastExamBacklinks.tsx
@@ -60,10 +60,10 @@ export default function PastExamBacklinks({ category, currentSlug }: PastExamBac
 
     return (
       <MetaCard ariaLabel="過去問での出題">
-        <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">
+        <h2 className="text-lg font-bold text-[var(--ink)] mb-1">
           過去問での出題
         </h2>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        <p className="text-sm text-[var(--ink-muted)] mb-4">
           この教材の分野が登場した {label}の過去問 ({civilEntries.length} 件)
         </p>
         <ul className="space-y-2">
@@ -77,7 +77,7 @@ export default function PastExamBacklinks({ category, currentSlug }: PastExamBac
                   title={
                     <>
                       {b.examTitle}{' '}
-                      <span className="text-gray-700 dark:text-gray-300">{b.section}</span>
+                      <span className="text-[var(--ink-body)]">{b.section}</span>
                     </>
                   }
                 />
@@ -98,10 +98,10 @@ export default function PastExamBacklinks({ category, currentSlug }: PastExamBac
 
   return (
     <MetaCard ariaLabel="過去問での出題">
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-1">
         過去問での出題
       </h2>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      <p className="text-sm text-[var(--ink-muted)] mb-4">
         このキーワードが登場した過去問の設問
       </p>
       <ul className="space-y-2">
@@ -112,7 +112,7 @@ export default function PastExamBacklinks({ category, currentSlug }: PastExamBac
                 title={
                   <>
                     {b.year}{' '}
-                    <span className="text-gray-700 dark:text-gray-300">{b.question}</span>
+                    <span className="text-[var(--ink-body)]">{b.question}</span>
                   </>
                 }
               />

--- a/src/components/ui/PdcaCycle/PdcaCycle.tsx
+++ b/src/components/ui/PdcaCycle/PdcaCycle.tsx
@@ -133,7 +133,7 @@ export default function PdcaCycle({ items }: PdcaCycleProps) {
           return (
             <div
               key={i}
-              className="flex items-start gap-3 p-3 rounded-card-content shadow-card-content border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+              className="flex items-start gap-3 p-3 rounded-card-content shadow-card-content border border-[var(--rule-soft)] bg-[var(--paper)]"
             >
               <div
                 className="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-white font-bold text-sm"
@@ -142,10 +142,10 @@ export default function PdcaCycle({ items }: PdcaCycleProps) {
                 {PHASE_LETTERS[i]}
               </div>
               <div className="flex-1 min-w-0">
-                <div className="font-bold text-sm text-gray-900 dark:text-gray-100">
+                <div className="font-bold text-sm text-[var(--ink)]">
                   {item.label}
                 </div>
-                <div className="text-sm text-gray-600 dark:text-gray-400 mt-0.5">
+                <div className="text-sm text-[var(--ink-body)] mt-0.5">
                   {item.description}
                 </div>
               </div>

--- a/src/components/ui/PersonaSelector/PersonaSelector.tsx
+++ b/src/components/ui/PersonaSelector/PersonaSelector.tsx
@@ -74,7 +74,7 @@ function resolveItems(
 }
 
 const CARD_BASE_CLASS =
-  "not-prose flex items-start gap-3 rounded-card-content border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-3 shadow-card-content";
+  "not-prose flex items-start gap-3 rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] px-3 py-3 shadow-card-content";
 
 const CARD_LINK_CLASS =
   "group hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow";
@@ -97,11 +97,11 @@ function PersonaCardInner({ personaName, caption, isLink }: PersonaCardInnerProp
       </span>
       <div className="min-w-0 flex-1 leading-snug">
         <div
-          className={`text-[14px] font-bold text-ink-strong dark:text-gray-100 ${isLink ? "group-hover:underline" : ""}`}
+          className={`text-[14px] font-bold text-ink-strong ${isLink ? "group-hover:underline" : ""}`}
         >
           {personaName}
         </div>
-        <div className="mt-0.5 text-[12px] text-ink-body dark:text-gray-300">{caption}</div>
+        <div className="mt-0.5 text-[12px] text-ink-body">{caption}</div>
       </div>
       {isLink && (
         <ArrowRight
@@ -119,7 +119,7 @@ export default function PersonaSelector({ items, mode, label }: PersonaSelectorP
   return (
     <div className="not-prose my-5">
       {label && (
-        <div className="mb-2 text-[11px] font-bold tracking-wider text-ink-muted dark:text-gray-400 uppercase">
+        <div className="mb-2 text-[11px] font-bold tracking-wider text-ink-muted uppercase">
           {label}
         </div>
       )}

--- a/src/components/ui/PillarNavCard/PillarNavCard.tsx
+++ b/src/components/ui/PillarNavCard/PillarNavCard.tsx
@@ -45,7 +45,7 @@ export default function PillarNavCard({ variant, currentSection }: PillarNavCard
     return (
       <MetaCard as="div" padding="compact">
         <div
-          className="nav-card-title text-gray-900 dark:text-white"
+          className="nav-card-title text-[var(--ink)]"
         >
           5 管理学習ガイド
         </div>
@@ -59,8 +59,8 @@ export default function PillarNavCard({ variant, currentSection }: PillarNavCard
                   aria-current={isActive ? "true" : undefined}
                   className={
                     isActive
-                      ? "text-sm font-bold text-gray-900 dark:text-gray-100"
-                      : "text-sm text-gray-600 dark:text-gray-400 hover:text-brand hover:underline"
+                      ? "text-sm font-bold text-[var(--ink)]"
+                      : "text-sm text-[var(--ink-body)] hover:text-brand hover:underline"
                   }
                 >
                   {p.label}
@@ -75,7 +75,7 @@ export default function PillarNavCard({ variant, currentSection }: PillarNavCard
 
   return (
     <MetaCard>
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-4">
         5 管理学習ガイド
       </h2>
       <ul className="space-y-2">
@@ -86,8 +86,8 @@ export default function PillarNavCard({ variant, currentSection }: PillarNavCard
               key={p.slug}
               className={`rounded-sm border px-4 py-3 transition-colors ${
                 isActive
-                  ? "bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800"
-                  : "border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-500"
+                  ? "bg-[var(--accent-fill)] border-[var(--accent)]"
+                  : "border-[var(--rule-soft)] hover:border-[var(--accent)]"
               }`}
             >
               <Link
@@ -95,7 +95,7 @@ export default function PillarNavCard({ variant, currentSection }: PillarNavCard
                 aria-current={isActive ? "true" : undefined}
                 className={
                   isActive
-                    ? "text-sm font-bold text-gray-900 dark:text-gray-100"
+                    ? "text-sm font-bold text-[var(--ink)]"
                     : "text-sm text-brand hover:underline"
                 }
               >

--- a/src/components/ui/RelatedArticles/RelatedArticles.tsx
+++ b/src/components/ui/RelatedArticles/RelatedArticles.tsx
@@ -59,8 +59,8 @@ export default function RelatedArticles({ currentMeta, categoryArticles }: Relat
 
   return (
     <MetaCard>
-      <h2 className="mb-1 text-lg font-bold text-gray-900 dark:text-white">関連記事</h2>
-      <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+      <h2 className="mb-1 text-lg font-bold text-[var(--ink)]">関連記事</h2>
+      <p className="mb-4 text-sm text-[var(--ink-muted)]">
         同じテーマの記事 ({related.length} 件)
       </p>
       <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -68,11 +68,11 @@ export default function RelatedArticles({ currentMeta, categoryArticles }: Relat
           <li key={doc.slug}>
             <Link
               href={`/docs/${doc.slug}`}
-              className="block h-full rounded-sm border border-gray-200 px-4 py-3 transition-colors hover:border-brand dark:border-gray-700 dark:hover:border-brand"
+              className="block h-full rounded-sm border border-[var(--rule-soft)] px-4 py-3 transition-colors hover:border-brand dark:hover:border-brand"
             >
               <div className="text-sm font-semibold text-brand">{doc.title}</div>
               {doc.description && (
-                <div className="mt-1 line-clamp-2 text-xs text-gray-600 dark:text-gray-400">
+                <div className="mt-1 line-clamp-2 text-xs text-[var(--ink-body)]">
                   {doc.description}
                 </div>
               )}

--- a/src/components/ui/RelatedKeywords/RelatedKeywords.tsx
+++ b/src/components/ui/RelatedKeywords/RelatedKeywords.tsx
@@ -48,23 +48,23 @@ export default function RelatedKeywords({ items }: RelatedKeywordsProps) {
               <span key={index} className="inline-flex items-center">
                 <Link
                   href={buildHref(item.slug)}
-                  className="text-sm text-blue-700 dark:text-blue-400 hover:underline"
+                  className="text-sm text-[var(--accent)] hover:underline"
                 >
                   {item.label}
                 </Link>
                 {!isLast && (
-                  <span className="text-gray-400 dark:text-gray-500 ml-1">|</span>
+                  <span className="text-[var(--ink-muted)] ml-1">|</span>
                 )}
               </span>
             );
           }
           return (
             <span key={index} className="inline-flex items-center">
-              <span className="text-sm text-gray-500 dark:text-gray-400">
+              <span className="text-sm text-[var(--ink-muted)]">
                 {item.label}
               </span>
               {!isLast && (
-                <span className="text-gray-300 dark:text-gray-600 ml-1">|</span>
+                <span className="text-[var(--ink-muted)] opacity-50 ml-1">|</span>
               )}
             </span>
           );

--- a/src/components/ui/RelatedTextbooks/RelatedTextbooks.tsx
+++ b/src/components/ui/RelatedTextbooks/RelatedTextbooks.tsx
@@ -138,10 +138,10 @@ export default function RelatedTextbooks({ currentMeta, categoryArticles }: Rela
 
   return (
     <MetaCard>
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-1">
         この試験で扱われた教材
       </h2>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      <p className="text-sm text-[var(--ink-muted)] mb-4">
         問題の分野に関連する教科書の章 ({entries.length} 件)
       </p>
       <ul className="space-y-2">
@@ -149,11 +149,11 @@ export default function RelatedTextbooks({ currentMeta, categoryArticles }: Rela
           <li key={doc.slug}>
             <Link
               href={`/docs/${doc.slug}`}
-              className="block rounded-sm border border-gray-200 dark:border-gray-700 px-4 py-3 hover:border-blue-400 dark:hover:border-blue-500 transition-colors"
+              className="block rounded-sm border border-[var(--rule-soft)] px-4 py-3 hover:border-[var(--accent)] transition-colors"
             >
-              <div className="text-sm font-semibold text-blue-600 dark:text-blue-400">{doc.title}</div>
+              <div className="text-sm font-semibold text-[var(--accent)]">{doc.title}</div>
               {doc.description && (
-                <div className="text-xs text-gray-600 dark:text-gray-400 mt-1 line-clamp-2">{doc.description}</div>
+                <div className="text-xs text-[var(--ink-body)] mt-1 line-clamp-2">{doc.description}</div>
               )}
             </Link>
           </li>

--- a/src/components/ui/SectionKeywords.tsx
+++ b/src/components/ui/SectionKeywords.tsx
@@ -26,10 +26,10 @@ export default function SectionKeywords({ currentSlug, section }: SectionKeyword
 
   return (
     <MetaCard ariaLabel="同セクションのキーワード">
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-1">
         {sec.title}
       </h2>
-      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      <p className="text-sm text-[var(--ink-muted)] mb-4">
         {chapter.title} &mdash; セクション {section}
       </p>
       <div className="flex flex-wrap gap-2">
@@ -37,7 +37,7 @@ export default function SectionKeywords({ currentSlug, section }: SectionKeyword
           <Link
             key={kw.slug}
             href={`/docs/pe-comprehensive-management-${kw.slug}`}
-            className="text-sm px-3 py-1.5 rounded-full border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:border-blue-400 dark:hover:border-blue-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+            className="text-sm px-3 py-1.5 rounded-full border border-[var(--rule-soft)] bg-[var(--bg)] text-[var(--ink-body)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
           >
             {kw.title}
           </Link>

--- a/src/components/ui/SeeAlso/SeeAlso.tsx
+++ b/src/components/ui/SeeAlso/SeeAlso.tsx
@@ -25,7 +25,7 @@ export default function SeeAlso({ href, title, reason }: SeeAlsoProps) {
   return (
     <Link
       href={href}
-      className="not-prose group my-5 flex items-start gap-3 rounded-card-content border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3.5 shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
+      className="not-prose group my-5 flex items-start gap-3 rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] px-4 py-3.5 shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
       style={{ textDecoration: "none" }}
     >
       <span
@@ -40,11 +40,11 @@ export default function SeeAlso({ href, title, reason }: SeeAlsoProps) {
         <div className="text-[11px] font-bold tracking-wider text-brand-deep dark:text-brand uppercase">
           あわせて読みたい
         </div>
-        <div className="mt-0.5 text-[15px] font-bold text-ink-strong dark:text-gray-100 group-hover:underline">
+        <div className="mt-0.5 text-[15px] font-bold text-ink-strong group-hover:underline">
           {title}
         </div>
         {reason && (
-          <div className="mt-1 text-sm leading-6 text-ink-body dark:text-gray-400">
+          <div className="mt-1 text-sm leading-6 text-ink-body">
             {reason}
           </div>
         )}

--- a/src/components/ui/SidebarAdBanner/SidebarAdBanner.tsx
+++ b/src/components/ui/SidebarAdBanner/SidebarAdBanner.tsx
@@ -31,7 +31,7 @@ export default function SidebarAdBanner({
 }: SidebarAdBannerProps) {
   return (
     <div className="not-prose mt-3">
-      <div className="relative overflow-hidden rounded-card-content border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-2 shadow-card-content">
+      <div className="relative overflow-hidden rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] p-2 shadow-card-content">
         <span
           className="absolute right-2 top-2 z-10 inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wider text-white"
           style={{ background: "var(--color-ink-muted)" }}

--- a/src/components/ui/SourceBadges/SourceBadges.tsx
+++ b/src/components/ui/SourceBadges/SourceBadges.tsx
@@ -30,7 +30,7 @@ export default function SourceBadges({ label = "関連白書", items }: SourceBa
   if (!items || items.length === 0) return null;
   return (
     <div className="not-prose my-4 flex items-baseline gap-2 flex-wrap">
-      <span className="text-[11px] font-bold tracking-wider text-ink-muted dark:text-gray-400 uppercase shrink-0">
+      <span className="text-[11px] font-bold tracking-wider text-ink-muted uppercase shrink-0">
         {label}
       </span>
       <div className="flex gap-1.5 flex-wrap">

--- a/src/components/ui/SpokeNavCard/SpokeNavCard.tsx
+++ b/src/components/ui/SpokeNavCard/SpokeNavCard.tsx
@@ -25,7 +25,7 @@ export default function SpokeNavCard({ href, label, title }: SpokeNavCardProps) 
   return (
     <Link
       href={href}
-      className="not-prose group my-4 flex items-center gap-3 rounded-card-content border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
+      className="not-prose group my-4 flex items-center gap-3 rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] px-4 py-3 shadow-card-content hover:shadow-card-hover hover:border-brand transition-shadow"
       style={{ textDecoration: "none" }}
     >
       <span
@@ -40,7 +40,7 @@ export default function SpokeNavCard({ href, label, title }: SpokeNavCardProps) 
         <div className="text-[11px] font-bold tracking-wider text-brand-deep dark:text-brand uppercase">
           {label}
         </div>
-        <div className="mt-0.5 text-[14px] font-bold text-ink-strong dark:text-gray-100 group-hover:underline truncate">
+        <div className="mt-0.5 text-[14px] font-bold text-ink-strong group-hover:underline truncate">
           {title}
         </div>
       </div>

--- a/src/components/ui/TextbookNav/TextbookNav.tsx
+++ b/src/components/ui/TextbookNav/TextbookNav.tsx
@@ -27,17 +27,17 @@ export default function TextbookNav({ currentSlug, categoryArticles }: TextbookN
 
   return (
     <MetaCard>
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-4">
         テキスト章ナビゲーション
       </h2>
       <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
         {prev ? (
           <Link
             href={`/docs/${prev.slug}`}
-            className="block rounded-sm border border-gray-200 dark:border-gray-700 p-4 hover:border-blue-400 dark:hover:border-blue-500 transition-colors"
+            className="block rounded-sm border border-[var(--rule-soft)] p-4 hover:border-[var(--accent)] transition-colors"
           >
-            <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">← 前の章</div>
-            <div className="text-sm font-semibold text-blue-600 dark:text-blue-400">{prev.title}</div>
+            <div className="text-xs text-[var(--ink-muted)] mb-1">← 前の章</div>
+            <div className="text-sm font-semibold text-[var(--accent)]">{prev.title}</div>
           </Link>
         ) : (
           <div />
@@ -45,10 +45,10 @@ export default function TextbookNav({ currentSlug, categoryArticles }: TextbookN
         {next ? (
           <Link
             href={`/docs/${next.slug}`}
-            className="block rounded-sm border border-gray-200 dark:border-gray-700 p-4 hover:border-blue-400 dark:hover:border-blue-500 transition-colors text-right"
+            className="block rounded-sm border border-[var(--rule-soft)] p-4 hover:border-[var(--accent)] transition-colors text-right"
           >
-            <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">次の章 →</div>
-            <div className="text-sm font-semibold text-blue-600 dark:text-blue-400">{next.title}</div>
+            <div className="text-xs text-[var(--ink-muted)] mb-1">次の章 →</div>
+            <div className="text-sm font-semibold text-[var(--accent)]">{next.title}</div>
           </Link>
         ) : (
           <div />

--- a/src/components/ui/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle/ThemeToggle.tsx
@@ -67,7 +67,7 @@ export default function ThemeToggle() {
   if (!mounted) {
     return (
       <button
-        className="w-9 h-9 rounded-sm bg-gray-200 dark:bg-gray-700 animate-pulse"
+        className="w-9 h-9 rounded-sm bg-[var(--rule-soft)] animate-pulse"
         disabled
         aria-label="読み込み中..."
       />
@@ -86,7 +86,7 @@ export default function ThemeToggle() {
     if (resolvedTheme === 'dark') {
       return <Sun className="w-5 h-5 text-yellow-500" />;
     }
-    return <Moon className="w-5 h-5 text-gray-700 dark:text-gray-300" />;
+    return <Moon className="w-5 h-5 text-[var(--ink-body)]" />;
   };
 
   const getAriaLabel = () => {
@@ -96,12 +96,12 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={cycleTheme}
-      className="flex flex-col items-center space-y-1 px-3 py-2 rounded-sm bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+      className="flex flex-col items-center space-y-1 px-3 py-2 rounded-sm bg-[var(--bg)] hover:bg-[var(--accent-fill)] transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2"
       aria-label={getAriaLabel()}
       title={`現在: ${theme === 'dark' ? 'dark' : 'light'}モード`}
     >
       {getIcon()}
-      <span className="hidden md:block text-xs font-medium text-gray-700 dark:text-gray-300">
+      <span className="hidden md:block text-xs font-medium text-[var(--ink-body)]">
         {theme === 'dark' ? 'dark' : 'light'}
       </span>
     </button>

--- a/src/components/ui/Timeline/Timeline.tsx
+++ b/src/components/ui/Timeline/Timeline.tsx
@@ -28,22 +28,22 @@ export default function Timeline({ items, className = "" }: TimelineProps) {
 
   return (
     <div className={`my-6 ml-4 ${className}`}>
-      <div className="space-y-6 border-l-2 border-dashed border-primary-300 dark:border-primary-600">
+      <div className="space-y-6 border-l-2 border-dashed border-[var(--accent)]">
         {items.map((item, index) => {
           const IconComponent = getIcon(item.icon);
 
           return (
             <div key={index} className="relative w-full">
-              <IconComponent className="absolute -top-0.5 z-10 -ml-3.5 h-7 w-7 rounded-full bg-white dark:bg-gray-900 text-primary-500 dark:text-primary-400" />
+              <IconComponent className="absolute -top-0.5 z-10 -ml-3.5 h-7 w-7 rounded-full bg-[var(--paper)] text-[var(--accent)]" />
               <div className="ml-8">
-                <div className="font-bold text-primary-600 dark:text-primary-400 text-base md:text-lg">
+                <div className="font-bold text-[var(--accent)] text-base md:text-lg">
                   {item.title}
                 </div>
-                <p className="mt-2 text-sm md:text-base text-gray-600 dark:text-gray-300 leading-relaxed">
+                <p className="mt-2 text-sm md:text-base text-[var(--ink-body)] leading-relaxed">
                   {item.description}
                 </p>
                 {item.time && (
-                  <span className="mt-2 inline-block text-sm font-semibold text-primary-500 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/20 px-2 py-1 rounded-sm">
+                  <span className="mt-2 inline-block text-sm font-semibold text-[var(--accent)] bg-[var(--accent-fill)] px-2 py-1 rounded-sm">
                     {item.time}
                   </span>
                 )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -270,19 +270,23 @@
 
   /* h3: サブセクション — 中間色の左アクセントバー（ゴシック・太さ700） */
   .prose-blog h3 {
-    @apply font-bold text-gray-800 dark:text-gray-200;
+    @apply font-bold;
+    color: var(--ink);
     font-size: var(--font-size-h3);
     line-height: 1.4;
     @apply mb-4 mt-12 pl-4 py-1;
-    @apply border-l-4 border-blue-400 dark:border-cyan-400;
+    @apply border-l-4;
+    border-left-color: var(--accent);
     letter-spacing: -0.01em;
   }
 
   /* h4: 小見出し — 細いグレーの左アクセント */
   .prose-blog h4 {
-    @apply text-lg font-semibold text-gray-700 dark:text-gray-300;
+    @apply text-lg font-semibold;
+    color: var(--ink-body);
     @apply mb-3 mt-8 pl-3;
-    @apply border-l-2 border-gray-300 dark:border-gray-600;
+    @apply border-l-2;
+    border-left-color: var(--rule-soft);
     letter-spacing: -0.01em;
   }
 


### PR DESCRIPTION
## 概要

デザイン改善ロードマップ後の**総仕上げ**。これまで page 層（app/）は token 統一済だったが、`src/components/ui/**` の共有 UI コンポーネントに旧 Tailwind パレットが残り、docs/category 等で page と chrome の世代差が出ていた。これを解消し、全レイヤーを editorial token に統一する。

35 ファイル変更（うち装飾系 24 は仕様駆動の並列移行、意味色・基底・特殊 11 は個別判断）。

## 変更
- **装飾系 24 コンポーネント**: CategoryNavCard / AuthorCard / PillarNavCard / SpokeNavCard / TextbookNav / Related{Articles,Keywords,Textbooks} / SectionKeywords / MetaListItem / LinkCard / NoteLink / MagazineInlineCard / MagazineSidebarCard / SidebarAdBanner / PastExamBacklinks / BackToTopButton / PersonaSelector / CareerAffiliate / SeeAlso / ExamQuestionNav / ExternalReferences / SourceBadges / ArticleImage を `border→rule-soft` / `link・active→accent` / `hover→accent-fill` / `地→paper・bg` へ。`dark:` 変種はトークンが theme-aware のため削除。
- **MetaCard 基底**: `bg-white/gray-800 + border-gray-200/60` → `paper + rule-soft`（SectionCard と同一 chrome）。12+ 消費先を一括統一。
- **DataTable / Timeline / ThemeToggle / FAQCard**: token 化（ハードコード hex `#4c9ac0` も accent へ）。
- **意味色の正規化**: MDX コンパイルエラーの warn ボックス → `--color-warn`(+fill)、検索 error → `--color-danger`(+fill)。

## 意図的に保持（§7/§8）
- **ExamFields の 5 管理色**（blue/emerald/amber/rose/teal）= 5 管理を識別するドメイン意味色。editorial mono へ平坦化すると教育的意味が消えるため保持（コメントで明記）。
- **PdcaCycle の P/D/C/A 4 色 SVG** = インフォグラフィック意味色。
- **検索ハイライト `<mark>` の黄・Sun アイコンの黄** = iconographic。

## 検証
- 残 legacy 色スキャン = 上記の意図分のみ（装飾の gray/blue/primary/cyan/neutral は **0**）。
- `type-check` / `lint` クリーン、pre-commit/pre-push 全ゲート通過。
- `next build`（webpack）で全 **1030+ ルート**（docs/category/全 page）prerender 成功。

Vercel check は stale 統合（本番=Cloudflare・GH Actions build=正）のため無視可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)