### PR TITLE
feat(note): note-publish.mjs 有料境界をconfig化（多資格）＋civil工事 paidBoundary

### DIFF
--- a/.claude/skills/social/publish-note/SKILL.md
+++ b/.claude/skills/social/publish-note/SKILL.md
@@ -29,7 +29,7 @@ browser-use CLI（Chrome プロファイル経由）で **note.com/dobokunote** 
 | アカウント | `note.com/stats47` / Profile 5 / stats47jp@gmail.com | **`note.com/dobokunote`** / `$NOTE_PROFILE` |
 | 記事パス | `docs/31_note記事原稿/<vertical>/<slug>/{note.md,draft.md}` | **`docs/note/技術士総監/magazines/総監模範論文-<persona>/<RXX>/article.md`** |
 | 有料フラグ | frontmatter `is_paid` / `price_jpy` | frontmatter **`notePricing: paid`** / **`price: 500`** |
-| 有料境界マーカー | 本文中 `ここから先は有料部分:` 行 | **`## 試験問題` 行の直前**（intro・「この記事でわかること」・マガジンCTA は無料プレビュー、試験問題＋解答以降が有料） |
+| 有料境界マーカー | 本文中 `ここから先は有料部分:` 行 | **既定＝`## 試験問題`/`## 予想問題` 行の直前**（intro・「この記事でわかること」・冒頭CTA は無料プレビュー、試験問題＋解答以降が有料）。**境界見出しはコンテンツ型ごとに上書き可**＝Windows/Playwright 版 `note-publish.mjs` が frontmatter `paidBoundary`（H2 見出しの先頭一致 regex）または `--boundary-regex` を読む。**1級土木 完全攻略パック（工事別）は `paidBoundary: 品質管理`**（導入＋冒頭CTA＋想定工事概要が無料・5管理の完成答案以降が有料）。境界が見つからなければ公開中断（boundaryBeforeExam ゲート） |
 | マガジン名/説明/価格 | 各 vertical の設定 | **`総監模範論文-<persona>/note掲載文.txt`** からコピペ |
 | ハッシュタグ | 記事内 | **`<RXX>/hashtags.txt`**（90 個前後・単一行 space 区切り） |
 | アイキャッチ | 生成画像 | **`<RXX>/img/cover.png`** |

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事01-道路改良高盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事01-道路改良高盛土/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji01

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事02-築堤盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事02-築堤盛土/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji02

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事03-宅地造成切盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事03-宅地造成切盛土/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji03

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事04-高速道路路体盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事04-高速道路路体盛土/article.md
@@ -8,6 +8,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 coverTitle: ["1級土木 施工経験記述", "高速道路 路体・路床盛土", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事05-サンドドレーン盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事05-サンドドレーン盛土/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji05

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事06-セメント改良土盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事06-セメント改良土盛土/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji06

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事07-切土法面地すべり/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事07-切土法面地すべり/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji07

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事08-補強土壁テールアルメ/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事08-補強土壁テールアルメ/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji08

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事09-擁壁裏込め盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事09-擁壁裏込め盛土/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji09

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事10-空港用地造成/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事10-空港用地造成/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji10

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事100-軟弱地盤地盤改良薬液注入/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事100-軟弱地盤地盤改良薬液注入/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji100

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事11-傾斜地段切り盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事11-傾斜地段切り盛土/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji11

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事12-深層混合処理盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事12-深層混合処理盛土/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji12

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事13-高含水比粘性土盛土/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事13-高含水比粘性土盛土/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji13

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事14-寒冷地路床凍上/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事14-寒冷地路床凍上/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji14

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事15-橋脚フーチングマスコン/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事15-橋脚フーチングマスコン/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji15

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事16-場所打ち杭杭体コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事16-場所打ち杭杭体コンクリート/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji16

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事17-RCボックスカルバート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事17-RCボックスカルバート/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji17

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事18-逆T式擁壁コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事18-逆T式擁壁コンクリート/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji18

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事19-砂防堰堤本体マスコン/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事19-砂防堰堤本体マスコン/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji19

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事20-水路トンネル覆工/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事20-水路トンネル覆工/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜水路トンネル 覆工コンクリート（5管理 完成答案）
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事21-下水処理場水槽RC/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事21-下水処理場水槽RC/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji21

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事22-暑中コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事22-暑中コンクリート/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji22

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事23-寒中コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事23-寒中コンクリート/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji23

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事24-PC橋上部工/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事24-PC橋上部工/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜PC橋上部工（場所打ち・固定支保工）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事25-根固めブロック/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事25-根固めブロック/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji25

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事26-高流動コンクリート充填/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事26-高流動コンクリート充填/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji26

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事27-場所打ち杭オールケーシング/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事27-場所打ち杭オールケーシング/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji27

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事28-場所打ち杭アースドリル/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事28-場所打ち杭アースドリル/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji28

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事29-PHC杭打込み/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事29-PHC杭打込み/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji29

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事30-鋼管杭中掘り/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事30-鋼管杭中掘り/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji30

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事31-鋼管矢板井筒基礎/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事31-鋼管矢板井筒基礎/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji31

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事32-ニューマチックケーソン基礎/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事32-ニューマチックケーソン基礎/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji32

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事33-深礎杭/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事33-深礎杭/article.md
@@ -8,6 +8,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 coverTitle: ["1級土木 施工経験記述", "深礎杭（人力掘削）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事34-鋼管ソイルセメント杭/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事34-鋼管ソイルセメント杭/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji34

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事35-橋台直接基礎/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事35-橋台直接基礎/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji35

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事36-既製杭地盤改良併用/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事36-既製杭地盤改良併用/article.md
@@ -8,6 +8,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 coverTitle: ["1級土木 施工経験記述", "既製杭＋地盤改良 中掘り根固め", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事37-アスファルト舗装新設/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事37-アスファルト舗装新設/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji37

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事38-舗装打換え修繕/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事38-舗装打換え修繕/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji38

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事39-コンクリート舗装版/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事39-コンクリート舗装版/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji39

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事40-道路改良拡幅線形/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事40-道路改良拡幅線形/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji40

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事41-道路改良切土法面/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事41-道路改良切土法面/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji41

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事42-排水性舗装/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事42-排水性舗装/article.md
@@ -8,6 +8,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 coverTitle: ["1級土木 施工経験記述", "排水性舗装の施工", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事43-橋面舗装/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事43-橋面舗装/article.md
@@ -8,6 +8,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 coverTitle: ["1級土木 施工経験記述", "橋面舗装（床版上）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事44-路上路盤再生/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事44-路上路盤再生/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji44

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事45-街路改良共同溝/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事45-街路改良共同溝/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜街路改良 共同溝（市街地 歩車道整備）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事46-電線共同溝整備/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事46-電線共同溝整備/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜電線共同溝整備（無電柱化）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事47-交差点改良/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事47-交差点改良/article.md
@@ -8,6 +8,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 coverTitle: ["1級土木 施工経験記述", "交差点改良（平面）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事48-歩道整備バリアフリー/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事48-歩道整備バリアフリー/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji48

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事49-トンネル坑内舗装/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事49-トンネル坑内舗装/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji49

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事50-積雪寒冷地舗装/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事50-積雪寒冷地舗装/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji50

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事51-河川護岸ブロック張/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事51-河川護岸ブロック張/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji51

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事52-河川築堤堤防新設/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事52-河川築堤堤防新設/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji52

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事53-樋門樋管設置/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事53-樋門樋管設置/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji53

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事54-水門設置/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事54-水門設置/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji54

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事55-河道掘削しゅんせつ/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事55-河道掘削しゅんせつ/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji55

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事56-床止め落差工/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事56-床止め落差工/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji56

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事57-海岸護岸消波工/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事57-海岸護岸消波工/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji57

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事58-海岸堤防嵩上げ/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事58-海岸堤防嵩上げ/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji58

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事59-港湾岸壁ケーソン据付/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事59-港湾岸壁ケーソン据付/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji59

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事60-防波堤築造/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事60-防波堤築造/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji60

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事61-河川橋梁橋脚仮締切/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事61-河川橋梁橋脚仮締切/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji61

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事62-砂防堰堤基礎本体/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事62-砂防堰堤基礎本体/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji62

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事63-下水道管渠開削/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事63-下水道管渠開削/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji63

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事64-下水道シールド/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事64-下水道シールド/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji64

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事65-推進工法小口径/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事65-推進工法小口径/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji65

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事66-推進工法中大口径/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事66-推進工法中大口径/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji66

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事67-雨水幹線築造/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事67-雨水幹線築造/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji67

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事68-上水道配水管布設開削/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事68-上水道配水管布設開削/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji68

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事69-浄水場沈澱池築造/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事69-浄水場沈澱池築造/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji69

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事70-下水処理場反応槽/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事70-下水処理場反応槽/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji70

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事71-マンホールポンプ場/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事71-マンホールポンプ場/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji71

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事72-既設管更生/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事72-既設管更生/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji72

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事73-水道管不断水工事/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事73-水道管不断水工事/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji73

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事74-雨水貯留施設地下/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事74-雨水貯留施設地下/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji74

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事75-橋台躯体逆T式/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事75-橋台躯体逆T式/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji75

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事76-橋脚躯体張出し/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事76-橋脚躯体張出し/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji76

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事77-PC桁架設クレーン/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事77-PC桁架設クレーン/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜PC桁架設（クレーン一括架設）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事78-鋼桁架設送出し/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事78-鋼桁架設送出し/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜鋼桁架設（送出し工法）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事79-床版取替更新/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事79-床版取替更新/article.md
@@ -8,6 +8,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 coverTitle: ["1級土木 施工経験記述", "床版取替（更新）", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事80-橋梁耐震補強/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事80-橋梁耐震補強/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji80

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事81-既設橋撤去架替/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事81-既設橋撤去架替/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜既設橋 撤去・架替（橋全体の解体から新橋架設）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事82-連続立体交差鉄道高架/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事82-連続立体交差鉄道高架/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji82

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事83-横断歩道橋設置/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事83-横断歩道橋設置/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji83

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事84-カルバート非開削推進/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事84-カルバート非開削推進/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji84

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事85-高架橋RC橋脚/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事85-高架橋RC橋脚/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜高架橋 RC橋脚（多基連続施工）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事86-鋼管矢板橋脚基礎/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事86-鋼管矢板橋脚基礎/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji86

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事87-山岳トンネルNATM/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事87-山岳トンネルNATM/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji87

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事88-山岳トンネル機械掘削/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事88-山岳トンネル機械掘削/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji88

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事89-トンネル覆工コンクリート/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事89-トンネル覆工コンクリート/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜道路トンネル 覆工コンクリート（セントル施工）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事90-トンネル坑口部明かり巻/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事90-トンネル坑口部明かり巻/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji90

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事91-都市部トンネル開削/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事91-都市部トンネル開削/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜都市部トンネル（開削工事）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事92-水路トンネル/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事92-水路トンネル/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜水路トンネル（掘削〜覆工・湧水対策）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事93-トンネル支保工吹付ロックボルト/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事93-トンネル支保工吹付ロックボルト/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji93

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事94-トンネル補修漏水覆工剥落/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事94-トンネル補修漏水覆工剥落/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji94

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事95-共同溝プレキャストボックス/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事95-共同溝プレキャストボックス/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji95

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事96-電線共同溝特殊部/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事96-電線共同溝特殊部/article.md
@@ -19,6 +19,7 @@ noteUrl: ""
 noteId: ""
 notePublishedAt: ""
 price: 1280
+paidBoundary: 品質管理
 ---
 # 1級土木 施工経験記述｜電線共同溝（特殊部）5管理 完成答案
 

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事97-鉄道近接土留め仮設/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事97-鉄道近接土留め仮設/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji97

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事98-大規模造成流域貯留/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事98-大規模造成流域貯留/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji98

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事99-法面対策吹付グラウンドアンカー/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事99-法面対策吹付グラウンドアンカー/article.md
@@ -1,6 +1,7 @@
 ---
 notePricing: paid
 price: 1280
+paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji99

--- a/scripts/note-publish.mjs
+++ b/scripts/note-publish.mjs
@@ -9,12 +9,12 @@
  *
  * 工程: account ゲート → エディタ → カバー(eyecatch) → タイトル → 本文(ClipboardEvent paste・
  *   markdown変換) → リンクカード化(各URL行を Range選択→Delete→type→Enter＝note の埋め込み検出は type で起動・paste不可) → 下書き保存 → 公開に進む → 有料+価格(#price JS setter)
- *   → タグ → 有料エリア設定 → 有料境界を「試験問題/予想問題」直前に設定 → ★境界検証ゲート★ → 投稿する。
+ *   → タグ → 有料エリア設定 → 有料境界を BOUNDARY 見出し（既定=「試験問題/予想問題」・frontmatter `paidBoundary` か `--boundary-regex` で上書き）直前に設定 → ★境界検証ゲート★ → 投稿する。
  *
  * 安全弁（収益アカウントのため）:
  *   1. account=dobokunote を assert（不一致は即中断・1記事も触らない）
  *   2. 既定は draft（下書き保存のみ）。実公開は --commit 必須
- *   3. --commit でも「有料境界が試験問題/予想問題の直前」を検証してからのみ投稿（boundaryBeforeExam=false は中断）
+ *   3. --commit でも「有料境界が BOUNDARY 見出しの直前」を検証してからのみ投稿（boundaryBeforeExam=false は中断）
  *   4. 公開後に note 公開ページを実取得し 無料プレビュー/カード/価格 を実体検証（偽成功ガード）
  *
  * 使い方:
@@ -76,6 +76,9 @@ const tagsCandidates = [typeSuffix && join(dir, `hashtags-${typeSuffix}.txt`), j
 const tagsFile = tagsCandidates.find(existsSync);
 const tags = tagsFile ? readFileSync(tagsFile, 'utf8').split(/\r?\n/).map((s) => s.trim().replace(/^#/, '')).filter(Boolean).slice(0, 99) : [];
 const isPaid = notePricing === 'paid' && price > 0;
+// 有料境界の見出し regex（H2 の innerText 先頭一致）。既定=総監/建設の「試験問題/予想問題」。
+// 他コンテンツ型は frontmatter `paidBoundary` か `--boundary-regex` で上書き（例: 1級土木 工事別パック=「品質管理」）。
+const BOUNDARY = getArg('--boundary-regex') || fmField('paidBoundary') || '試験問題|予想問題';
 
 // ガード: プレースホルダ残・空タイトル
 if (/\{\{|※note\s*公開後|MAGAZINE_URL/.test(body)) { console.error('ABORT: プレースホルダが本文に残存'); process.exit(1); }
@@ -194,32 +197,34 @@ try {
     } catch (e) { console.log('[10] tags skip:', e.message.split('\n')[0]); }
   }
 
-  // 11. 有料エリア設定 → 境界を 試験問題/予想問題 直前へ
+  // 11. 有料エリア設定 → 境界を BOUNDARY 見出し直前へ（既定=試験問題/予想問題・civil=品質管理）
   let boundaryOk = !isPaid; // 無料は境界不要
   if (isPaid) {
     const area = page.getByRole('button', { name: '有料エリア設定' });
     if (await area.count()) {
       await area.first().click(); await sleep(3500);
-      const t = await page.evaluate(() => {
+      const t = await page.evaluate((boundaryStr) => {
+        const re = new RegExp('^(' + boundaryStr + ')');
         const isLineBtn = (el) => (el.tagName === 'BUTTON' || el.getAttribute('role') === 'button') && /ラインをこの場所に変更/.test(el.innerText || el.getAttribute('aria-label') || '');
         const seq = Array.from(document.querySelectorAll('h1,h2,h3,button,[role=button]'));
-        const hIdx = seq.findIndex((el) => el.tagName === 'H2' && /^(試験問題|予想問題)/.test((el.innerText || '').trim()));
-        if (hIdx < 0) return { ok: false, reason: 'no 試験/予想問題 h2' };
+        const hIdx = seq.findIndex((el) => el.tagName === 'H2' && re.test((el.innerText || '').trim()));
+        if (hIdx < 0) return { ok: false, reason: 'no boundary h2: ' + boundaryStr };
         let btn = null; for (let i = hIdx - 1; i >= 0; i--) { if (isLineBtn(seq[i])) { btn = seq[i]; break; } }
         if (!btn) return { ok: false, reason: 'no preceding line-button' };
         document.querySelectorAll('[data-np-target]').forEach((e) => e.removeAttribute('data-np-target')); btn.setAttribute('data-np-target', '1');
         return { ok: true, heading: (seq[hIdx].innerText || '').slice(0, 24) };
-      });
+      }, BOUNDARY);
       console.log('[11] boundary target:', JSON.stringify(t));
       if (t.ok) {
         await page.click('[data-np-target="1"]'); await sleep(2500);
-        const v = await page.evaluate(() => {
+        const v = await page.evaluate((boundaryStr) => {
+          const re = new RegExp('^(' + boundaryStr + ')');
           const seq = Array.from(document.querySelectorAll('h1,h2,h3,p,button,[role=button]'));
           const lineIdx = seq.findIndex((el) => /このラインより先を有料にする/.test(el.innerText || ''));
-          const hIdx = seq.findIndex((el) => el.tagName === 'H2' && /^(試験問題|予想問題)/.test((el.innerText || '').trim()));
+          const hIdx = seq.findIndex((el) => el.tagName === 'H2' && re.test((el.innerText || '').trim()));
           let between = 0; if (lineIdx >= 0 && hIdx > lineIdx) for (let i = lineIdx + 1; i < hIdx; i++) { const tx = (seq[i].innerText || '').trim(); if (tx && !/ラインをこの場所に変更|このラインより先/.test(tx)) between++; }
           return { lineIdx, hIdx, between, boundaryBeforeExam: lineIdx >= 0 && hIdx > lineIdx && between === 0 };
-        });
+        }, BOUNDARY);
         console.log('[11] boundary verify:', JSON.stringify(v));
         boundaryOk = v.boundaryBeforeExam;
       }


### PR DESCRIPTION
## 概要
civil 完全攻略パックを既存の多資格publish基盤で公開できるよう、`note-publish.mjs` の有料境界を**config化**。土木専用スクリプトは作らず共通基盤を拡張（設計判断：差分はデータでありロジック共通）。

## 変更
- **note-publish.mjs**: 有料境界の見出しを frontmatter `paidBoundary`（H2先頭一致regex）or `--boundary-regex` で上書き可に。既定「試験問題|予想問題」維持＝**総監/建設は後方互換**。ヘッダdoc更新
- **100工事**: `paidBoundary: 品質管理`（案A＝導入+CTA+想定工事概要が無料・5管理の完成答案から有料）。`## 品質管理` H2は全100実在を確認
- **publish-note SKILL.md**: 差分マップの有料境界行をconfig化・civil例を明記

## 検証
- `node --check` syntax OK
- paidBoundary 100/100・`## 品質管理`H2 100/100

## 残（公開実走）
1. 1工事 DRAFT試走（`note-publish.mjs --article <一工事>` 無--commit）→ commit → URL書き戻し確認
2. 100工事 ¥1,280 個別公開→収録→目次（browser-use）

🤖 Generated with [Claude Code](https://claude.com/claude-code)