### PR TITLE
feat(uptime): GA スクリプト存在チェックを追加（#6 GA停止 regression の機械検知）

### DIFF
--- a/.github/workflows/uptime-ping.yml
+++ b/.github/workflows/uptime-ping.yml
@@ -90,6 +90,15 @@ jobs:
                 continue
               fi
 
+              # GA 計装検証: gtag スクリプトが SSR HTML に載っているか。
+              # GoogleAnalytics を client-gating 等に変えると gtag が SSR から消え本番 GA が
+              # 停止する regression（2026-07-03 #6）を機械検知する。pages.dev でも script tag
+              # 自体は在る（config のみ hostname で抑止）ので、この検査は全 URL で成立する。
+              if ! grep -q 'googletagmanager' /tmp/body.html; then
+                FAILURES+=("$URL [$UA_LABEL] no GA script (googletagmanager) — GA 計装が SSR HTML から消失")
+                continue
+              fi
+
               echo "OK: $URL [$UA_LABEL] size=$SIZE"
             done
           done


### PR DESCRIPTION
計測基盤セッションで #6 が GoogleAnalytics を client-gating に変え gtag が SSR HTML から消え本番 GA が全停止(PR #350復旧)。uptime-ping の <main>/キーワード検査をすり抜けユーザーが手動で気づくまで未検知だった。再発防止としてuptime-ping各URL検査に googletagmanager 存在チェックを追加→GA計装がSSRから消えたら1日3回のpingで検知。pages.devでもscript tag自体は在る(configのみ抑止)。🤖 Generated with [Claude Code](https://claude.com/claude-code)