### PR TITLE
fix(note): 公開バッチの偽成功(幻noteId)を再発防止する二層ゲート

### DIFF
--- a/.claude/skills/social/note-publish/SKILL.md
+++ b/.claude/skills/social/note-publish/SKILL.md
@@ -36,7 +36,7 @@ node scripts/note-publish.mjs --article <path> --commit --schedule 2026-06-20T07
 
 ### マガジン一括（バッチ）
 
-1マガジン分（`article-*.md` 全部）の公開は **`note-publish-magazine`** を使う（1記事ずつ `note-publish --commit` を直列実行・**冪等**〔frontmatter に noteUrl あればskip〕・1記事最大2回試行・失敗で停止→再実行で再開・公開順 R03→R08-yosou × II1→II2→III）。公開前の単品価格揃えは **`note-price-sweep`**（frontmatter `price` を一括スイープ・既定 1980→500・CRLF保持）。
+1マガジン分（`article-*.md` 全部）の公開は **`note-publish-magazine`** を使う（1記事ずつ `note-publish --commit` を直列実行・**冪等**〔frontmatter に noteUrl あればskip〕・1記事最大2回試行・失敗で停止→再実行で再開・公開順 R03→R08-yosou × II1→II2→III）。**偽成功ガード（2026-07-01）**: 即時公開分は「noteUrl が書けた」だけで OK とせず、書き戻した noteId が note API で実在するか照合し、確定 404（幻 id）なら fail 停止する（工事82-87 が fail=0 のまま未公開だった再発防止）。**バッチ完了後は必ず `npm run verify-note-status`**（fm=published↔ライブ404 を検出）で全件確証してから完了報告する。公開前の単品価格揃えは **`note-price-sweep`**（frontmatter `price` を一括スイープ・既定 1980→500・CRLF保持）。
 
 ```
 node scripts/note-price-sweep.mjs --dir <magazineDir> --commit          # Step1: 価格スイープ（→ pathspec commit）

--- a/.claude/skills/social/publish-note/SKILL.md
+++ b/.claude/skills/social/publish-note/SKILL.md
@@ -204,6 +204,13 @@ browser-use --headed --profile "$NOTE_PROFILE" state 2>&1 > /tmp/note-acct.txt
 
 「投稿できた」というログを**信用しない**。stats47/publish-x で予約ゼロの空振り事故があった（[[feedback_publish_x_false_success]]）。公開後は **note の公開ページ（または下書き一覧）を実取得して、本文・カバー・タグ・価格・カード化が実際に反映されているか DOM/スクショで確認**してから「完了」と報告する。clipboard paste 不発（本文空）も頻発するため、paste 後に本文の文字数を eval で確認する。
 
+### 幻 noteId（fail=0 なのに未公開）— バッチ公開後の必須ゲート
+
+`note-publish.mjs` の writeback は**ページから拾った URL の id を書くだけ**で、公開が実際は未完了でも幻 id を frontmatter に書きうる。`note-publish-magazine.mjs` は従来 `noteUrl` の有無だけで OK 判定していたため、**`fail=0` と報告しつつ一部が未公開＋幻 id（API で 404）** という偽成功が起きた（2026-06-30 完全攻略パック 工事82-87 の6本・[[project_civil1_flagship_pack]]）。
+
+- **バッチ側の一次ガード（2026-07-01 実装済）**: `note-publish-magazine.mjs` は即時公開分について、書き戻した noteId が note API v3 で実在するか照合する。確定 404（幻 id）なら `fail` で停止する（予約投稿は go-live 後刻ゆえ検証しない）。
+- **バッチ後の確証ゲート（必須）**: 公開バッチ完了後・「完了」と報告する前に必ず `npm run verify-note-status` を回す。**fm=published ↔ ライブ=404** を `WARN` で列挙する reconciler で、幻 id・静かな未公開を全件で捕捉する。WARN が出たら該当記事の frontmatter（noteUrl/noteId/notePublishedAt）を空へリセット→`--commit` で再公開→再照合する。ネットワーク依存で遅いため CI ゲートには入れない（weekly-review でも定期実行）。
+
 ## トラブルシューティング
 
 要素検索ヘルパー（`find_idx`）・実証済み要素パターン・clipboard paste 不発時の対処は **[references/troubleshooting.md](references/troubleshooting.md)**。既存公開記事の更新は **[references/update-mode.md](references/update-mode.md)**。

--- a/docs/handoffs/2026-06-30-civil1-flagship-postpublish.md
+++ b/docs/handoffs/2026-06-30-civil1-flagship-postpublish.md
@@ -1,11 +1,14 @@
 # ハンドオフ: 1級土木 完全攻略パック 100本 公開完了 → 仕上げ（別PC継続用）
 
-**日付**: 2026-06-30
-**状態**: **100本すべて note 即時公開済み（fail=0）**。frontmatter 書き戻しは develop に commit/push 済み。
+**日付**: 2026-06-30（**2026-07-01 更新**）
+**状態**: 100本 note 公開済み ＋ **マガジン m8290970a7f05 へ 100/100 収録完了（2026-07-01）**。
 **前ハンドオフ**: [2026-06-30-civil1-flagship-publish.md](2026-06-30-civil1-flagship-publish.md)（公開手順本体）。本書はその**公開後の続き**。
 
+> [!warning] 是正（2026-07-01）— 「fail=0」は偽成功だった
+> 当初「100本すべて即時公開済み（fail=0）」と記録したが、**工事82-87 の6本は実際には未公開**で、frontmatter に幻 noteId（note API で 404）＋ `published` が誤書き戻しされていた（バッチ成功判定が `noteUrl` 有無だけだったため）。2026-07-01 に検出→6本を実公開し直し正 noteId へ是正（API 検証済 published/¥1280/can_read=false・**PR #313 merged**）→マガジン収録し **100/100 完了**。再発防止として `note-publish-magazine.mjs` に noteId 実在照合を追加＋公開後 `npm run verify-note-status` を必須ゲート化（publish-note SKILL.md「偽成功の罠」）。
+
 > [!note] 結論
-> 100本の本番公開は完了。残るは **マガジン収録 → SKU 公開 → deploy** の3工程でパック完成。その後に PDF・目次・予約投稿修復など。
+> 100本公開＋マガジン収録は完了。残るは **SKU published:true → deploy**（＋後続で PDF・目次・無料23本CTA live）。
 
 ---
 
@@ -21,13 +24,14 @@
 
 ## 2. 残作業（この順で・別PCで実行）
 
-### 2-1. マガジン `m8290970a7f05` へ100本収録
+### 2-1. マガジン `m8290970a7f05` へ100本収録 ✅ 完了（2026-07-01）
 ```bash
