### PR TITLE
chore(metrics): crosswalk を CI 週次配線＋roadmap を deploy 済に反映（計測基盤 follow-up）

### DIFF
--- a/.github/workflows/fetch-metrics.yml
+++ b/.github/workflows/fetch-metrics.yml
@@ -65,6 +65,14 @@ jobs:
           GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ./credentials/gsc-service-account.json
         run: npm run fetch-gsc-data -- --dimension date --days 7
 
+      # GA4×GSC crosswalk 用: ページ別 GSC スナップショット（gsc-page-*.json）。
+      # 従来 page 次元は月次 index-coverage でしか取れず crosswalk が最大月次だった。
+      # 週次化して ga4-page（週次）と鮮度を揃える。
+      - name: Fetch GSC (page, for crosswalk)
+        env:
+          GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ./credentials/gsc-service-account.json
+        run: npm run fetch-gsc-data -- --dimension page
+
       # 収益カバレッジ ダッシュボード用: ページ別流入（report-monetization-coverage.mts が
       # 最新 ga4-page-*.json を読む）。
       - name: Fetch GA4 (page, for monetization coverage)
@@ -114,6 +122,12 @@ jobs:
           GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
         run: npm run audit-ga4-bot-ratio
 
+      # GA4×GSC crosswalk 生成: 上で取得した ga4-page × gsc-page を URL で突合し、
+      # title/meta 機会（上位表示低CTR）と ランキング機会（表示多い低順位）を surface（オフライン）。
+      - name: Generate GA4xGSC crosswalk report
+        continue-on-error: true
+        run: npm run report-ga4-gsc-crosswalk
+
       - name: Check data integrity
         id: integrity
         continue-on-error: true
@@ -145,12 +159,13 @@ jobs:
           git checkout develop
           git pull --rebase origin develop
 
-          mkdir -p .claude/state/metrics/ga4 .claude/state/metrics/gsc .claude/state/metrics/monetization
+          mkdir -p .claude/state/metrics/ga4 .claude/state/metrics/gsc .claude/state/metrics/monetization .claude/state/metrics/crosswalk
           cp -r /tmp/metrics-publish/ga4/* .claude/state/metrics/ga4/ 2>/dev/null || true
           cp -r /tmp/metrics-publish/gsc/* .claude/state/metrics/gsc/ 2>/dev/null || true
           cp -r /tmp/metrics-publish/monetization/* .claude/state/metrics/monetization/ 2>/dev/null || true
+          cp -r /tmp/metrics-publish/crosswalk/* .claude/state/metrics/crosswalk/ 2>/dev/null || true
 
-          git add .claude/state/metrics/ga4 .claude/state/metrics/gsc .claude/state/metrics/monetization
+          git add .claude/state/metrics/ga4 .claude/state/metrics/gsc .claude/state/metrics/monetization .claude/state/metrics/crosswalk
           if git diff --cached --quiet; then
             echo "No changes to publish"
             exit 0

--- a/docs/todo/measurement-infra-enhancement.md
+++ b/docs/todo/measurement-infra-enhancement.md
@@ -10,6 +10,27 @@
 
 ---
 
+## 実施状況（2026-07-03・本番 deploy 済 `93b379df6`）
+
+**コード実装完了（develop→main 反映済）**:
+- ✅ #1 NoteLink 計測（別イベント `note_article_click`・PR #343）
+- ✅ #2 MagazineCard trackLabel 伝播（PR #344）
+- ✅ #3 収益カバレッジ表を CI 週次配線（PR #344）
+- ✅ #4 bot 比率監査を CI 週次配線（PR #344）
+- ✅ #6 pages.dev の gtag ブロック（fail-open・PR #344）
+- ✅ #7 UTM referral の policy+check（PR #345・**content 移行は burndown 残**＝下記 item 7）
+- ✅ #9 サイト内検索を URL(?q=) 同期し `view_search_results` 有効化（PR #346）。scroll は拡張計測 ON で自動・outbound は #1＋拡張計測でカバー済＝#9 完了
+- ✅ #11 GA4×GSC crosswalk レポート（PR #347）＋週次 CI 自動化（gsc-page fetch＋crosswalk step）
+- （関連）deploy ドリフト検知＋check-links 偽陽性是正（PR #342）
+
+**GA4 UI（ユーザー作業）**: A 内部トラフィック/参照除外 ✅・B キーイベント ✅・C 拡張計測 全 ON 確認 ✅／**D カスタムディメンション（#8/#10 の前提）未・E bing bot 確定 未**
+
+**残（未着手）**: #5 分析 cadence（metrics-analyzer は LLM＝cloud routine／seo-meta 配線）・#8 カスタムパラメータ（GA4 D 前提）・#10 アフィリ A/B（GA4 event_label 登録前提）・#12 note.com referral・Tier 3（#13-16）・#7 content 移行 burndown
+
+**deploy 後の検証待ち**: GA4 DebugView で `note_article_click`/`view_search_results` 発火・金曜 fetch-metrics 週次で coverage/bot-audit/crosswalk が更新されるか
+
+---
+
 ## Tier 1 — すぐやる（低コスト・高効果／既存資産の配線・是正）
 
 1. **NoteLink のクリック計測** 🔴 — `src/components/ui/NoteLink/NoteLink.tsx:60-64` の `<a>` に `data-cta="note"`＋`data-cta-label` を付与（既存デリゲート `AnalyticsProvider.tsx:26-52` に乗る）。記事内 note 無料記事送客（11箇所）が丸ごと未計測なのを解消。**最大の穴**。URL にも UTM 付与。


### PR DESCRIPTION
## 目的

計測基盤の deploy 後 follow-up（① roadmap 反映・② crosswalk CI 自動化）。

## 変更（2ファイル）

**② crosswalk の CI 週次自動化**（`fetch-metrics.yml`）— #344 マージで fetch-metrics.yml のコンフリクトが解消したため実施:
- `fetch-gsc-data --dimension page` を週次追加（従来 page 次元は月次 index-coverage のみ→ga4-page 週次と鮮度を揃える）
- `report-ga4-gsc-crosswalk` を bot audit の後に実行（`continue-on-error`）
- publish に `crosswalk/` を追加（週次 commit）

**① roadmap doc に実施状況セクション追加**（`measurement-infra-enhancement.md`）:
- #1/2/3/4/6/7/9/11 が deploy 済（PR 番号付き）・GA4 UI A/B/C 済・D/E と #5/#8/#10/#12/Tier3/#7burndown が残、を明記（drift 防止）

## 検証

- YAML 妥当性確認（24 steps・crosswalk 2 step が正しい位置）
- pre-commit 全ゲート通過・並行コミット非巻き込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)