### PR TITLE
トップのカードUI刷新: 資格カード(3列/フロストパネル)＋最新記事(A8型サムネ)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import MagazineSidebarCard from "@/components/ui/MagazineSidebarCard";
 import { Hero, ExamCards, LatestArticles, AboutSection } from "@/components/home";
 import type { LatestArticle } from "@/components/home";
 import { getDocsMetaByCategory, getAllDocsMeta, type DocMeta } from "@/lib/docs";
+import { resolveCardImage } from "@/lib/card-image";
 import categoriesData from "@/config/categories.json";
 import homeExamCardsData from "@/config/home-exam-cards.json";
 import { CategoryDef } from "@/lib/categories";
@@ -120,6 +121,7 @@ function pickRecent(allMeta: DocMeta[], n: number): LatestArticle[] {
       tags: (meta.tags || []).filter(
         (t) => !["primary", "secondary", "past-questions", "guide", "textbook", "keyword"].includes(t),
       ),
+      image: resolveCardImage(meta.category, meta.slug),
     }));
 }
 

--- a/src/components/home/ExamCards.tsx
+++ b/src/components/home/ExamCards.tsx
@@ -62,15 +62,17 @@ function ExamCard({ e }: { e: ExamData }) {
       ) : (
         <div className="absolute inset-0 bg-[var(--accent-fill)]" />
       )}
-      {/* 可読性スクリム（下部を暗くしてタイトルを白で乗せる。画像・テーマ非依存で両モード同一） */}
-      <div aria-hidden="true" className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
       {/* 試験別テーマ色ライン（上端） */}
-      <span aria-hidden="true" className={`absolute inset-x-0 top-0 h-1 ${t.bar}`} />
-      {/* テキスト（左下・白） */}
-      <div className="absolute inset-x-0 bottom-0 p-5 sm:p-6 text-white">
-        <div className="font-mono text-[10px] tracking-widest uppercase text-white/75 mb-1.5">{e.nextExam}</div>
-        <h3 className="font-serif font-black text-xl sm:text-2xl leading-tight">{e.label}</h3>
-        <div className="text-[13px] leading-snug text-white/85 mt-1">{e.subtitle}</div>
+      <span aria-hidden="true" className={`absolute inset-x-0 top-0 z-10 h-1 ${t.bar}`} />
+      {/* 下部テキスト帯：黒の半透明フロストパネル（backdrop-blur）。画像は上部をそのまま見せ、
+          テキスト範囲にだけ半透明ダークを敷く。上端はソフトなグラデで硬い境界を和らげておしゃれに。 */}
+      <div className="absolute inset-x-0 bottom-0">
+        <div aria-hidden="true" className="h-6 bg-gradient-to-t from-black/35 to-transparent" />
+        <div className="border-t border-white/10 bg-black/45 px-4 py-3 text-white backdrop-blur-md">
+          <div className="font-mono text-[10px] uppercase tracking-widest text-white/80">{e.nextExam}</div>
+          <h3 className="mt-0.5 font-serif text-lg font-black leading-tight sm:text-xl">{e.label}</h3>
+          <div className="mt-1 line-clamp-1 text-[12px] leading-snug text-white/85">{e.subtitle}</div>
+        </div>
       </div>
     </Link>
   );
