### PR TITLE
fix(author): サイト著者カードの X リンクを @doboku373 へ更新

### DIFF
--- a/src/components/ui/AuthorSidebarCard/AuthorSidebarCard.tsx
+++ b/src/components/ui/AuthorSidebarCard/AuthorSidebarCard.tsx
@@ -88,7 +88,7 @@ export default function AuthorSidebarCard() {
             rel="noopener noreferrer"
             className="hover:text-[var(--accent)] hover:underline"
           >
-            X @dobokunotecom
+            X @doboku373
           </a>
           <Link href="/about" className="hover:text-[var(--accent)] hover:underline">
             運営者について →

--- a/src/config/author.ts
+++ b/src/config/author.ts
@@ -41,7 +41,7 @@ export const AUTHOR = {
     "建設法務",
   ],
   imageUrl: "/img/author-avatar.png",
-  twitterUrl: "https://x.com/dobokunotecom",
+  twitterUrl: "https://x.com/doboku373",
   // プロフィールカード用の一文（経歴・姿勢の本質のみ）。資格の列挙は qualifications に集約し
   // 肩書き/bio と重複させない。サイドバー・記事末尾の各プロフィールカードで使用。
   tagline:


### PR DESCRIPTION
凍結済み @dobokunotecom を指したままだった著者カードの X リンク（author.ts twitterUrl ＋ AuthorSidebarCard 表示ハンドル）を、運用再開した @doboku373 へ是正。本番ライブの user-facing ドリフト修正。次回 develop→main 昇格（別PC公開時）でライブ反映。🤖 Generated with [Claude Code](https://claude.com/claude-code)