### PR TITLE
feat(note): 公開済みカバーのライブ差し替えツール note-update-cover を正式化

### DIFF
--- a/.claude/agents/note-cover-writer.md
+++ b/.claude/agents/note-cover-writer.md
@@ -72,3 +72,4 @@ generate: 32 covers 再生成
 - **テンプレ実装・色定義** — `ogp-create` スキル（`renderNoteCoverG2` / tokens）
 - **マガジンヘッダーカバー** — `generate-magazine-covers.mjs`（`magazine-banner`、別系統）
 - **本文・図版の編集** — 別工程
+- **公開済み記事のライブ反映** — 別工程。本エージェントは `cover:` 執筆＋PNG 再生成まで。**すでに公開済みの記事**は cover.png を作り直しても note 側に自動反映されないため、`npm run note-update-cover`（`scripts/note-update-cover.mjs`・有料 paywall 保持）でライブ差し替えする。真実源 → `docs/design-system/note-cover.md`「ライブ反映」

--- a/.claude/skills/conversion/ogp-create/SKILL.md
+++ b/.claude/skills/conversion/ogp-create/SKILL.md
@@ -196,6 +196,7 @@ node scripts/generate-note-covers.mjs 1級土木    # slug 部分一致で対象
 node scripts/generate-note-covers.mjs 安全管理   # slug 部分一致で 1 記事だけ再生成
 npm run note-cover-gallery                        # 全 cover を1枚 HTML で目視（OGP の ogp-gallery と対称・資格×種別で絞込）
 npm run check-note-cover-fit                      # banner/hi/leadIn がフル1280幅超で画面外に切れる"真の溢れ"を検出（0件必須・pre-commit でも --staged）