@@ -82,7 +84,7 @@ export default function ExamCards({ exams }: ExamCardsProps) {
       <div className="mb-6 sm:mb-8">
         <h2 className="font-serif text-2xl sm:text-3xl font-black text-[var(--ink)]">対応する資格・試験</h2>
       </div>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
         {exams.map((e) => (
           <ExamCard key={e.slug} e={e} />
         ))}

--- a/src/components/home/LatestArticles.tsx
+++ b/src/components/home/LatestArticles.tsx
@@ -8,6 +8,7 @@ export interface LatestArticle {
   categoryLabel?: string | undefined;
   date?: string | undefined;
   tags?: string[] | undefined;
+  image?: string | undefined;
 }
 
 interface LatestArticlesProps {
@@ -38,32 +39,50 @@ export default function LatestArticles({ articles }: LatestArticlesProps) {
             <Link
               key={a.slug}
               href={`/docs/${a.slug}`}
-              className="group block bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section p-5 sm:p-6 hover:border-[var(--accent)] hover:shadow-soft transition-all"
+              className="group flex flex-col overflow-hidden bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section hover:border-[var(--accent)] hover:shadow-soft transition-all"
             >
-              <div className="flex items-center gap-2 mb-2 flex-wrap">
-                {a.categoryLabel && (
-                  <span className="font-mono text-[10px] tracking-widest uppercase text-[var(--accent)] px-2 py-0.5 bg-[var(--accent-fill)] rounded-sm">
-                    {a.categoryLabel}
-                  </span>
+              {/* サムネ（16:9・資格別プール写真。文字は焼き込まず下の HTML で見出しを出す＝A8/Yahoo 型）。
+                  プール原版が 16:9 なので object-cover でも被写体を切らない。 */}
+              <div className="relative aspect-[16/9] overflow-hidden bg-[var(--accent-fill)]">
+                {a.image && (
+                  <img
+                    src={a.image}
+                    alt=""
+                    aria-hidden="true"
+                    width={1024}
+                    height={576}
+                    loading="lazy"
+                    decoding="async"
+                    className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
+                  />
                 )}
-                {date && <span className="font-mono text-[10px] text-[var(--ink-muted)] tabular-nums">{date}</span>}
               </div>
-              <h3 className="font-serif font-bold text-base sm:text-lg text-[var(--ink)] leading-snug group-hover:text-[var(--accent)] transition-colors">
-                {a.title}
-              </h3>
-              {a.tags && a.tags.length > 0 && (
-                <div className="flex gap-3 mt-3 flex-wrap">
-                  {a.tags.slice(0, 4).map((t) => (
-                    <span key={t} className="font-mono text-[10px] text-[var(--ink-muted)] flex items-center gap-1">
-                      <Hash className="w-2.5 h-2.5" />
-                      {t}
+              <div className="p-5 sm:p-6">
+                <div className="flex items-center gap-2 mb-2 flex-wrap">
+                  {a.categoryLabel && (
+                    <span className="font-mono text-[10px] tracking-widest uppercase text-[var(--accent)] px-2 py-0.5 bg-[var(--accent-fill)] rounded-sm">
+                      {a.categoryLabel}
                     </span>
-                  ))}
+                  )}
+                  {date && <span className="font-mono text-[10px] text-[var(--ink-muted)] tabular-nums">{date}</span>}
                 </div>
-              )}
-              <div className="mt-3 inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-[var(--ink-muted)] group-hover:text-[var(--accent)] transition-colors">
-                <span>Read</span>
-                <ArrowRight className="w-3 h-3" />
+                <h3 className="font-serif font-bold text-base sm:text-lg text-[var(--ink)] leading-snug group-hover:text-[var(--accent)] transition-colors">
+                  {a.title}
+                </h3>
+                {a.tags && a.tags.length > 0 && (
+                  <div className="flex gap-3 mt-3 flex-wrap">
+                    {a.tags.slice(0, 4).map((t) => (
+                      <span key={t} className="font-mono text-[10px] text-[var(--ink-muted)] flex items-center gap-1">
+                        <Hash className="w-2.5 h-2.5" />
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <div className="mt-3 inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-[var(--ink-muted)] group-hover:text-[var(--accent)] transition-colors">
+                  <span>Read</span>
+                  <ArrowRight className="w-3 h-3" />
+                </div>
               </div>
             </Link>
           );

--- a/src/lib/card-image.ts
+++ b/src/lib/card-image.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+
+// 記事一覧カード（A8/Yahoo 型サムネ）の画像を解決する。
+// 方針: 記事ごとに画像を生成せず、資格別の「文字なし写真プール」から slug 決定的に 1 枚を選ぶ。
+// 見出しは HTML で重ねる前提なので、文字が焼き込まれた OGP は使わない（真実源: brand-image-system.md）。
+// フォールバック連鎖: guide-covers/{category}/{n}.webp -> card-{category}.webp -> undefined（呼び出し側で無地地）。
+
+const PUBLIC_DIR = path.join(process.cwd(), 'public');
+
+// ビルド時 fs アクセスをカテゴリ単位でキャッシュ（SSG の 1 プロセス内で使い回す）。
+const poolCache = new Map<string, string[]>();
+const cardCache = new Map<string, boolean>();
+
+// guide-covers/{category}/ 内の webp をソートして返す（例: ["1.webp", ..., "5.webp"]）。
+function listPool(category: string): string[] {
+  const cached = poolCache.get(category);
+  if (cached) return cached;
+  const dir = path.join(PUBLIC_DIR, 'images', 'guide-covers', category);
+  let files: string[];
+  try {
+    files = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.webp'))
+      .sort();
+  } catch {
+    files = [];
+  }
+  poolCache.set(category, files);
+  return files;
+}
+
+function hasCardImage(category: string): boolean {
+  const cached = cardCache.get(category);
+  if (cached !== undefined) return cached;
+  const exists = fs.existsSync(path.join(PUBLIC_DIR, 'images', `card-${category}.webp`));
+  cardCache.set(category, exists);
+  return exists;
+}
+
+// FNV-1a 32bit。slug から決定的にプール index を得る（ビルド間で安定させるため Math.random は使わない）。
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+export function resolveCardImage(
+  category?: string | null,
+  slug?: string | null,
+): string | undefined {
+  if (!category) return undefined;
+  const pool = listPool(category);
+  if (pool.length > 0) {
+    const key = slug || category;
+    const idx = fnv1a(key) % pool.length;
+    return `/images/guide-covers/${category}/${pool[idx]}`;
+  }
+  if (hasCardImage(category)) return `/images/card-${category}.webp`;
+  return undefined;
+}


### PR DESCRIPTION
トップ (`/`) のカード群を2点刷新する。

## 1. 資格カード（ExamCards）
- 画像全面の黒スクリム（`from-black/85` グラデ）を撤去 → 資格別アクセント写真を活かす
- 下部テキストを **黒半透明フロストパネル**化（`bg-black/45` + `backdrop-blur-md`、上端ソフトグラデ＋`border-white/10`）
- PC **2列 → 3列**（visible 6枚＝3×2 の整形。レスポンシブ 1→2→3）
- 狭幅化に合わせ資格名を `text-lg/xl`、サブタイトルを `line-clamp-1` で帯高さ統一

## 2. 最新の記事（LatestArticles）※A8/Yahoo 参考
- テキストのみのカードに **16:9 サムネ**を追加（上サムネ＋下テキストの A8 型）
- **記事ごとの画像生成はしない**。資格別の文字なし写真プール（`guide-covers/{category}/N.webp`・全7資格×5枚・Imagen 生成済み）から **slug 決定的**に1枚選択 → 同カテゴリでも記事ごとに絵柄が変わる
- 見出しは HTML で重ねる（OGP＝見出し焼き込み済みは不使用・二重化回避）。`brand-image-system.md` の「文字は非焼き込み」「マスターから crop」「16:9=ホームカード」原則に準拠
- フォールバック連鎖: `guide-covers` プール → `card-{category}.webp` → 無地アクセント地
- `src/lib/card-image.ts` 新設（ビルド時 fs・カテゴリ単位キャッシュ・FNV-1a で決定的 index）

## なぜこの設計か
- 対象 1,096 記事に per-article 生成は非現実的。ブランド画像システムの設計思想「量産せずマスターから crop で統一感」に一致。Codex の出番は将来のプール拡張のみ（要ユーザー確認・課金）。

## 検証
- dev `http://localhost:3020/` HTTP 200・`<main>`・サムネ配信 200 確認
- `eslint` 0 / `lint-ui.mjs` 0 / `tsc --noEmit` 0
- pre-commit フック全通過（`check-home-exam-coverage` 含む）

対象: `src/components/home/ExamCards.tsx` / `LatestArticles.tsx` / `src/app/page.tsx` / `src/lib/card-image.ts`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)