-node scripts/note-magazine-add-articles.mjs --target <マガジンkey/設定> --from <packDir> --commit
-#   既定 dry-run。--probe で1記事目のボタン文言ダンプ。引数の正確な対応は scripts header 参照（--target/--from/--notes/--limit）
-#   packDir = docs/note/1級・2級土木/1級土木/magazines/1級土木-経験記述-完全攻略パック
+# 実行済コマンド（会社PC・冪等・分割再実行で 0→2→85→94→100）
+node scripts/note-magazine-add-articles.mjs --target m8290970a7f05 --notes <100個のnoteId,カンマ区切り> --commit
+#   noteId は各 工事NN-*/article.md frontmatter。--plan-only で API 差分のみ確認可（ブラウザ不要）。
+#   孤児 Chrome がプロファイルをロックし LAUNCH_FAIL する→毎回 playwright-note-profile の chrome を Stop-Process＋Singleton* を rm。
 ```
-- 100本の noteId は各 `工事NN-*/article.md` の frontmatter にあり（収録対象の真実源）
+- 独立 API 検証（`api/v1/magazines/m8290970a7f05/notes` 全ページ）で **100/100 収録・未収録なし** を確認済み。
 
 ### 2-2. SKU を published:true（パック完成）
 - `src/lib/note-magazines.ts` の `civil-1-keiken-complete-pack`（現在 `published: false`・noteUrl=m8290970a7f05・¥9,800）を **100本収録完了後に `published: true`** へ

--- a/scripts/note-publish-magazine.mjs
+++ b/scripts/note-publish-magazine.mjs
@@ -8,6 +8,12 @@
  * 直列必須・並行不可）。冪等（frontmatter に noteUrl があればスキップ）・1記事最大2回試行・
  * 失敗で停止（再実行で再開）。
  *
+ * 偽成功ガード（2026-07-01）: 即時公開は「noteUrl が書けた」だけで OK とせず、書き戻した
+ *   noteId が note API v3 で実在するかを照合する（幻 id=確定404 なら fail で停止）。writeback は
+ *   ページ URL から id を抜くだけで、公開未完了でも幻 id を書きうるため fmHasUrl だけでは
+ *   偽成功を素通りさせる（工事82-87 が fail=0 のまま未公開だった再発防止）。予約投稿は go-live が
+ *   後刻ゆえ実在検証しない（weekly `verify-note-status` が担保）。バッチ後も同 reconciler で全件照合推奨。
+ *
  * 公開順は article 名の昇順（R03→R07→R08-yosou × II1→II2→III）。各記事公開後、
  * note-publish が noteUrl/noteId/notePublishedAt を frontmatter に writeback する
  * （git commit はしない＝呼び側で pathspec commit）。
@@ -70,6 +76,23 @@ if (LIST) {
 }
 const rel = (f) => f.replace(/\\/g, '/').replace(ROOT.replace(/\\/g, '/') + '/', '');
 const fmHasUrl = (f) => /noteUrl:\s*"https?:\/\//.test(readFileSync(f, 'utf8'));
+const fmNoteId = (f) => (readFileSync(f, 'utf8').match(/^noteId:\s*"?([a-z0-9]+)"?/mi) || [])[1] || '';
+
+// 偽成功ガード: 公開直後に noteId が note API で実在するか検証する。writeback は「ページから
+//   拾った URL に id があれば書く」ため、公開が実際は未完了でも幻 id を書き込みうる（2026-06-30
+//   工事82-87 が fail=0 のまま未公開＝[[project_civil1_flagship_pack]]）。fmHasUrl だけでは
+//   検出できない。'ok'=実在 / '404'=確定不在(幻ID) / 'unknown'=network揺れ(判定保留)。
+//   即時公開のみ検証（予約は go-live 後刻で API 404 が正常＝weekly verify-note-status が担保）。
+function liveNoteStatus(noteId) {
+  let confirmed404 = false;
+  for (let i = 0; i < 3; i++) {
+    let out = '';
+    try { out = execFileSync('curl', ['-s', '--ssl-no-revoke', '--max-time', '20', `https://note.com/api/v3/notes/${noteId}`], { encoding: 'utf8', maxBuffer: 8 * 1024 * 1024 }); } catch { out = ''; }
+    try { const d = JSON.parse(out); const data = d.data || d; if (data && data.status) return 'ok'; confirmed404 = true; } catch { /* 空/非JSON=throttle → retry */ }
+    if (i < 2) { try { execFileSync('sleep', [String(2 + i)]); } catch {} } // 新規公開の eventual-consistency ラグも吸収
+  }
+  return confirmed404 ? '404' : 'unknown';
+}
 
 console.log(`[対象] ${files.length} 記事 (${srcLabel})${LIST ? '' : ` pattern=${PATTERN}`}${SCHED_START ? `  予約: ${SCHED_START} から ${INTERVAL_H}h 間隔` : ''}`);
 let previewSlot = 0;
