### PR TITLE
docs(ogp): OGP 既定反転(dark→ライト写真前面)の doc-sync 漏れを是正

### DIFF
--- a/.claude/skills/conversion/ogp-create/SKILL.md
+++ b/.claude/skills/conversion/ogp-create/SKILL.md
@@ -30,6 +30,9 @@ note 公開用ドラフト（`docs/note/`）のカバー画像（1280×670）も
 
 ## テンプレート
 
+> [!important] 現在の既定＝ライト写真前面（2026-07-02〜）
+> サイト OGP の既定は **ライト写真前面**（資格別ブランド写真＋淡スクリム＋濃色文字・kicker/主題/subtitle/種別バッジ）。`npm run ogp` は既定でこれを出す。**旧ダーク配色は `--dark` フラグ**で描画（2026-06-29〜2026-07-02 の旧既定）。背景写真は Codex 生成のブランド写真プールで、`.claude/config/ogp/backgrounds/<exam-key>.png` に置き `resolveBackgroundImage` が解決する。真実源＝[`docs/reference/brand-image-system.md`](../../../../docs/reference/brand-image-system.md)（プール・色統一）＋[`ogp-prompts.md`](../../../../docs/reference/ogp-prompts.md)「変更履歴」。下表の `mono-tag` 行の「warm off-white／16px 外枠」等は旧ライト仕様の記述で、現行の写真前面既定とは一致しない点に注意（詳細仕様は上記 SSOT を参照）。
+
 | ID | 用途 | デザイン |
 |---|---|---|
 | `mono-tag` | サイト OGP（1200×630）共通（T06） | warm off-white 背景 + 薄い濃紺グリッド + シアン/紺アクセントバー + Navy カテゴリチップ + **全幅・縦中央寄せ大タイトル（最大76px）** + **資格別テーマ色 16px 外枠**（下部メタ・タグラインは撤去済み）。**任意で資格別 AI 背景**（あり時は最背面に画像＋可読性スクリム `rgba(253,252,248,0.7)`／なし時は上記オフホワイト固定・後方互換、下記「資格別 AI 背景」） |

--- a/.claude/skills/conversion/ogp-create/scripts/lib/ogp-templates.mjs
+++ b/.claude/skills/conversion/ogp-create/scripts/lib/ogp-templates.mjs
@@ -93,7 +93,7 @@ function debugSafetyOverlay(width) {
   };
 }
 
-// ---- テンプレート: mono-tag ダーク（2026-06-29 リデザイン・サイト OGP 既定）----
+// ---- テンプレート: mono-tag ダーク（2026-06-29 リデザイン。--dark 指定時のみ・2026-07-02 に非既定化）----
 //
 // 深紺グラデ地。ワードマークは置かず、資格名を大きな kicker（accentLight）に。
 // タイトルは「資格名を除いた主題（大・白）＋サブタイトル（小・淡色）」の階層で、
@@ -189,8 +189,8 @@ function renderMonoTagDark({ examLabel, mainLines, subLines, mainFont, contentTy
 // ---- テンプレート: mono-tag (T06) ----
 
 function renderMonoTag({ lines, categoryLabel: cat, fontSize, accentColor, backgroundImage, contentType, dark, examLabel, mainLines, subLines, mainFont }, { width, height }) {
-  // ダーク（サイト OGP 既定・2026-06-29 リデザイン）は新レイアウト（資格名 kicker ＋ 主題/サブ階層）へ委譲。
-  // ライト（--light / note カバー mono-tag フォールバック）は従来の全幅レイアウト（以下）。
+  // ダーク（--dark 指定時のみ・旧既定〜2026-07-02。2026-06-29 リデザイン）は資格名 kicker ＋ 主題/サブ階層へ委譲。
+  // ライト（既定＝写真前面 2026-07-02〜 / note カバー mono-tag フォールバック）は全幅レイアウト＋資格別背景写真＋subtitle（以下）。
   if (dark) {
     return renderMonoTagDark({ examLabel, mainLines, subLines, mainFont, contentType, accentColor }, { width, height });
   }

--- a/.claude/skills/conversion/ogp-create/scripts/ogp-create.mjs
+++ b/.claude/skills/conversion/ogp-create/scripts/ogp-create.mjs
@@ -342,7 +342,7 @@ async function generateOne({ fullPath, fullSlug, fonts, args, stats }) {
     backgroundImage,
     accentColor,
     contentType,
-    // ダーク（サイト OGP 既定）用
+    // ダーク（--dark 指定時のみ。2026-06-29〜2026-07-02 は既定だったが現在は非既定）用
     dark: !args.light,
     examLabel: categoryLabel,
     mainLines,

--- a/.claude/skills/conversion/ogp-design-explore/SKILL.md
+++ b/.claude/skills/conversion/ogp-design-explore/SKILL.md
@@ -79,7 +79,7 @@ mcp__aidesigner__get_credit_status   # 残量を確認。残りが少なけれ�
 ## 参照
 
 - 量産・本番生成（決定論テンプレ）: `/ogp-create`（`.claude/skills/conversion/ogp-create/SKILL.md`）
-- 資格別 AI 背景（背景だけを Gemini で生成・全記事共有）: `npm run ogp-backgrounds`（`scripts/generate-ogp-backgrounds.mjs`）。mono-tag の最背面に敷く下地用。**課金が発生するため実行前にユーザー確認**（`--dry-run` は無料）。意匠の全面試作は本スキル、背景下地だけならこちらが軽量
+- 資格別 AI 背景（背景だけを Gemini で生成・全記事共有）: `npm run ogp-backgrounds`（`scripts/generate-ogp-backgrounds.mjs`）。mono-tag の最背面に敷く下地用。**課金が発生するため実行前にユーザー確認**（`--dry-run` は無料）。意匠の全面試作は本スキル、背景下地だけならこちらが軽量。※**2026-07-02〜、現行の資格別背景は Codex 生成のブランド写真プール**（`.claude/config/ogp/backgrounds/<exam-key>.png`・真実源 [`docs/reference/brand-image-system.md`](../../../../docs/reference/brand-image-system.md)）。この Gemini 生成はレガシー/代替扱い
 - デザイン SSOT: `docs/reference/ogp-prompts.md`（レイアウト・配色・テーマ色・変更履歴）
 - テーマ色トークン（真実源）: `docs/design-system/note-cover-tokens.json`
 - レンダラ実装: `.claude/skills/conversion/ogp-create/scripts/lib/ogp-templates.mjs`


### PR DESCRIPTION
OGP の既定を dark→ライト写真前面へ反転(#338/#340)した際の doc-sync 漏れを是正。ogp-create/SKILL.md に現既定 callout・script コメントの「既定=ダーク」是正・ogp-design-explore に Codex プール補足。挙動不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)