### PR TITLE
fix(utm): UTM referral 統一の追随もれを是正（agent＋doc SSOT ドリフト）

### DIFF
--- a/.claude/agents/note-link-injector.md
+++ b/.claude/agents/note-link-injector.md
@@ -30,7 +30,7 @@ note.com 公開用ドラフトの本文中に出現する doboku-note キーワ�
 | 入力 | `docs/note/{slug}/article.md` のフルパス |
 | 辞書 | `src/config/pe-chapters.json`（PE 658 キーワード、`{slug, title}` のみ） |
 | ルール | `.claude/skills/social/social-post/SKILL.md` の「キーワード内部リンク（全占有方針）」 |
-| URL | `https://doboku-note.com/docs/pe-comprehensive-management-{slug}?utm_source=note&utm_medium=inline&utm_campaign={記事の安定slug}&utm_content=kw-{slug}` |
+| URL | `https://doboku-note.com/docs/pe-comprehensive-management-{slug}?utm_source=note&utm_medium=referral&utm_campaign={記事の安定slug}&utm_content=kw-{slug}` |
 | 操作 | Edit ツールで本文に `[text](url)` を追記（UTM 付き・下記ルール8） |
 | 範囲外 | frontmatter / 画像参照 / コードブロック / 見出し（`#`〜`###`） |
 
@@ -43,7 +43,7 @@ note.com 公開用ドラフトの本文中に出現する doboku-note キーワ�
 5. **1 概念ペアは 1 リンクに統合**: `X理論 ↔ Y理論` → `[X理論 ↔ Y理論](url)` のように 1 リンクで囲む
 6. **note 続編 cross-sell 行も対象**: 「note のおすすめ続編」セクションも例外なし
 7. **既にリンク化済みのテキストは触らない**（重複リンク防止）
-8. **全リンクに UTM を付与**: 注入する各 URL に `?utm_source=note&utm_medium=inline&utm_campaign={記事の安定slug}&utm_content=kw-{キーワードslug}` を付ける（note→サイト送客の計測。真実源 `docs/project/03_SNS/02_チャネル動線設計.md`）。`utm_campaign` は記事ディレクトリの安定 ASCII slug（例: `pe-bousai`）。**生 URL を単独行で置かない**（`/note-publish` がカード化し UTM が消える＝送客リンクは必ず UTM 付きインライン）
+8. **全リンクに UTM を付与**: 注入する各 URL に `?utm_source=note&utm_medium=referral&utm_campaign={記事の安定slug}&utm_content=kw-{キーワードslug}` を付ける（note→サイト送客の計測。真実源 `docs/project/03_SNS/02_チャネル動線設計.md`）。`utm_campaign` は記事ディレクトリの安定 ASCII slug（例: `pe-bousai`）。**生 URL を単独行で置かない**（`/note-publish` がカード化し UTM が消える＝送客リンクは必ず UTM 付きインライン）
 
 ## Synonym 判断（Agent の主戦場）
 

--- a/docs/project/03_SNS/02_チャネル動線設計.md
+++ b/docs/project/03_SNS/02_チャネル動線設計.md
@@ -102,11 +102,11 @@ doboku-note の認知獲得から有料転換までの 5 チャネルファネ�
 | **サイト → note**（`buildMagazineUrl`） | `doboku-note` | `referral` | `note-magazine` | 配置識別子（例: `keyword-2026-sidebar`） |
 | **note 記事 → サイト deep link**（`add-note-utm`） | `note` | `referral` | 記事の `utmCampaign`（例: `civil-keiken-leadmagnet`） | 送客先識別子（任意・例: `guide-civil-1`） |
 
-> **なぜ `utm_medium=referral` か（2026-07-03 確定）**: `referral` は GA4 が標準で「Referral」チャネルに分類する medium。`inline`/`banner` のような非標準値は GA4 デフォルトで「Unassigned」に落ち、note 流入のチャネル分類が壊れる。link 形式（インライン/バナー/カード）の区別は medium ではなく **`utm_content`** で持つ。過去に土木系 note が `inline`・総監系が `referral` とドリフトしていたのを referral へ統一（114 箇所/53 ファイル移行済）。機械検証は `check-note-site-utm` が `utm_medium=referral` を強制する。
+> **なぜ `utm_medium=referral` か（2026-07-03 確定）**: `referral` は GA4 が標準で「Referral」チャネルに分類する medium。`inline`/`banner` のような非標準値は GA4 デフォルトで「Unassigned」に落ち、note 流入のチャネル分類が壊れる。link 形式（インライン/バナー/カード）の区別は medium ではなく **`utm_content`** で持つ。過去に土木系 note が `inline`・総監系が `referral` とドリフトしていたのを referral へ統一する方針（PR #345）。**既存 inline リンク約 94 箇所は各ファイル編集時に referral へ段階移行する burndown**（cover-fit/note-lint 債務と絡むため一括移行せず・新 check が編集時に強制）。機械検証は `check-note-site-utm` が `utm_medium=referral` を強制する。
 >
 > **note のリンクカードと UTM の使い分け**: note のリンクカード（OGP プレビュー）は UTM 付き URL だと安定して生成されないため、**サイトへの送客リンクは UTM 付きのインライン（テキスト）リンク**で張る。リンクカードは note 内部 CTA（有料マガジン・もくじ）に限定し UTM は付けない（内部リンクは note 管理画面のクリック統計で足りる・doboku-note の GA4 は note.com を見ない）。カード表示と UTM 計測を両立したい場合のみ、`public/_redirects` のクリーン URL → 302（UTM 付与）方式を使う（未実装＝計測基盤ロードマップ Tier 3 #15）。**注意**: 送客 URL を**単独行の生 URL** で置くと `/note-publish` が自動でリンクカード化し UTM が落ちる。サイト送客リンクは必ず**アンカー文言付きインライン** `[テキスト](url?utm…)` で本文に畳み込む。
 >
-> **機械検証**: `npm run check-note-site-utm`（pre-commit は `--staged`）が `docs/note/**` の `doboku-note.com/docs/` 送客リンクを検査し、生 URL（カード化で UTM 消失）と `utm_source=note` 欠落を検出する。既存違反のバーンダウン中は `SKIP_NOTE_UTM=1` で一時回避。
+> **機械検証**: `npm run check-note-site-utm`（pre-commit は `--staged`）が `docs/note/**` の `doboku-note.com/docs/` 送客リンクを検査し、生 URL（カード化で UTM 消失）・`utm_source=note` 欠落・`utm_medium=referral` 以外（旧 inline 等）を検出する。既存違反のバーンダウン中は `SKIP_NOTE_UTM=1` で一時回避。
 
 ### 実装ファイル
 


### PR DESCRIPTION
計測基盤セッションの SSOT ドリフト点検で発見。#7(UTM referral 統一/PR #345)の追随もれ2系統を是正: (1) note-link-injector agent が旧 utm_medium=inline を prescribe→referral (2) 02_チャネル動線設計.md の「114/53移行済」誤記→burndown 明記＋機械検証に medium 検査追記。check-doc-refs 壊れ参照0・agent description 変更なしで台帳不要。🤖 Generated with [Claude Code](https://claude.com/claude-code)