### PR TITLE
feat(analytics): サイト内検索を URL(?q=) 同期し GA4 検索計測を有効化（計測基盤 #9）

### DIFF
--- a/src/app/search/SearchPageClient.tsx
+++ b/src/app/search/SearchPageClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { useSearch } from "@/hooks/useSearch";
 import { SearchBox } from "@/components/search/SearchBox";
 import { SearchResults } from "@/components/search/SearchResults";
@@ -18,6 +18,8 @@ interface SearchPageClientProps {
 
 export default function SearchPageClient({ categories, popular }: SearchPageClientProps) {
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
   const {
     query,
     setQuery,
@@ -43,6 +45,12 @@ export default function SearchPageClient({ categories, popular }: SearchPageClie
   const handleSearch = (searchQuery: string) => {
     setQuery(searchQuery);
     updateSearchQuery({ q: searchQuery });
+    // 検索クエリを URL(?q=) に同期する。
+    // (1) GA4 拡張計測「サイト内検索」が ?q= を含む pageview から検索イベントを自動生成する
+    // (2) 検索結果が共有/ブックマーク/戻る操作可能になる（UX 改善）
+    // router.replace + scroll:false で履歴汚染とスクロールジャンプを避ける。
+    const qs = searchQuery.trim() ? `?q=${encodeURIComponent(searchQuery.trim())}` : "";
+    router.replace(`${pathname}${qs}`, { scroll: false });
   };
 
   const handleCategoryChange = (newCategory: string) => {


### PR DESCRIPTION
## 目的

計測基盤 強化ロードマップ #9 のうち**サイト内検索**の計測穴を解消。GA4 拡張計測「サイト内検索」は ON だが、`?q=` を含む URL からしか検索を拾えず、当サイトは検索ボックス入力で URL を更新しない（`SearchPageClient` の `handleSearch` が client 状態のみ更新）ため、**実際の検索の大半が未計測**だった。

## 変更（1ファイル）

`SearchPageClient.tsx` の `handleSearch` で `router.replace` により検索クエリを URL(`?q=`) に同期:
- GA4 拡張計測が `?q=` を含む pageview から検索イベント（`view_search_results`）を**自動生成**（新規 GA4 コード不要・既定検索パラメータ `q` なので GA4 側の追加設定も不要）
- 検索結果が**共有/ブックマーク/戻る操作可能**になる UX 改善も付随
- `router.replace` + `scroll:false` で履歴汚染・スクロールジャンプを回避

## #9 の完了判定

拡張計測が全 ON（ユーザー確認済）のため:
- **scroll depth**: 90% スクロール自動計測 → 実装不要
- **outbound（note/e-gov）**: 離脱クリック自動計測＋PR #343（NoteLink）でカバー済
- **サイト内検索**: 本 PR で解消

→ **#9 完了**。

## 検証

- `npm run type-check` 通過・pre-commit 全ゲート通過
- deploy 後 GA4 DebugView で `view_search_results` 発火を確認予定（SPA の history-based pageview 経由）

🤖 Generated with [Claude Code](https://claude.com/claude-code)