### PR TITLE
feat(home): ExamCards の stats を種別セクションへ deep-link 化＋hover仕上げ

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,17 @@ type HomeExamCard = {
 const homeExamCards = homeExamCardsData as HomeExamCard[];
 const categoryBySlug = new Map(categories.map((c) => [c.slug, c]));
 
-function computeStat(metas: DocMeta[], spec: HomeStatSpec): { k: string; v: string } {
+// 各カテゴリページの種別セクション(id=`sec-<DocGroupKey>`)へ直行させるためのアンカー。
+// spec.groups の frontmatter 値を canonical な DocGroupKey へ寄せる（past-exam → pastExam）。
+function statAnchor(spec: HomeStatSpec): string | undefined {
+  if (spec.value !== undefined || spec.distinctYear || spec.total) return undefined;
+  const raw = spec.groups?.[0];
+  if (!raw) return undefined;
+  return raw === "past-exam" ? "pastExam" : raw;
+}
+
+function computeStat(metas: DocMeta[], spec: HomeStatSpec): { k: string; v: string; anchor?: string } {
+  const anchor = statAnchor(spec);
   if (spec.value !== undefined) return { k: spec.label, v: spec.value };
   if (spec.distinctYear) {
     const years = new Set(metas.map((m) => (String(m.slug).match(/r\d+/) || [])[0]).filter(Boolean));
@@ -54,7 +64,7 @@ function computeStat(metas: DocMeta[], spec: HomeStatSpec): { k: string; v: stri
   const n = metas.filter(
     (m) => (m.group ? groups.includes(m.group) : false) || tags.some((t) => m.tags?.includes(t)),
   ).length;
-  return { k: spec.label, v: n.toLocaleString() };
+  return { k: spec.label, v: n.toLocaleString(), ...(anchor ? { anchor } : {}) };
 }
 
 // categories.json（visible≠false・variant≠reference）に存在する資格だけを、

--- a/src/components/category/CategorySections.tsx
+++ b/src/components/category/CategorySections.tsx
@@ -478,7 +478,7 @@ function PeConstructionExamTable({ docs }: { docs: DocMeta[] }) {
 
 export function DocSection({ group, layout, secondaryDocs }: { group: DocGroup; layout?: 'cards' | 'exam-table' | 'exam-table-2' | 'pe-exam-table' | 'pe-first-stage-table' | 'pe-construction-exam-table'; secondaryDocs?: DocMeta[] | undefined }) {
   return (
-    <section>
+    <section id={`sec-${group.key}`} className="scroll-mt-24">
       <div className="mb-6">
         <div className="flex items-baseline justify-between gap-2 flex-wrap">
           <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">{group.title}</h2>

--- a/src/components/category/CategoryViews.tsx
+++ b/src/components/category/CategoryViews.tsx
@@ -42,7 +42,7 @@ export function CivilConstruction1View({ groups, mobileCareerAds = [] }: { group
       {guideGroup && <DocSection group={guideGroup} />}
       {mobileCareerAds[0]}
       {textbookGroup && (
-        <section>
+        <section id={`sec-${textbookGroup.key}`} className="scroll-mt-24">
           <div className="mb-6">
             <div className="flex items-baseline justify-between gap-2 flex-wrap">
               <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">{textbookGroup.title}</h2>
@@ -80,6 +80,7 @@ export function CivilConstruction1View({ groups, mobileCareerAds = [] }: { group
       {secondaryTopicDocs.length > 0 && (
         <DocSection
           group={{
+            key: 'secondary',
             title: '第2次検定 分野別対策',
             description: '経験記述・施工管理（コンクリート工・土工・品質管理・施工計画）の基礎と過去問',
             docs: secondaryTopicDocs,
@@ -125,6 +126,7 @@ export function CivilConstruction2View({ groups, mobileCareerAds = [] }: { group
       {secondaryTopicDocs.length > 0 && (
         <DocSection
           group={{
+            key: 'secondary',
             title: '第2次検定 分野別対策',
             description: '経験記述・施工管理（コンクリート工・土工・品質管理・施工計画）の基礎と過去問（主任技術者視点）',
             docs: secondaryTopicDocs,
@@ -166,7 +168,7 @@ export function PeComprehensiveView({ groups, mobileCareerAds = [] }: { groups: 
       )}
       {/* キーワード索引へのナビゲーション（本体は /sitemap-keywords に移動） */}
       {keywordCount > 0 && (
-        <section>
+        <section id="sec-keyword" className="scroll-mt-24">
           <div className="mb-6">
             <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">キーワードを探す</h2>
             <p className="text-[14px] text-[var(--ink-muted)] mt-1">

--- a/src/components/home/ExamCards.tsx
+++ b/src/components/home/ExamCards.tsx
@@ -7,7 +7,7 @@ interface ExamData {
   en: string;
   subtitle: string;
   description: string;
-  stats: { k: string; v: string }[];
+  stats: { k: string; v: string; anchor?: string }[];
   nextExam: string;
   variant: "civil" | "pe";
 }
@@ -23,10 +23,9 @@ function ExamIcon({ variant }: { variant: ExamData["variant"] }) {
 
 function ExamCard({ e }: { e: ExamData }) {
   return (
-    <Link
-      href={`/category/${e.slug}`}
-      className="group block bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section p-6 sm:p-8 transition-all hover:border-[var(--accent)] hover:shadow-lift hover:-translate-y-0.5"
-    >
+    // stretched-link パターン: カード全体はタイトルリンク(疑似要素)でカテゴリへ。stats は z-10 で
+    // その上に乗り、各種別セクション(/category/{slug}#sec-<group>)へ個別に直行できる。
+    <article className="group relative bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section p-6 sm:p-8 transition-all hover:border-[var(--accent)] hover:shadow-lift hover:-translate-y-0.5">
       <div className="flex items-start justify-between gap-4 mb-5">
         <div className="w-14 h-14 bg-[var(--accent-fill)] text-[var(--accent)] rounded-card-content flex items-center justify-center transition-colors group-hover:bg-[var(--accent)] group-hover:text-[var(--paper)]">
           <ExamIcon variant={e.variant} />
@@ -36,22 +35,37 @@ function ExamCard({ e }: { e: ExamData }) {
           <div className="font-mono text-[10px] text-[var(--ink-body)] mt-1.5">{e.nextExam}</div>
         </div>
       </div>
-      <h3 className="font-serif font-black text-xl sm:text-2xl leading-tight text-[var(--ink)] mb-1.5">{e.label}</h3>
+      <h3 className="font-serif font-black text-xl sm:text-2xl leading-tight text-[var(--ink)] mb-1.5 transition-colors group-hover:text-[var(--accent)]">
+        <Link href={`/category/${e.slug}`} className="after:absolute after:inset-0 after:content-['']">
+          {e.label}
+        </Link>
+      </h3>
       <div className="text-[13px] text-[var(--ink-muted)] mb-4">{e.subtitle}</div>
       <p className="text-[14px] leading-[1.85] text-[var(--ink-body)] mb-5">{e.description}</p>
-      <div className="grid grid-cols-3 gap-3 pt-4 border-t border-[var(--rule-soft)] mb-5">
-        {e.stats.map((s) => (
-          <div key={s.k}>
-            <div className="font-serif font-black text-lg sm:text-xl text-[var(--ink)] tabular-nums">{s.v}</div>
-            <div className="font-mono text-[10px] text-[var(--ink-muted)] uppercase tracking-wider mt-0.5">{s.k}</div>
-          </div>
-        ))}
+      <div className="grid grid-cols-3 gap-2 pt-4 border-t border-[var(--rule-soft)] mb-5">
+        {e.stats.map((s) => {
+          const href = s.anchor ? `/category/${e.slug}#sec-${s.anchor}` : `/category/${e.slug}`;
+          return (
+            <Link
+              key={s.k}
+              href={href}
+              className="relative z-10 rounded-card-inline px-1.5 py-2 hover:bg-[var(--accent-fill)] transition-colors group/stat"
+            >
+              <div className="font-serif font-black text-lg sm:text-xl text-[var(--ink)] tabular-nums transition-colors group-hover/stat:text-[var(--accent)]">
+                {s.v}
+              </div>
+              <div className="font-mono text-[10px] text-[var(--ink-muted)] uppercase tracking-wider mt-0.5 transition-colors group-hover/stat:text-[var(--accent)]">
+                {s.k}
+              </div>
+            </Link>
+          );
+        })}
       </div>
       <div className="inline-flex items-center gap-2 font-mono text-[11px] tracking-widest uppercase text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors">
         <span>Read the notes</span>
-        <ArrowRight className="w-3.5 h-3.5" />
+        <ArrowRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" />
       </div>
-    </Link>
+    </article>
   );
 }
 

--- a/src/lib/category-groups.ts
+++ b/src/lib/category-groups.ts
@@ -2,6 +2,7 @@ import { type DocMeta } from '@/lib/docs';
 import { classifyDoc, getGroupOrder, getGroupLabel, type DocGroupKey } from '@/lib/doc-classifier';
 
 export type DocGroup = {
+  key: DocGroupKey;
   title: string;
   description: string;
   docs: DocMeta[];
@@ -170,6 +171,7 @@ export function groupDocs(docs: DocMeta[], category: string): DocGroup[] {
     sortDocs(groupDocs, groupKey, category);
 
     result.push({
+      key: groupKey,
       title: getGroupLabel(category, groupKey),
       description: GROUP_DESCRIPTIONS[category]?.[groupKey] ?? '',
       docs: groupDocs,


### PR DESCRIPTION
## 概要
トップの「対応する資格・試験」カードの stats（記事/過去問/教科書 等）が非リンクで機能していなかったのを、**各資格の種別セクションへ直行する deep-link** に変更。

## 変更
- カード全体は stretched-link でカテゴリへ、stats は `z-10` で個別リンク化し `/category/{slug}#sec-<group>` へ直行。
- `DocGroup` に `key` を追加、`DocSection` が `id="sec-{key}"`＋`scroll-mt-24` を付与。CivilConstruction1View の textbook 手書きセクション・総監の keyword 索引ナビ・civil 二次の合成セクションにも id 付与。
- `page.tsx`: stat ごとに anchor（canonical DocGroupKey・`past-exam`→`pastExam`）を算出し受け渡し。
- 仕上げ(C): stat hover で accent-fill＋accent色、"READ THE NOTES" 矢印スライド。

## 検証
- type-check ✓ / lint-ui exit0
- 6カテゴリ × 12 アンカーを dev サーバーで curl 実査＝**全解決**
- 1440 / 390px スクショ目視 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)