+npm run note-update-cover -- --list <file> --commit  # 公開済み記事の stale カバーをライブ差し替え（有料 paywall 保持・本文不触）
 ```
 
 > banner は工事名列挙・科目名等の **descriptive テキストが正規**で 7〜11 字超を許容（`bannerFontSize` が 48px まで自動縮小しフル幅には収まる／正方形クロップで両端が切れるのは想定内）。`check-note-cover-fit` が止めるのは**フル幅すら超えて画面外で切れる**ケースのみ。真実源 [`note-cover.md`](../../../../docs/design-system/note-cover.md)。

--- a/.claude/skills/social/publish-note/references/update-mode.md
+++ b/.claude/skills/social/publish-note/references/update-mode.md
@@ -219,6 +219,8 @@ await page.keyboard.press('Delete');
 カバー画像を更新する場合、本文編集の前にアイキャッチを差し替える。
 editor-operations.md Phase 2 と同じ手順で既存アイキャッチを置き換える（画像はアップロード操作なので edit 画面でも機能する。paste 制約は本文テキストのみ）。
 
+> **カバーだけを更新する（本文を触らない）場合は専用ツールが速い**: `cover.png` 再デザイン後の stale カバー（git 最終コミット日 > `notePublishedAt`）を一括差し替えするなら `npm run note-update-cover -- --list <file> --commit`（`scripts/note-update-cover.mjs`）。本文不触なので有料記事の paywall 境界は自然保持され、ツールは境界 line の present を読み取り検証するのみ（line を動かさない）＋新カバー load 未確認なら保存しない fail-safe。一回限り `.tmp/*.mjs` を書かずこれを使う。詳細 → [`docs/design-system/note-cover.md`](../../../../../docs/design-system/note-cover.md)「ライブ反映」。
+
 ### Phase U-6: 「公開に進む」→「更新する」（2 段）
 
 公開済み記事の編集画面でも、右上ボタンは create と同じ **「公開に進む」**。

--- a/.claude/skills/social/publish-note/references/update-mode.md
+++ b/.claude/skills/social/publish-note/references/update-mode.md
@@ -219,7 +219,7 @@ await page.keyboard.press('Delete');
 カバー画像を更新する場合、本文編集の前にアイキャッチを差し替える。
 editor-operations.md Phase 2 と同じ手順で既存アイキャッチを置き換える（画像はアップロード操作なので edit 画面でも機能する。paste 制約は本文テキストのみ）。
 
-> **カバーだけを更新する（本文を触らない）場合は専用ツールが速い**: `cover.png` 再デザイン後の stale カバー（git 最終コミット日 > `notePublishedAt`）を一括差し替えするなら `npm run note-update-cover -- --list <file> --commit`（`scripts/note-update-cover.mjs`）。本文不触なので有料記事の paywall 境界は自然保持され、ツールは境界 line の present を読み取り検証するのみ（line を動かさない）＋新カバー load 未確認なら保存しない fail-safe。一回限り `.tmp/*.mjs` を書かずこれを使う。詳細 → [`docs/design-system/note-cover.md`](../../../../../docs/design-system/note-cover.md)「ライブ反映」。
+> **カバーだけの一括差し替え（本文を触らない・公開済み記事）は専用ツール `npm run note-update-cover` を使う**（一回限り `.tmp/*.mjs` を書かない）。stale 検出ルール・paywall 保持の仕組み・fail-safe 仕様は真実源 [`docs/design-system/note-cover.md`](../../../../../docs/design-system/note-cover.md)「ライブ反映」に集約（本節では再掲しない）。
 
 ### Phase U-6: 「公開に進む」→「更新する」（2 段）
 

--- a/docs/design-system/note-cover.md
+++ b/docs/design-system/note-cover.md
@@ -117,6 +117,22 @@ npm run check-note-cover-fit      # CI/手動（0件必須）。pre-commit は -
 
 `check-note-cover-fit` は `renderNoteCoverG2` のレイアウト式（`bannerFontSize`/`hiFontSize`・上段 1160px・banner 1280px）をミラーする回帰ゲート。「7〜11字推奨」超過は**検出しない**（descriptive banner は正規）。検出するのは画面外クリップのみ。
 
+## ライブ反映（公開後の stale カバー解消）
+
+`cover.png` を再デザインしても、**公開済み note 記事のカバーは自動では更新されない**（ソース→ライブ非同期）。stale 判定は `cover.png` の git 最終コミット日 > frontmatter `notePublishedAt`。差し替えはブラウザ自動化で行う。
+
+```bash
+# DRY（差し替え load 確認まで・保存しない）
+npm run note-update-cover -- --article docs/note/.../article.md
+# ライブ反映（公開に進む→更新する）。複数は --list で
+npm run note-update-cover -- --list .tmp/list.txt --commit
+```
+
+- 本文を一切触らず eyecatch だけ差し替えるため、**有料記事の paywall 境界は自然保持**される（`note-update-body` の境界「再設定」は不要。本ツールは境界 line の present を読み取り検証するのみで line を動かさない）。
+- fail-safe：新カバー load 未確認／有料境界 line 未確認なら「更新する」を押さない（coverless 化・paywall 開放を防ぐ）。
+- 永続プロファイルは 1 Chrome のみ＝**並列不可・逐次**。大量は 20-28 件チャンク×background 逐次で。
+- 反映後は note API v3 で `eyecatch` 新 ID・`can_read=false`・`price` 不変 を**実体検証**する（proxy 不可）。詳細 → [note-api-verification.md](../reference/note-api-verification.md)
+
 ## 関連
 
 - 値 SSoT: [`note-cover-tokens.json`](note-cover-tokens.json)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "note-price-sweep": "node scripts/note-price-sweep.mjs",
     "note-publish-magazine": "node scripts/note-publish-magazine.mjs",
     "note-update-body": "node scripts/note-update-body.mjs",
+    "note-update-cover": "node scripts/note-update-cover.mjs",
     "note-attach-file": "node scripts/note-attach-file.mjs",
     "note-attach-magazine-pdfs": "node scripts/note-attach-magazine-pdfs.mjs",
     "note-meta-lint": "node scripts/note-meta-lint.mjs",

--- a/scripts/note-update-cover.mjs
+++ b/scripts/note-update-cover.mjs
@@ -1,0 +1,156 @@
+/**
+ * note-update-cover.mjs — 公開済み note 記事の「カバー画像(eyecatch)」をライブ差し替えする
+ *
+ * note-publish.mjs（新規公開）/ note-update-body.mjs（本文差し替え）と対で、
+ * 「カバーだけを最新版へ差し替え→更新する」を担う。
+ * cover.png をサイト側で再デザイン（G2/キャラ variant 等）した後、ライブ note に未反映の
+ * "stale カバー" を解消する。検出は `cover.png` の git 最終コミット日 > frontmatter notePublishedAt。
+ *
+ * 使い方:
+ *   node scripts/note-update-cover.mjs --article <article.md path>            # DRY（差し替え load 確認まで・保存しない）
+ *   node scripts/note-update-cover.mjs --article <article.md path> --commit   # ライブ反映（公開に進む→更新する）
+ *   node scripts/note-update-cover.mjs --list <list.txt> --commit             # 複数（# 始まりは無視）
+ *
+ * フロー（doOne）:
+ *   editor 遷移 → (既存カバーあれば)カバーimg(img[src*=st-note] top<360)click → 「削除」(button exact)
+ *   → button[name=画像を追加] click → モーダル「画像をアップロード」を fileChooser で受け setFiles
+ *   → トリミング「保存」(exact) → 新カバー load 確認(st-note|blob|uploads, top<380, 10×polling)＝fail-safe
+ *   → --commit のみ: 公開に進む →
+ *        [有料] 有料エリア設定 click → 「このラインより先を有料にする」line present を読み取り検証
+ *               （line は動かさない＝本文を触らないので paywall 境界は元々保持される）→ 無ければ ABORT
+ *        [無料] スキップ
+ *      → 更新する(exact) → 更新通知は必ず「いいえ」（購入者への通知スパム防止）
+ *
+ * fail-safe:
+ *   - 新カバー load 未確認なら「更新する」を押さない（coverless 化を防ぐ）
+ *   - 有料記事で境界 line を確認できないなら ABORT（paywall 保護）
+ *
+ * 検証: ライブ反映後は note API v3 で eyecatch が新 ID・can_read=false・price 不変 を確認すること
+ *   （proxy ではなく実体検証。[[feedback_note_prepublish_verify_not_proxy]]）
+ *
+ * 制約: 永続プロファイル(.local/playwright-note-profile)は 1 Chrome インスタンスのみ
+ *   ＝複数 list を並列実行不可。大量は 20-28 件チャンク×逐次（background）で回す。
+ *
+ * 真実源/関連: docs/design-system/note-cover.md / docs/reference/note-api-verification.md
+ * 終了コード: 0 = 全件成功 / 1 = 1件以上失敗 / 2 = account gate 失敗
+ */
+import { chromium } from 'playwright';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync, existsSync } from 'node:fs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PROFILE = join(ROOT, '.local/playwright-note-profile');
+const COMMIT = process.argv.includes('--commit');
+const getA = (n) => { const i = process.argv.indexOf(n); return i >= 0 ? process.argv[i + 1] : null; };
+const ART = getA('--article');
+const LIST = getA('--list');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function arts() {
+  if (LIST) return readFileSync(resolve(ROOT, LIST), 'utf8').split(/\r?\n/).map((s) => s.trim()).filter((s) => s && !s.startsWith('#'));
+  if (ART) return [ART];
+  console.error('usage: --article <path> | --list <file>  [--commit]');
+  process.exit(2);
+}
+function parse(p) {
+  const abs = resolve(ROOT, p);
+  const raw = readFileSync(abs, 'utf8').replace(/^﻿/, '');
+  const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] || '';
+  const f = (k) => (fm.match(new RegExp('^' + k + ':\\s*(?:"(.*?)"|\'(.*?)\'|(.+?))\\s*$', 'm')) || []).slice(1).find(Boolean) || '';
+  const noteId = f('noteId');
+  const pricing = f('notePricing');
+  const m = abs.match(/article-([A-Za-z0-9-]+)\.md$/);
+  const cover = m ? join(dirname(abs), 'img', `cover-${m[1]}.png`) : join(dirname(abs), 'img', 'cover.png');
+  return { abs, noteId, pricing, cover };
+}
+
+async function doOne(page, { abs, noteId, pricing, cover }) {
+  const tag = abs.split(/[/\\]/).slice(-3).join('/');
+  console.log(`\n[article] ${noteId} ${tag} pricing=${pricing}`);
+  if (!/^n[0-9a-f]{6,}$/.test(noteId)) { console.error('[skip] noteId不正:', noteId); return false; }
+  if (!existsSync(cover)) { console.error('[skip] cover.png無し'); return false; }
+  await page.goto(`https://editor.note.com/notes/${noteId}/edit`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForSelector('[contenteditable=true]', { timeout: 30000 }); await sleep(4000);
+  // 1. 既存カバーを削除（差し替え方式）
+  let addBtn = page.getByRole('button', { name: '画像を追加' });
+  if (!(await addBtn.count())) {
+    let box = null;
+    for (let i = 0; i < 8 && !box; i++) {
+      box = await page.evaluate(() => { const img = [...document.querySelectorAll('img')].find((i) => /st-note/.test(i.src || '') && i.getBoundingClientRect().top < 360 && i.width > 140); if (!img) return null; const r = img.getBoundingClientRect(); return { x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) }; });
+      if (!box) await sleep(1500);
+    }
+    if (!box) { console.error('[FAIL] 既存カバー検出不可'); return false; }
+    await page.mouse.click(box.x, box.y); await sleep(1500);
+    const del = page.getByRole('button', { name: '削除', exact: true });
+    if (!(await del.count())) { console.error('[FAIL] 削除ボタン無し'); return false; }
+    await del.first().click(); await sleep(2500); console.log('[del] 既存カバー削除');
+    addBtn = page.getByRole('button', { name: '画像を追加' });
+    for (let i = 0; i < 6 && !(await addBtn.count()); i++) await sleep(1000);
+  }
+  if (!(await addBtn.count())) { console.error('[FAIL] 「画像を追加」未出現'); return false; }
+  // 2. 新カバーをアップロード（モーダル「画像をアップロード」→fileChooser。input 直接設定は不可）
+  await addBtn.first().click(); await sleep(2000);
+  try {
+    const [ch] = await Promise.all([page.waitForEvent('filechooser', { timeout: 9000 }), page.getByText('画像をアップロード', { exact: false }).first().click()]);
+    await ch.setFiles(cover);
+  } catch (e) { console.error('[FAIL] アップロード:', e.message.split('\n')[0]); return false; }
+  await sleep(4000);
+  const save = page.getByRole('button', { name: '保存', exact: true });
+  if (await save.count()) { await save.first().click(); console.log('[crop] 保存'); await sleep(3000); }
+  // 3. 新カバー load 確認（fail-safe）
+  let okImg = false;
+  for (let i = 0; i < 10 && !okImg; i++) {
+    okImg = await page.evaluate(() => [...document.querySelectorAll('img')].some((i) => /st-note|blob:|uploads/.test(i.src || '') && i.getBoundingClientRect().top < 380 && i.width > 110));
+    if (!okImg) await sleep(1200);
+  }
+  if (!okImg) { console.error('[FAIL] 新カバー未確認→保存中断(coverless防止)'); await page.screenshot({ path: join(ROOT, `.tmp/nc-fail-${noteId}.png`) }); return false; }
+  console.log('[ok] 新カバー load確認');
+  if (!COMMIT) { console.log('[dry] 未保存'); return true; }
+  // 4. 公開に進む → 設定ページ
+  await sleep(1500);
+  const next = page.getByRole('button', { name: '公開に進む' });
+  if (!(await next.count())) { console.error('[FAIL] 公開に進む無し'); return false; }
+  await next.first().click();
+  let onSet = false;
+  for (let i = 0; i < 10; i++) { await sleep(1800); if (await page.getByRole('button', { name: '有料エリア設定' }).count() || await page.getByRole('button', { name: '更新する', exact: true }).count()) { onSet = true; break; } }
+  if (!onSet) { console.error('[FAIL] 設定ページ未到達'); return false; }
+  // 4b. 有料記事 = paywall 境界の読み取り検証（line は動かさない・本文不触なので保持される）
+  const area = page.getByRole('button', { name: '有料エリア設定' });
+  if (await area.count()) {
+    await area.first().click(); await sleep(3500);
+    const hasLine = await page.evaluate(() => /このラインより先を有料にする/.test(document.body.innerText || ''));
+    await page.screenshot({ path: join(ROOT, `.tmp/nc-paywall-${noteId}.png`) });
+    if (!hasLine) { console.error('[ABORT] 有料境界line未確認→保存中断(paywall保護)'); return false; }
+    console.log('[paywall] 境界line確認OK(保持・未移動)');
+  } else {
+    console.log('[free] 有料エリア設定なし=無料記事');
+  }
+  // 4c. 更新する → 通知いいえ
+  const upd = page.getByRole('button', { name: '更新する', exact: true });
+  for (let i = 0; i < 6 && !(await upd.count()); i++) await sleep(1000);
+  if (!(await upd.count())) { console.error('[FAIL] 更新する未検出'); return false; }
+  await upd.first().click(); console.log('[save] 更新する');
+  await sleep(2500);
+  for (let i = 0; i < 6; i++) { const no = page.getByRole('button', { name: 'いいえ', exact: true }); if (await no.count()) { await no.first().click(); console.log('[save] 通知いいえ'); break; } await sleep(1200); }
+  await sleep(3000);
+  console.log('[OK] ライブ反映完了');
+  return true;
+}
+
+const list = arts();
+console.log(`=== note-update-cover: ${list.length}件 mode=${COMMIT ? 'COMMIT' : 'DRY'} ===`);
+const ctx = await chromium.launchPersistentContext(PROFILE, { headless: false, channel: 'chrome', ignoreHTTPSErrors: true, viewport: { width: 1366, height: 1000 }, args: ['--disable-blink-features=AutomationControlled'] });
+let ok = 0, fail = 0; const fails = [];
+try {
+  const page = ctx.pages()[0] || (await ctx.newPage());
+  await page.goto('https://note.com/settings/account', { waitUntil: 'domcontentloaded', timeout: 60000 });
+  let acct = false;
+  for (let i = 0; i < 10; i++) { await sleep(1500); if (/dobokunote/.test(await page.evaluate(() => document.body.innerText || ''))) { acct = true; break; } }
+  if (!acct) { console.error('ABORT account(dobokunote 未ログイン)'); await ctx.close(); process.exit(2); }
+  console.log('[1] account OK');
+  for (const p of list) { try { (await doOne(page, parse(p))) ? ok++ : (fail++, fails.push(p)); } catch (e) { console.error('[ERR]', p, e.message.split('\n')[0]); fail++; fails.push(p); } if (list.length > 1) await sleep(2000); }
+} finally { await ctx.close(); }
+console.log(`\n[done] ok=${ok} fail=${fail}/${list.length}`);
+if (fails.length) console.log('FAILS:\n' + fails.join('\n'));
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## 概要