@@ -94,7 +117,16 @@ for (let i = 0; i < files.length; i++) {
     console.log(`${tag} ${SCHED_START ? `RESERVE @${schedArgs[1]}` : 'PUBLISH'}${attempt > 1 ? ` (retry ${attempt})` : ''}`);
     try {
       execFileSync('node', ['scripts/note-publish.mjs', '--article', f, '--commit', ...schedArgs], { cwd: ROOT, encoding: 'utf8', timeout: 360000, stdio: ['ignore', 'pipe', 'pipe'] });
-      if (fmHasUrl(f)) done = true; else lastErr = 'noteUrl not written after publish';
+      if (!fmHasUrl(f)) { lastErr = 'noteUrl not written after publish'; }
+      else if (SCHED_START) { done = true; } // 予約=go-live 後刻・実在検証しない（weekly verify-note-status が担保）
+      else {
+        // 偽成功ガード（即時公開）: 書き戻した noteId が note API で実在するか照合
+        const id = fmNoteId(f);
+        const live = id ? liveNoteStatus(id) : 'unknown';
+        if (live === 'ok') done = true;
+        else if (live === '404') { lastErr = `偽成功検出: 公開後 noteId ${id} が note API で実在せず（幻ID）。frontmatter をリセットして再公開が必要`; break; } // retry しても skip されるだけ→即停止
+        else { done = true; console.warn(`    WARN: noteId ${id} 実在未確認(network揺れ)。バッチ後に npm run verify-note-status で要照合`); }
+      }
     } catch (e) { lastErr = ((e.stdout || '') + (e.stderr || '')).trim().split('\n').slice(-2).join(' | '); }
     if (!done && attempt < 2) await new Promise((r) => setTimeout(r, 8000));
   }
@@ -103,4 +135,5 @@ for (let i = 0; i < files.length; i++) {
   await new Promise((r) => setTimeout(r, 12000)); // pacing
 }
 console.log(`\n[done] ok=${ok} skip=${skip} fail=${fail} / ${files.length}`);
+if (!SCHED_START) console.log('[偽成功ガード] 即時公開分は noteId 実在を照合済み。全件確証は `npm run verify-note-status`（fm=published↔ライブ404 を検出）を推奨。');
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
工事82-87がfail=0のまま未公開＋幻noteId(API404)だった事故の再発防止。①note-publish-magazineに即時公開分のnoteId実在照合(確定404でfail停止)②SKILL2本に幻noteId節＋公開後verify-note-status必須ゲート化③postpublish handoffの偽SSOT是正・収録100/100反映。