### PR TITLE
refactor(home): ExamCards のスコープ数字行を削除

### DIFF
--- a/src/components/home/ExamCards.tsx
+++ b/src/components/home/ExamCards.tsx
@@ -42,7 +42,6 @@ function ExamCard({ e }: { e: ExamData }) {
   const t = EXAM_THEME[e.slug] ?? FALLBACK_THEME;
   const img = EXAM_IMAGE[e.slug];
   // stats を 1 行のスコープに集約（deep-link はやめ、網羅性の提示のみ残す）。
-  const scope = e.stats.map((s) => `${s.k} ${s.v}`).join(" ・ ");
   return (
     // 画像前面カード: 背景画像＋下部スクリム＋テーマ色ライン、左下にライブ文字を重ねる。カード全体＝カテゴリへのリンク。
     <Link
@@ -72,7 +71,6 @@ function ExamCard({ e }: { e: ExamData }) {
         <div className="font-mono text-[10px] tracking-widest uppercase text-white/75 mb-1.5">{e.nextExam}</div>
         <h3 className="font-serif font-black text-xl sm:text-2xl leading-tight">{e.label}</h3>
         <div className="text-[13px] leading-snug text-white/85 mt-1">{e.subtitle}</div>
-        <div className="font-mono text-[11px] text-white/60 mt-2.5 tabular-nums">{scope}</div>
       </div>
     </Link>
   );


### PR DESCRIPTION
## 概要
画像前面カードの「記事N・過去問N・ガイドN」生カウント行を撤去。数の意味が弱く、少数 vertical で「内容が薄い」印象を与える諸刃だったため。中身の質的説明はサブタイトルが担う。

## 変更
- `ExamCards`: スコープ数字行と `scope` 生成を削除。受験月・資格名・サブタイトルの3点に集約。
- `e.stats` のデータ経路は残置（描画のみ停止・害なし）。

## 検証
- type-check ✓ / lint-ui exit0 / スクショ目視 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)