`cover.png` を再デザインしても公開済み note 記事のカバーは自動更新されない（ソース→ライブ非同期）。stale カバー（`cover.png` git 最終コミット日 > `notePublishedAt`）をブラウザ自動化でライブ差し替えするツールを `scripts/note-update-cover.mjs` として正式化。

これまで `.tmp/scratchpad` にあった実証済みツールの formalize。`npm run note-update-cover` を追加。

## 設計

- **本文を一切触らず eyecatch だけ差し替える** → 有料記事の paywall 境界は自然保持される（`note-update-body` の全文置換と違い境界「再設定」は不要）。本ツールは境界 line（「このラインより先を有料にする」）の present を**読み取り検証するのみ**で line を動かさない。
- **fail-safe**: 新カバー load 未確認／有料境界 line 未確認なら「更新する」を押さない（coverless 化・paywall 開放を防ぐ）。
- 永続プロファイルは 1 Chrome のみ＝並列不可・逐次（大量は 20-28 件チャンク×background 逐次）。

## 実走実績（2026-06-30）

- **無料 55＋有料 112＝計 167 枚**をライブ反映、coverless/paywall 事故 0。
- 有料 112 枚: 1 検証＋chunk 28×3＋27 全て fail=0。
- **full sweep API 検証 113/113**: eyecatch 全件 fresh ID（当日 UP）・`can_read=false` 全件（paywall 1 件も開かず）・`price` 不変。

## 変更

- `scripts/note-update-cover.mjs`（新規）
- `package.json`: `note-update-cover` script 追加
- `docs/design-system/note-cover.md`: 「ライブ反映（公開後の stale カバー解消）」節を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)