### PR TITLE
fix(note): 完全攻略パック 工事82-87 実公開＋正noteId是正

### DIFF
--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事82-連続立体交差鉄道高架/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事82-連続立体交差鉄道高架/article.md
@@ -5,9 +5,9 @@ paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji82
-noteUrl: "https://note.com/dobokunote/n/n9a707bb67bd3"
-noteId: "n9a707bb67bd3"
-notePublishedAt: "2026-06-30"
+noteUrl: "https://note.com/dobokunote/n/nd23afbeecb2c"
+noteId: "nd23afbeecb2c"
+notePublishedAt: "2026-07-01"
 noteStatus: published
 coverTitle: ["1級土木 施工経験記述", "連続立体交差 鉄道高架", "5管理 完成答案"]
 cover:

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事83-横断歩道橋設置/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事83-横断歩道橋設置/article.md
@@ -6,9 +6,9 @@ noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji83
 noteStatus: published
-noteUrl: "https://note.com/dobokunote/n/n0fa7dfaca87b"
-noteId: "n0fa7dfaca87b"
-notePublishedAt: "2026-06-30"
+noteUrl: "https://note.com/dobokunote/n/nb8b8b9533bcc"
+noteId: "nb8b8b9533bcc"
+notePublishedAt: "2026-07-01"
 coverTitle: ["1級土木 施工経験記述", "横断歩道橋設置", "5管理 完成答案"]
 cover:
   leadIn: "1級土木施工管理技士 二次"

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事84-カルバート非開削推進/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事84-カルバート非開削推進/article.md
@@ -5,9 +5,9 @@ paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji84
-noteUrl: "https://note.com/dobokunote/n/nceab2731c5b7"
-noteId: "nceab2731c5b7"
-notePublishedAt: "2026-06-30"
+noteUrl: "https://note.com/dobokunote/n/n1fec875cca5d"
+noteId: "n1fec875cca5d"
+notePublishedAt: "2026-07-01"
 noteStatus: published
 coverTitle: ["1級土木 施工経験記述", "カルバート非開削（推進）", "5管理 完成答案"]
 cover:

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事85-高架橋RC橋脚/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事85-高架橋RC橋脚/article.md
@@ -15,9 +15,9 @@ cover:
     - { icon: doc, text: "完成答案" }
     - { icon: edit, text: "置換ガイド" }
     - { icon: check, text: "5管理一覧" }
-noteUrl: "https://note.com/dobokunote/n/n28ce5602f65a"
-noteId: "n28ce5602f65a"
-notePublishedAt: "2026-06-30"
+noteUrl: "https://note.com/dobokunote/n/nb44e8c218401"
+noteId: "nb44e8c218401"
+notePublishedAt: "2026-07-01"
 price: 1280
 paidBoundary: 品質管理
 ---

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事86-鋼管矢板橋脚基礎/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事86-鋼管矢板橋脚基礎/article.md
@@ -5,9 +5,9 @@ paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji86
-noteUrl: "https://note.com/dobokunote/n/n2ef6f8e23aaf"
-noteId: "n2ef6f8e23aaf"
-notePublishedAt: "2026-06-30"
+noteUrl: "https://note.com/dobokunote/n/nf44492754254"
+noteId: "nf44492754254"
+notePublishedAt: "2026-07-01"
 noteStatus: published
 coverTitle: ["1級土木 施工経験記述", "鋼管矢板 橋脚基礎", "5管理 完成答案"]
 cover:

--- a/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事87-山岳トンネルNATM/article.md
+++ b/docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック/工事87-山岳トンネルNATM/article.md
@@ -5,9 +5,9 @@ paidBoundary: 品質管理
 noteSeries: 1級土木-経験記述-完全攻略パック
 noteMagazine: 1級土木-経験記述-完全攻略パック
 utmCampaign: civil1-keiken-pack-koji87
-noteUrl: "https://note.com/dobokunote/n/n636fd3e19c16"
-noteId: "n636fd3e19c16"
-notePublishedAt: "2026-06-30"
+noteUrl: "https://note.com/dobokunote/n/n3dd143707c2e"
+noteId: "n3dd143707c2e"
+notePublishedAt: "2026-07-01"
 noteStatus: published
 coverTitle: ["1級土木 施工経験記述", "山岳トンネルNATM 5管理 完成答案"]
 cover:


### PR DESCRIPTION
別PC公開の偽成功で未公開だった工事82-87を実公開し直し、幻ID(API 404)→正noteIdへ是正。全6本API検証済(published/¥1280/can_read=false)。マガジンm8290970a7f05に収録し100/100完了。