### PR TITLE
fix(ga4): GoogleAnalytics SSR 回帰を修正（本番 GA 復旧）

### DIFF
--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,22 +1,12 @@
 "use client";
 
 import Script from "next/script";
-import { useEffect, useState } from "react";
 
 export default function GoogleAnalytics() {
   // NEXT_PUBLIC_GA_ID: Google Analytics トラッキングID（GA4の測定ID）
   // 例: G-XXXXXXXXXX
   // 未設定の場合はGoogle Analyticsコンポーネントがレンダリングされない
   const gaId = process.env.NEXT_PUBLIC_GA_ID;
-
-  // pages.dev（Cloudflare プレビュー/本番直 URL）からの発火を除外する。
-  // 本番カスタムドメイン(doboku-note.com)・未知ホストは通す fail-open 方式（否定チェック）に
-  // することで、万一ドメインが変わっても本番 GA を誤って止めない。判定は client のみ可能なため
-  // 初期値はブロック（SSR/初回描画は null）で、mount 後に hostname を見て解除する。
-  const [previewBlocked, setPreviewBlocked] = useState(true);
-  useEffect(() => {
-    setPreviewBlocked(window.location.hostname.endsWith(".pages.dev"));
-  }, []);
 
   // dev (npm run dev / localhost) では GA4 を発火させない（内部トラフィック混入防止）
   // - GA4 で Direct トラフィックが Organic より多く混入する根本原因
@@ -29,11 +19,11 @@ export default function GoogleAnalytics() {
     return null;
   }
 
-  // pages.dev プレビュー/コラボ環境からの内部トラフィック混入を除外
-  if (previewBlocked) {
-    return null;
-  }
-
+  // 本番は SSR で gtag スクリプトを HTML に載せ、確実にロードさせる（初回 page_view を取りこぼさない）。
+  // pages.dev（Cloudflare プレビュー/本番直 URL）からの内部トラフィック混入は、
+  // gtag('config') を hostname で条件分岐して除外する（config を送らなければ GA は活性化しない）。
+  // 本番カスタムドメイン(doboku-note.com)・未知ホストは通す fail-open。SPA 遷移・クリックイベント側の
+  // pages.dev 除外は src/lib/gtag.ts のガードで担保する。
   return (
     <>
       <Script
@@ -48,9 +38,11 @@ export default function GoogleAnalytics() {
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', '${gaId}', {
-              page_path: window.location.pathname,
-            });
+            if (!location.hostname.endsWith('.pages.dev')) {
+              gtag('config', '${gaId}', {
+                page_path: window.location.pathname,
+              });
+            }
           `,
         }}
       />

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -21,6 +21,11 @@ declare global {
   }
 }
 
+// pages.dev（Cloudflare プレビュー/本番直 URL）からの内部トラフィック混入を除外する。
+// 本番カスタムドメイン・未知ホストは通す fail-open（否定チェック）。SSR では window が無いので false。
+const isPreviewHost = () =>
+  typeof window !== "undefined" && window.location.hostname.endsWith(".pages.dev");
+
 // ページビューを送信
 // Issue #84 hotfix (2026-04-25): gtag.js 未ロード時のガードを追加。
 // 将来 Script strategy を lazyOnload 等に変更しても、hydration 直後の
@@ -28,6 +33,7 @@ declare global {
 // クラッシュさせないようにする。
 export const pageview = (url: string) => {
   if (!GA_ID) return;
+  if (isPreviewHost()) return;
   if (typeof window === "undefined" || typeof window.gtag !== "function") return;
   window.gtag("config", GA_ID, {
     page_path: url,
@@ -49,6 +55,7 @@ export const event = ({
   // NODE_ENV: 本番環境でのみイベントを送信
   // 開発環境ではGoogle Analyticsイベントを無効化
   if (!GA_ID || process.env.NODE_ENV !== "production") return;
+  if (isPreviewHost()) return; // pages.dev プレビューからのイベント混入を除外
 
   const eventParams: GtagConfig = {
     event_category: category,


### PR DESCRIPTION
計測系ブランチをリリース統合（develop 集約）。CI check-runs=success 確認済。🤖 Generated with [Claude Code](https://claude.com/claude-code)