### PR TITLE
feat(note): 完全攻略パック100工事に公開URL書き戻し用frontmatterフィールド追加

### DIFF
--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事01-道路改良高盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事01-道路改良高盛土/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji01
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "道路改良 高盛土", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事02-築堤盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事02-築堤盛土/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji02
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "河川堤防 築堤盛土", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事03-宅地造成切盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事03-宅地造成切盛土/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji03
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事04-高速道路路体盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事04-高速道路路体盛土/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji04
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事05-サンドドレーン盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事05-サンドドレーン盛土/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji05
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事06-セメント改良土盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事06-セメント改良土盛土/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji06
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事07-切土法面地すべり/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事07-切土法面地すべり/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji07
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "山間部切土法面 地すべり対策", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事08-補強土壁テールアルメ/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事08-補強土壁テールアルメ/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji08
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事09-擁壁裏込め盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事09-擁壁裏込め盛土/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji09
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事10-空港用地造成/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事10-空港用地造成/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji10
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "空港用地造成", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事100-軟弱地盤地盤改良薬液注入/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事100-軟弱地盤地盤改良薬液注入/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji100
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事11-傾斜地段切り盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事11-傾斜地段切り盛土/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji11
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "傾斜地 段切り盛土", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事12-深層混合処理盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事12-深層混合処理盛土/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji12
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "深層混合処理＋盛土", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事13-高含水比粘性土盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事13-高含水比粘性土盛土/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji13
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "高含水比粘性土 盛土", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事14-寒冷地路床凍上/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事14-寒冷地路床凍上/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji14
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "寒冷地路床 凍上抑制", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事15-橋脚フーチングマスコン/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事15-橋脚フーチングマスコン/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji15
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "橋脚フーチング マスコン", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事16-場所打ち杭杭体コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事16-場所打ち杭杭体コンクリート/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji16
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事17-RCボックスカルバート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事17-RCボックスカルバート/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji17
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "RCボックスカルバート", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事18-逆T式擁壁コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事18-逆T式擁壁コンクリート/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji18
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事19-砂防堰堤本体マスコン/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事19-砂防堰堤本体マスコン/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji19
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "砂防堰堤 本体マスコン", "5管理 完成答案"]
 noteUrl: ""
 noteId: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事20-水路トンネル覆工/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事20-水路トンネル覆工/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji20
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "水路トンネル 覆工コンクリート", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事21-下水処理場水槽RC/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事21-下水処理場水槽RC/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji21
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "下水処理場 水槽RC", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事22-暑中コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事22-暑中コンクリート/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji22
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "暑中コンクリート打設", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事23-寒中コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事23-寒中コンクリート/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji23
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事24-PC橋上部工/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事24-PC橋上部工/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji24
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "PC橋上部工（場所打ち）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事25-根固めブロック/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事25-根固めブロック/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji25
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "根固めブロック 製作・据付", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事26-高流動コンクリート充填/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事26-高流動コンクリート充填/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji26
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事27-場所打ち杭オールケーシング/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事27-場所打ち杭オールケーシング/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji27
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事28-場所打ち杭アースドリル/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事28-場所打ち杭アースドリル/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji28
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事29-PHC杭打込み/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事29-PHC杭打込み/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji29
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事30-鋼管杭中掘り/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事30-鋼管杭中掘り/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji30
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事31-鋼管矢板井筒基礎/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事31-鋼管矢板井筒基礎/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji31
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事32-ニューマチックケーソン基礎/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事32-ニューマチックケーソン基礎/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji32
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事33-深礎杭/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事33-深礎杭/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji33
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事34-鋼管ソイルセメント杭/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事34-鋼管ソイルセメント杭/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji34
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事35-橋台直接基礎/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事35-橋台直接基礎/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji35
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事36-既製杭地盤改良併用/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事36-既製杭地盤改良併用/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji36
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事37-アスファルト舗装新設/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事37-アスファルト舗装新設/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji37
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "アスファルト舗装新設", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事38-舗装打換え修繕/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事38-舗装打換え修繕/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji38
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事39-コンクリート舗装版/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事39-コンクリート舗装版/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji39
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "コンクリート舗装（版）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事40-道路改良拡幅線形/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事40-道路改良拡幅線形/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji40
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "道路改良 拡幅・線形改良", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事41-道路改良切土法面/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事41-道路改良切土法面/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji41
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "切土法面を伴う道路改良", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事42-排水性舗装/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事42-排水性舗装/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji42
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事43-橋面舗装/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事43-橋面舗装/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji43
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事44-路上路盤再生/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事44-路上路盤再生/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji44
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "路上路盤再生", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事45-街路改良共同溝/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事45-街路改良共同溝/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji45
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "街路改良 共同溝", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事46-電線共同溝整備/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事46-電線共同溝整備/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji46
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "電線共同溝整備（無電柱化）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事47-交差点改良/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事47-交差点改良/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji47
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事48-歩道整備バリアフリー/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事48-歩道整備バリアフリー/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji48
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事49-トンネル坑内舗装/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事49-トンネル坑内舗装/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji49
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "トンネル坑内舗装 5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事50-積雪寒冷地舗装/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事50-積雪寒冷地舗装/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji50
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "積雪寒冷地 舗装工事", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事51-河川護岸ブロック張/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事51-河川護岸ブロック張/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji51
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "河川護岸 ブロック張", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事52-河川築堤堤防新設/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事52-河川築堤堤防新設/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji52
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "河川築堤 堤防新設", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事53-樋門樋管設置/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事53-樋門樋管設置/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji53
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "樋門・樋管設置", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事54-水門設置/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事54-水門設置/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji54
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "水門設置工事", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事55-河道掘削しゅんせつ/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事55-河道掘削しゅんせつ/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji55
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "河道掘削 しゅんせつ", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事56-床止め落差工/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事56-床止め落差工/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji56
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "床止め・落差工", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事57-海岸護岸消波工/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事57-海岸護岸消波工/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji57
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "海岸護岸 消波工", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事58-海岸堤防嵩上げ/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事58-海岸堤防嵩上げ/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji58
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "海岸堤防嵩上げ", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事59-港湾岸壁ケーソン据付/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事59-港湾岸壁ケーソン据付/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji59
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "港湾岸壁 ケーソン据付", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事60-防波堤築造/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事60-防波堤築造/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji60
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "防波堤築造", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事61-河川橋梁橋脚仮締切/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事61-河川橋梁橋脚仮締切/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji61
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "河川橋梁橋脚 仮締切", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事62-砂防堰堤基礎本体/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事62-砂防堰堤基礎本体/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji62
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "砂防堰堤 基礎・本体", "5管理 完成答案"]
 noteUrl: ""
 noteId: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事63-下水道管渠開削/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事63-下水道管渠開削/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji63
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "下水道管渠 開削", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事64-下水道シールド/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事64-下水道シールド/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji64
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "下水道シールド", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事65-推進工法小口径/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事65-推進工法小口径/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji65
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "推進工法（小口径）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事66-推進工法中大口径/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事66-推進工法中大口径/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji66
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "推進工法（中大口径）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事67-雨水幹線築造/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事67-雨水幹線築造/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji67
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "雨水幹線築造", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事68-上水道配水管布設開削/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事68-上水道配水管布設開削/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji68
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "上水道配水管布設 開削", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事69-浄水場沈澱池築造/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事69-浄水場沈澱池築造/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji69
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "浄水場 沈澱池築造", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事70-下水処理場反応槽/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事70-下水処理場反応槽/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji70
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "下水処理場 反応槽", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事71-マンホールポンプ場/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事71-マンホールポンプ場/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji71
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "マンホールポンプ場", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事72-既設管更生/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事72-既設管更生/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji72
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "既設管更生工事", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事73-水道管不断水工事/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事73-水道管不断水工事/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji73
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "水道管 不断水工事", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事74-雨水貯留施設地下/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事74-雨水貯留施設地下/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji74
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "雨水貯留施設（地下）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事75-橋台躯体逆T式/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事75-橋台躯体逆T式/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji75
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事76-橋脚躯体張出し/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事76-橋脚躯体張出し/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji76
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "橋脚躯体（張出し）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事77-PC桁架設クレーン/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事77-PC桁架設クレーン/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji77
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "PC桁架設（クレーン）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事78-鋼桁架設送出し/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事78-鋼桁架設送出し/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji78
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "鋼桁架設（送出し工法）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事79-床版取替更新/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事79-床版取替更新/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji79
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事80-橋梁耐震補強/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事80-橋梁耐震補強/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji80
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "橋梁耐震補強", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事81-既設橋撤去架替/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事81-既設橋撤去架替/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji81
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "既設橋 撤去・架替", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事82-連続立体交差鉄道高架/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事82-連続立体交差鉄道高架/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji82
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "連続立体交差 鉄道高架", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事83-横断歩道橋設置/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事83-横断歩道橋設置/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji83
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事84-カルバート非開削推進/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事84-カルバート非開削推進/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji84
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "カルバート非開削（推進）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事85-高架橋RC橋脚/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事85-高架橋RC橋脚/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji85
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "高架橋 RC橋脚", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事86-鋼管矢板橋脚基礎/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事86-鋼管矢板橋脚基礎/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji86
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "鋼管矢板 橋脚基礎", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事87-山岳トンネルNATM/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事87-山岳トンネルNATM/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji87
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "山岳トンネルNATM 5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事88-山岳トンネル機械掘削/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事88-山岳トンネル機械掘削/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji88
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "山岳トンネル 機械掘削", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事89-トンネル覆工コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事89-トンネル覆工コンクリート/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji89
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "道路トンネル 覆工コンクリート", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事90-トンネル坑口部明かり巻/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事90-トンネル坑口部明かり巻/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji90
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "トンネル坑口部 明かり巻", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事91-都市部トンネル開削/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事91-都市部トンネル開削/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji91
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "都市部トンネル 開削工事", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事92-水路トンネル/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事92-水路トンネル/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji92
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "水路トンネル", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事93-トンネル支保工吹付ロックボルト/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事93-トンネル支保工吹付ロックボルト/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji93
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "トンネル支保工 吹付・ロックボルト", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事94-トンネル補修漏水覆工剥落/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事94-トンネル補修漏水覆工剥落/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji94
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "トンネル補修 漏水・覆工剥落", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事95-共同溝プレキャストボックス/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事95-共同溝プレキャストボックス/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji95
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "共同溝 プレキャストボックス", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事96-電線共同溝特殊部/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事96-電線共同溝特殊部/article.md
@@ -3,6 +3,7 @@ notePricing: paid
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji96
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "電線共同溝（特殊部）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事97-鉄道近接土留め仮設/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事97-鉄道近接土留め仮設/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji97
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "鉄道近接 土留め・仮設工事", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事98-大規模造成流域貯留/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事98-大規模造成流域貯留/article.md
@@ -4,6 +4,7 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji98
+noteStatus: draft
 noteUrl: ""
 noteId: ""
 notePublishedAt: ""

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事99-法面対策吹付グラウンドアンカー/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事99-法面対策吹付グラウンドアンカー/article.md
@@ -4,6 +4,10 @@ price: 1280
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji99
+noteUrl: ""
+noteId: ""
+notePublishedAt: ""
+noteStatus: draft
 coverTitle: ["1級土木 施工経験記述", "法面対策 吹付・グラウンドアンカー", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"


### PR DESCRIPTION
## 概要
note-publish.mjs の frontmatter 書き戻し（`.replace` 方式）は対象フィールドが既存である前提。検証で全100工事が `noteUrl`/`noteId`/`notePublishedAt`/`noteStatus` を完備しておらず（0/100）、このまま公開すると**URLが記録されず空振り**するため、空フィールドを冪等追加。

## 変更（100記事・265フィールド追加）
- `noteUrl: ""` / `noteId: ""` / `notePublishedAt: ""` / `noteStatus: draft`
- template-A 55件＝4点新規、template-B 45件＝noteStatus補完。utmCampaign 直後に挿入

🤖 Generated with [Claude Code](https://claude.com/claude-code)