### PR TITLE
feat(analytics): NoteLink の note 無料記事クリックを計測（計測基盤 Tier1 #1）

### DIFF
--- a/.claude/scripts/fetch-ga4-cta-clicks.mjs
+++ b/.claude/scripts/fetch-ga4-cta-clicks.mjs
@@ -28,7 +28,7 @@ dotenv.config({ path: ".env.local" });
 
 const OUTPUT_DIR = ".claude/state/metrics/ga4";
 const DEFAULT_DAYS = 28;
-const EVENT_NAMES = ["note_cta_click", "affiliate_cta_click"];
+const EVENT_NAMES = ["note_cta_click", "affiliate_cta_click", "note_article_click"];
 
 function parseArgs() {
   const args = process.argv.slice(2);

--- a/src/components/providers/AnalyticsProvider.tsx
+++ b/src/components/providers/AnalyticsProvider.tsx
@@ -18,19 +18,23 @@ export default function AnalyticsProvider() {
     gtag.pageview(url);
   }, [pathname, searchParams]);
 
-  // 収益 CTA（note 有料マガジン / アフィリエイト）のクリックを 1 つのデリゲート
-  // リスナーで計測する。各コンポーネントを client 化せず、サーバー描画の <a> に
-  // data-cta="note" | "affiliate"（+ data-cta-label）を付けるだけで拾える設計。
-  // GA4 はイベントに pagePath を自動付与するため、eventName × pagePath で
-  // ページ別の CTA クリック数（= 収益カバレッジダッシュボードの CTR 分母）が取れる。
+  // 収益 CTA（note 有料マガジン / アフィリエイト）と note 無料記事への送客リンクの
+  // クリックを 1 つのデリゲートリスナーで計測する。各コンポーネントを client 化せず、
+  // サーバー描画の <a> に data-cta="note" | "affiliate" | "note-article"（+ data-cta-label）
+  // を付けるだけで拾える設計。GA4 はイベントに pagePath を自動付与するため、
+  // eventName × pagePath でページ別クリック数が取れる。
+  // note（有料マガジン購入 CTA）と note-article（無料記事ナビ）は別イベントに分離し、
+  // 収益ファネルの分母（note_cta_click）を無料記事クリックで汚染しない。
   useEffect(() => {
     const ACTION: Record<string, string> = {
       note: "note_cta_click",
       affiliate: "affiliate_cta_click",
+      "note-article": "note_article_click",
     };
     const CATEGORY: Record<string, string> = {
       note: "note-magazine",
       affiliate: "affiliate",
+      "note-article": "note-article",
     };
     const onClick = (e: MouseEvent) => {
       const start = e.target as Element | null;

--- a/src/components/ui/NoteLink/NoteLink.tsx
+++ b/src/components/ui/NoteLink/NoteLink.tsx
@@ -18,6 +18,17 @@ interface NoteLinkProps {
    * 正方形版を生成しておくこと。
    */
   readonly coverImage?: string;
+  /**
+   * GA4 クリック計測ラベル（任意）。省略時は URL の note 記事 ID を使う。
+   * 有料マガジン CTA（note_cta_click）とは別イベント note_article_click で計測する。
+   */
+  readonly trackLabel?: string;
+}
+
+/** note URL から計測ラベルを導く。例: .../n/nc360aaa381b0 → note-nc360aaa381b0 */
+function trackLabelFromUrl(url: string): string {
+  const m = url.match(/\/n\/([a-zA-Z0-9]+)/);
+  return m ? `note-${m[1]}` : "note-article";
 }
 
 /**
@@ -53,6 +64,7 @@ export default function NoteLink({
   title,
   description,
   coverImage,
+  trackLabel,
 }: NoteLinkProps) {
   const imageUrl = coverImage ? toSquareImage(coverImage) : null;
 
@@ -61,6 +73,8 @@ export default function NoteLink({
       href={url}
       target="_blank"
       rel="noopener noreferrer"
+      data-cta="note-article"
+      data-cta-label={trackLabel ?? trackLabelFromUrl(url)}
       className="not-prose group my-6 block max-w-2xl rounded-card-content overflow-hidden border border-[var(--rule-soft)] bg-[var(--paper)] shadow-card-content hover:shadow-card-hover hover:border-brand dark:hover:border-brand transition-shadow"
     >
       <div className="flex flex-col sm:flex-row">


### PR DESCRIPTION
## 目的

計測基盤 強化ロードマップ（[measurement-infra-enhancement.md](docs/todo/measurement-infra-enhancement.md)）の **Tier 1 #1**。記事内 note 無料記事への送客カード `NoteLink`（11箇所）が `data-cta` 未付与で GA4 クリック未計測だった穴（監査で「最大の穴」と判定）を解消。

## 変更（3ファイル・additive）

- **`NoteLink.tsx`**: `<a>` に `data-cta="note-article"` ＋ `data-cta-label` を付与。任意 `trackLabel` prop（省略時は URL から note 記事 ID を導出）。既存11箇所は MDX 無修正で自動的に計測対象に。
- **`AnalyticsProvider.tsx`**: デリゲートマップに `note-article → note_article_click` を追加。
- **`fetch-ga4-cta-clicks.mjs`**: `EVENT_NAMES` に `note_article_click` を追加し CI 供給パイプラインに載せる。

## 設計判断

有料マガジン購入 CTA（`note_cta_click`）とは**別イベント `note_article_click` に分離**。収益ファネルの分母（`report-monetization-coverage.mts` の noteCTR）を無料記事ナビのクリックで汚染しないため。

## 検証

- `npm run type-check` 通過
- pre-commit 全ゲート通過
- GA4 イベント発火はプレビューで視認不可のため型・配線で検証（実発火は deploy 後 GA4 側で確認）

真実源: [measurement-infra-enhancement.md](docs/todo/measurement-infra-enhancement.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)