### PR TITLE
fix(metrics): fetch-metrics Publish を dirty tree に耐性化（週次publish失敗の修正）

### DIFF
--- a/.github/workflows/fetch-metrics.yml
+++ b/.github/workflows/fetch-metrics.yml
@@ -179,8 +179,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git fetch origin develop
-          git checkout develop
-          git pull --rebase origin develop
+          # 実行中の in-place 書き込み（crosswalk-latest.md・weekly-metrics/index.json 等の追跡ファイル）で
+          # 作業ツリーが dirty になり `git pull --rebase` が "cannot pull with rebase" で失敗するのを防ぐ。
+          # 成果物は直前の "Stage outputs" で /tmp に退避済みなので、origin/develop 先頭へ hard reset して
+          # クリーンにしてから /tmp を復元する（-f で dirty tree でも develop へ切替）。
+          git checkout -f develop
+          git reset --hard origin/develop
 
           mkdir -p .claude/state/metrics/ga4 .claude/state/metrics/gsc .claude/state/metrics/monetization .claude/state/metrics/crosswalk .claude/state/weekly-metrics
           cp -r /tmp/metrics-publish/ga4/* .claude/state/metrics/ga4/ 2>/dev/null || true


### PR DESCRIPTION
## 背景
PR #359 マージ後、develop 上で fetch-metrics を手動実行して検証したところ、SNS計測ステップ（Fetch GA4 SNS source×medium・Snapshot weekly NSM + SNS metrics）は全て success だったが、最後の **Publish to develop** ステップが失敗した。

```
M .claude/state/weekly-metrics/index.json
error: cannot pull with rebase: You have unstaged changes.
```

## 原因
復旧した `snapshot-weekly-metrics.mjs` が実行中に**追跡ファイル `weekly-metrics/index.json` を in-place で書き換える**ため、Publish の `git pull --rebase origin develop` が dirty tree で失敗する。develop 手動実行で顕在化したが、**main へデプロイ後の週次スケジュール実行でも毎回 publish が落ちる**回帰。

## 修正
成果物は直前の "Stage outputs" で `/tmp` に退避済みなので、`git checkout develop; git pull --rebase` を `git checkout -f develop; git reset --hard origin/develop` へ変更し、作業ツリーを確実にクリーンにしてから /tmp を復元する。dispatch（develop起動）・schedule（main起動）双方で成立。

verify-yt-status.yml は `git add`→commit を pull の前に行うため同種の問題はなし（本修正は fetch-metrics.yml のみ）。

## 検証
- YAML valid・pre-commitゲート緑
- マージ後に develop で再度 workflow_dispatch し、Publish 成功＋`ga4-sourceMedium-sns-*.json`/週次スナップショットのコミットを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)