### PR TITLE
fix(design): 既定 border の token 化 + 残存デッドコード除去（QA 仕上げ）

### DIFF
--- a/src/components/icons/CategoryIcons.tsx
+++ b/src/components/icons/CategoryIcons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Briefcase, Heart } from "lucide-react";
 
 export const getCategoryIcon = (iconName: string, className?: string) => {

--- a/src/lib/mdx-callout-parser.ts
+++ b/src/lib/mdx-callout-parser.ts
@@ -127,7 +127,7 @@ function generateCalloutComponent(type: string, title: string, content: string[]
 export function parseInlineCallouts(content: string): string {
   return content.replace(
     />\s*\[!(\w+)\](.*?)$/gm,
-    (match, type, title) => {
+    (_match, type, title) => {
       const cleanType = (type as string)?.toLowerCase() || 'info';
       const cleanTitle = (title as string)?.trim() || '';
       const supportedType = SUPPORTED_TYPES.includes(cleanType) ? cleanType : 'info';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,19 @@
 @tailwind components;
 @tailwind utilities;
 
+/* 既定の border 色をエディトリアル token に向ける。
+   Tailwind preflight は color クラス未指定の border-* を gray-200 固定にするため、
+   ダークモードで bare な罫線（Callout の border-l・prose のテーブル/hr 等）が追従しない。
+   既定値を --rule-soft（light/dark 両定義）に上書きして theme-aware にする。
+   明示的な border-[var(--...)] / border-{color} はユーティリティ specificity が勝つため不変。 */
+@layer base {
+  *,
+  ::before,
+  ::after {
+    border-color: var(--rule-soft);
+  }
+}
+
 /* ===== Base Styles ===== */
 @layer base {
   /* Card design tokens — single source of truth */


### PR DESCRIPTION
## 概要

コンポーネント token 化(#289)後の**視覚 QA（Playwright）と dead-code レビューで見つかった仕上げ**をまとめた最終ポリッシュ PR。

## 1. 既定 border 色の token 化（ダークモード追従の完成）

視覚 QA で、ダークモード時に color クラス未指定の bare な `border-*`（Callout の `border-l-[3px]`・prose のテーブル/hr 等 **33 箇所**）が Tailwind preflight の既定 gray-200 のまま暗転しない既存事象を検出。

`src/styles/globals.css` の base layer に1規則：
```css
@layer base { *, ::before, ::after { border-color: var(--rule-soft); } }
```
- **light**: rule-soft(#e8e8eb) ≈ gray-200 で見た目ほぼ不変。
- **dark**: rule-soft(#2a2a2a) へ追従。
- 明示的 `border-[var(--..)]`/`border-{color}` はユーティリティ specificity が勝つため不変。

検証: preview(out/) を Playwright で dark 検証 → 既定 gray 罫線 **33→0**・白背景 **0**。

## 2. 残存デッドコード除去（dead-code レビュー完結）

`docs/reviews/code/2026-06-27-dead-code-candidates.md` の残項目。大型候補（inlineMobileOnly / component-loader 二重管理 / SidebarSearch / 旧サイドバー系 / ReferenceCardLink / ErrorBoundary）は **Phase 0f(PR #284) で除去済み**。残る確実な未使用 local 2件を処理：
- `CategoryIcons.tsx`: 未使用 `React` import 削除（新 JSX 変換で不要）。
- `mdx-callout-parser.ts`: replace callback の未使用 `match` を `_match` へ。

検証: `tsc --noEmit --noUnusedLocals --noUnusedParameters` クリーン化。

## 全体検証
- `type-check` / `lint` クリーン、`next build`(webpack) 成功、pre-commit/pre-push 全ゲート通過。

Vercel check は stale 統合（本番=Cloudflare・GH Actions build=正）のため無視可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)