### PR TITLE
feat(analytics): 計測基盤 Tier1 の配線（#2/#3/#4/#6）

### DIFF
--- a/.github/workflows/fetch-metrics.yml
+++ b/.github/workflows/fetch-metrics.yml
@@ -98,6 +98,22 @@ jobs:
           GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
         run: npm run fetch-ga4-cta-clicks -- --by-device
 
+      # 収益カバレッジ ダッシュボード生成: ページ別流入(ga4-page) × CTA クリック(ga4-cta-clicks) ×
+      # 配置真実源を突合し monetization/coverage-*.{json,md} を生成（オフライン・上の fetch 結果を読む）。
+      # 従来 npm script のみで CI 未配線＝coverage-latest.md が 2026-06-18 で停止していたのを週次自動化。
+      - name: Generate monetization coverage report
+        continue-on-error: true
+        run: npm run report-monetization-coverage
+
+      # bot 混入監視: Japan フィルタ後も残る bot 署名（高外国比率・低engagement の参照元）を surface し
+      # bot-audit-*.json を ga4/ に出力（新規スパム候補は STDOUT）。従来 CI 未配線＝2026-05-17 以降実行ゼロ。
+      - name: Audit GA4 bot ratio
+        continue-on-error: true
+        env:
+          GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ./credentials/gsc-service-account.json
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+        run: npm run audit-ga4-bot-ratio
+
       - name: Check data integrity
         id: integrity
         continue-on-error: true
@@ -129,11 +145,12 @@ jobs:
           git checkout develop
           git pull --rebase origin develop
 
-          mkdir -p .claude/state/metrics/ga4 .claude/state/metrics/gsc
+          mkdir -p .claude/state/metrics/ga4 .claude/state/metrics/gsc .claude/state/metrics/monetization
           cp -r /tmp/metrics-publish/ga4/* .claude/state/metrics/ga4/ 2>/dev/null || true
           cp -r /tmp/metrics-publish/gsc/* .claude/state/metrics/gsc/ 2>/dev/null || true
+          cp -r /tmp/metrics-publish/monetization/* .claude/state/metrics/monetization/ 2>/dev/null || true
 
-          git add .claude/state/metrics/ga4 .claude/state/metrics/gsc
+          git add .claude/state/metrics/ga4 .claude/state/metrics/gsc .claude/state/metrics/monetization
           if git diff --cached --quiet; then
             echo "No changes to publish"
             exit 0

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,12 +1,22 @@
 "use client";
 
 import Script from "next/script";
+import { useEffect, useState } from "react";
 
 export default function GoogleAnalytics() {
   // NEXT_PUBLIC_GA_ID: Google Analytics トラッキングID（GA4の測定ID）
   // 例: G-XXXXXXXXXX
   // 未設定の場合はGoogle Analyticsコンポーネントがレンダリングされない
   const gaId = process.env.NEXT_PUBLIC_GA_ID;
+
+  // pages.dev（Cloudflare プレビュー/本番直 URL）からの発火を除外する。
+  // 本番カスタムドメイン(doboku-note.com)・未知ホストは通す fail-open 方式（否定チェック）に
+  // することで、万一ドメインが変わっても本番 GA を誤って止めない。判定は client のみ可能なため
+  // 初期値はブロック（SSR/初回描画は null）で、mount 後に hostname を見て解除する。
+  const [previewBlocked, setPreviewBlocked] = useState(true);
+  useEffect(() => {
+    setPreviewBlocked(window.location.hostname.endsWith(".pages.dev"));
+  }, []);
 
   // dev (npm run dev / localhost) では GA4 を発火させない（内部トラフィック混入防止）
   // - GA4 で Direct トラフィックが Organic より多く混入する根本原因
@@ -19,8 +29,10 @@ export default function GoogleAnalytics() {
     return null;
   }
 
-  // 本番ホスト以外でも除外（pages.dev / プレビュー / コラボ環境からのアクセスを除外したい場合は
-  // ここで window.location.hostname を見て分岐できる。現状は dev 排除のみ）
+  // pages.dev プレビュー/コラボ環境からの内部トラフィック混入を除外
+  if (previewBlocked) {
+    return null;
+  }
 
   return (
     <>

--- a/src/components/ui/MagazineCard/MagazineCard.tsx
+++ b/src/components/ui/MagazineCard/MagazineCard.tsx
@@ -35,6 +35,7 @@ export default function MagazineCard({ id, utmContent }: MagazineCardProps) {
       description={magazine.description}
       imageUrl={magazine.imageUrl}
       badge={magazine.badge}
+      trackLabel={utmContent}
     />
   );
 }


### PR DESCRIPTION
## 目的

計測基盤 強化ロードマップ（[measurement-infra-enhancement.md](docs/todo/measurement-infra-enhancement.md)）の **Tier 1 のうち agent 実行可能な配線・是正を一括実装**。PR #343（#1 NoteLink 計測）に続く第2弾。

## 変更（3ファイル・additive／低リスク）

- **#2 MagazineCard**（`MagazineCard.tsx`）: `MagazineInlineCard` へ `trackLabel={utmContent}` を伝播。従来 undefined で href フォールバックしていた CTA クリックの**ページ×配置粒度を回復**。
- **#6 GoogleAnalytics**（`GoogleAnalytics.tsx`）: `pages.dev` を否定チェックで除外。**fail-open**（本番カスタムドメイン・未知ホストは通し、`pages.dev` プレビュー直 URL のみ遮断）＝万一ドメインが変わっても本番 GA を誤停止しない。client mount 後に hostname 判定。
- **#3 収益カバレッジ CI 配線**（`fetch-metrics.yml`）: `report-monetization-coverage` を週次実行し publish に `monetization/` を追加。**`coverage-latest.md` が 2026-06-18 で停止**していたのを自動化。
- **#4 bot 比率監査 CI 配線**（`fetch-metrics.yml`）: `audit-ga4-bot-ratio` を週次実行。**2026-05-17 以降実行ゼロ**だったのを復活し、新規スパム参照元を毎週 surface（`bot-audit-*.json` は ga4/ 出力で自動 publish）。

## 検証

- `npm run type-check` 通過
- `fetch-metrics.yml` の YAML 妥当性確認（22 ステップ・新2ステップが正しい位置）
- 両 CI ステップは `continue-on-error` でワークフロー本体を保護
- 入力確認: monetization=state 読取のみ（オフライン）／bot-audit=GA4 API 自前呼出（creds env 付与済）

## スコープ外（判断ゲート・別途）

- **#5**: metrics-analyzer は LLM エージェントで CI 不可（scheduled cloud routine 要・`/routines` 確認の上で別途）／seo-meta 配線は generator 要確認
- **#7 UTM 規約統一**: doc(inline/site) vs 実装(referral/doboku-note) のドリフト是正は**値変更＝GA4 データ連続性に影響**するため方針決定が必要

## サーバ側（別途・ユーザー手作業）

GA4 UI の内部トラフィック除外フィルタ・参照除外・既知ボット除外 ON・カスタムディメンション登録（詳細は roadmap doc）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)