### PR TITLE
カテゴリページ: 試験ガイド・テキストを体系リスト化（全カテゴリ・カード→目次調）

### DIFF
--- a/.local/r2/posts/civil-construction-1/guide-exam-overview/article.mdx
+++ b/.local/r2/posts/civil-construction-1/guide-exam-overview/article.mdx
@@ -8,7 +8,6 @@ category: civil-construction-1
 group: guide
 tags:
   - guide
-  - career
 published: true
 publishedAt: '2026-06-01'
 seoTitle: 1級土木施工管理技士の試験概要｜受験資格・科目・合格率・日程【2026】

--- a/.local/r2/posts/civil-construction-2/guide-exam-overview/article.mdx
+++ b/.local/r2/posts/civil-construction-2/guide-exam-overview/article.mdx
@@ -8,7 +8,6 @@ category: civil-construction-2
 group: guide
 tags:
   - guide
-  - career
 published: true
 publishedAt: '2026-06-01'
 seoTitle: 2級土木施工管理技士の試験概要｜受験資格・科目・合格率・日程【2026】

--- a/docs/design-system/design-system.md
+++ b/docs/design-system/design-system.md
@@ -120,6 +120,7 @@
 | `SectionBlock`（`layout/SectionBlock.tsx`） | セクション間余白・band 背景を統一 | — |
 | `SectionCard`（`ui/SectionCard/`） | カード（radius/border/shadow を token に統一・カード内カード回避） | — |
 | `ArticleHeader`（`ui/ArticleHeader/`） | docs 記事冒頭（breadcrumb + h1 + description リード + byline/meta） | — |
+| `CurriculumSections`（`category/CurriculumSections.tsx`） | カテゴリページの体系表示。試験ガイド・テキストを**カードでなく目次調リスト**で見せ、章立て・出題分野の体系を一目で伝える（`CurriculumSection` 枠 / `CurriculumList` 目次リスト / `CareerSection` 注目カード＋リスト）。編成は `src/config/category-curriculum.json`（SSOT）、解決は `src/lib/category-curriculum.ts`（resolver・silent drop 防止の `unassigned` 付き）、健全性は `check-category-curriculum`（pre-commit）。過去問テーブル群（`CategorySections.tsx`）とは併存 | `CurriculumList`: `blocks`/`numbered`。`CareerSection`: `featured`/`rest` |
 
 `not-found` は Header/Footer を持たない設計のため PageShell を使わない（意図的な例外）。
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "check-ogp-title-fit": "node scripts/check-ogp-title-fit.mjs",
     "check-note-cover-fit": "node scripts/check-note-cover-fit.mjs",
     "check-home-exam-coverage": "node scripts/check-home-exam-coverage.mjs",
+    "check-category-curriculum": "node scripts/check-category-curriculum.mjs",
     "check-affiliate-mats": "node scripts/check-affiliate-mats.mjs",
     "check-affiliate-prose": "node scripts/check-affiliate-prose.mjs",
     "fetch-gsc-data": "node .claude/skills/analytics/fetch-gsc-data/scripts/fetch-gsc-data.mjs",

--- a/scripts/check-category-curriculum.mjs
+++ b/scripts/check-category-curriculum.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// category-curriculum.json の健全性チェック（pre-commit / CI）。
+// - HARD FAIL: config の slug が doc-meta-index に実在しない（タイプミス・記事削除の取り残し）
+// - HARD FAIL: careerFeatured に career タグでない記事を指定
+// - WARN: config 未割当の非キャリア guide 記事（resolver が unassigned で拾うが、編成漏れの気づき用）
+// - WARN: textbookChapters のレンジ外にある textbook 記事（resolver は「その他」章へ回す）
+// 真実源: src/lib/category-curriculum.ts（resolver）/ docs/design-system/design-system.md §3。
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const curriculum = JSON.parse(fs.readFileSync(path.join(ROOT, 'src/config/category-curriculum.json'), 'utf8'));
+const index = JSON.parse(fs.readFileSync(path.join(ROOT, 'src/config/doc-meta-index.json'), 'utf8'));
+const docs = index.docs; // { fullSlug: { category, group, tags, textbook_order, ... } }
+
+const errors = [];
+const warnings = [];
+
+// カテゴリ別の guide / textbook 記事を index から収集。
+// classifyDoc（src/lib/doc-classifier.ts）と同じく group フィールドを優先し、
+// group が無い場合のみ tags でフォールバックする（例: pe-construction の group:keyword を guide と誤認しない）。
+function docsOf(category, kind) {
+  const out = [];
+  for (const [slug, m] of Object.entries(docs)) {
+    if (m.category !== category) continue;
+    const isGuide = m.group === 'guide' || (!m.group && (m.tags || []).includes('guide'));
+    const isTextbook = m.group === 'textbook' || (!m.group && (m.tags || []).includes('textbook'));
+    if (kind === 'guide' && isGuide) out.push({ slug, ...m });
+    if (kind === 'textbook' && isTextbook) out.push({ slug, ...m });
+  }
+  return out;
+}
+
+for (const [category, cfg] of Object.entries(curriculum)) {
+  if (category.startsWith('$')) continue;
+
+  const guideDocs = docsOf(category, 'guide');
+  const guideBySlug = new Map(guideDocs.map((d) => [d.slug, d]));
+  const assigned = new Set();
+
+  // examGuide + fields のブロック slug を検証
+  const blockSpecs = [];
+  if (cfg.examGuide) blockSpecs.push({ where: `${category}.examGuide`, slugs: cfg.examGuide.slugs, kind: 'guide' });
+  for (const b of cfg.fields?.blocks ?? []) blockSpecs.push({ where: `${category}.fields.${b.id}`, slugs: b.slugs, kind: 'guide' });
+
+  for (const spec of blockSpecs) {
+    for (const suffix of spec.slugs) {
+      const full = `${category}-${suffix}`;
+      const d = guideBySlug.get(full);
+      if (!d) {
+        errors.push(`[${spec.where}] slug 不在: "${suffix}"（${full} が doc-meta-index の guide に無い）`);
+        continue;
+      }
+      if ((d.tags || []).includes('career')) {
+        errors.push(`[${spec.where}] "${suffix}" は career タグ付き。分野/受験ガイドに置けない（career タグを外すか careerFeatured へ）`);
+      }
+      assigned.add(full);
+    }
+  }
+
+  // careerFeatured の検証
+  for (const suffix of cfg.careerFeatured ?? []) {
+    const full = `${category}-${suffix}`;
+    const d = guideBySlug.get(full);
+    if (!d) {
+      errors.push(`[${category}.careerFeatured] slug 不在: "${suffix}"（${full} が無い）`);
+      continue;
+    }
+    if (!(d.tags || []).includes('career')) {
+      errors.push(`[${category}.careerFeatured] "${suffix}" は career タグが無い（注目キャリアに置けない）`);
+    }
+  }
+
+  // 未割当の非キャリア guide（WARN）
+  const unassigned = guideDocs.filter(
+    (d) => !assigned.has(d.slug) && !(d.tags || []).includes('career'),
+  );
+  if (unassigned.length > 0) {
+    warnings.push(`[${category}] config 未割当の guide ${unassigned.length} 本（unassigned で表示される）: ${unassigned.map((d) => d.slug.replace(`${category}-`, '')).join(', ')}`);
+  }
+
+  // textbookChapters レンジ外（WARN）
+  if (cfg.textbookChapters) {
+    const tb = docsOf(category, 'textbook');
+    const outside = tb.filter((d) => {
+      const o = d.textbook_order;
+      if (typeof o !== 'number') return true;
+      return !cfg.textbookChapters.some((r) => o >= r.min && o <= r.max);
+    });
+    if (outside.length > 0) {
+      warnings.push(`[${category}] textbookChapters レンジ外 ${outside.length} 本（「その他」章へ）: ${outside.map((d) => `${d.slug.replace(`${category}-`, '')}(${d.textbook_order})`).join(', ')}`);
+    }
+  }
+}
+
+for (const w of warnings) console.log(`[check-category-curriculum] WARN ${w}`);
+if (errors.length > 0) {
+  for (const e of errors) console.error(`[check-category-curriculum] ERROR ${e}`);
+  console.error(`\n[check-category-curriculum] ✗ ${errors.length} 件のエラー`);
+  process.exit(1);
+}
+console.log(`[check-category-curriculum] ✓ config の slug は全て実在（WARN ${warnings.length} 件）`);

--- a/scripts/install-pre-commit.mjs
+++ b/scripts/install-pre-commit.mjs
@@ -98,6 +98,12 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# category-curriculum.json の slug 実在＋career タグ整合（カテゴリページ体系リストの slug 陳腐化・silent drop の再発防止）
+node scripts/check-category-curriculum.mjs
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 # アフィリエイト A8 mat が SSOT 許可リスト(affiliate-mats.json)に存在するか検証（mat タイポ/未登録/失効の取りこぼし防止）
 node scripts/check-affiliate-mats.mjs --staged
 if [ $? -ne 0 ]; then

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { getPopularDocs } from '@/lib/popular';
 import {
   CivilConstruction1View,
   CivilConstruction2View,
+  ConcreteView,
   PeFirstStageView,
   PeComprehensiveView,
   PeConstructionView,
@@ -161,6 +162,8 @@ export default async function CategoryPage({
                 <PeComprehensiveView groups={groups} mobileCareerAds={mobileCareerAds} />
               ) : slug === 'pe-construction' ? (
                 <PeConstructionView groups={groups} />
+              ) : slug === 'concrete-chief-engineer' || slug === 'concrete-diagnostician' ? (
+                <ConcreteView groups={groups} />
               ) : (
                 groups.map(group => (
                   <DocSection key={group.title} group={group} />

--- a/src/components/category/CategoryViews.tsx
+++ b/src/components/category/CategoryViews.tsx
@@ -2,73 +2,46 @@ import { type ReactNode } from 'react';
 import Link from 'next/link';
 import { getGroupLabel } from '@/lib/doc-classifier';
 import { type DocGroup } from '@/lib/category-groups';
-import { DocCard, DocSection } from '@/components/category/CategorySections';
+import { DocSection } from '@/components/category/CategorySections';
+import { resolveCurriculum, resolveTextbookChapters } from '@/lib/category-curriculum';
+import { CurriculumSection, CurriculumList, CareerSection } from '@/components/category/CurriculumSections';
 
-/** civil-construction-1: primary をテーブル、secondary の年度別を統合 */
+/** civil-construction-1: 受験ガイド＋分野別＋テキスト章目次をリスト化、過去問はテーブル維持 */
 export function CivilConstruction1View({ groups, mobileCareerAds = [] }: { groups: DocGroup[]; mobileCareerAds?: ReactNode[] }) {
-  const guideGroup = groups.find(g => g.title === getGroupLabel('civil-construction-1', 'guide'));
-  const textbookGroup = groups.find(g => g.title === getGroupLabel('civil-construction-1', 'textbook'));
-  const primaryGroup = groups.find(g => g.title === getGroupLabel('civil-construction-1', 'primary'));
-  const secondaryGroup = groups.find(g => g.title === getGroupLabel('civil-construction-1', 'secondary'));
+  const category = 'civil-construction-1';
+  const guideGroup = groups.find(g => g.key === 'guide');
+  const textbookGroup = groups.find(g => g.key === 'textbook');
+  const primaryGroup = groups.find(g => g.key === 'primary');
+  const secondaryGroup = groups.find(g => g.key === 'secondary');
+
+  const curriculum = resolveCurriculum(category, guideGroup?.docs ?? []);
+  const chapters = resolveTextbookChapters(category, textbookGroup?.docs ?? []);
+  // 受験ガイド節に未割当（config 追記漏れ・新規記事）を必ず合流させ silent drop を防ぐ
+  const examGuideDocs = [...(curriculum.examGuide?.docs ?? []), ...curriculum.unassigned];
+  const fieldsCount = curriculum.fields?.blocks.reduce((n, b) => n + b.docs.length, 0) ?? 0;
+  const textbookCount = chapters.reduce((n, c) => n + c.docs.length, 0);
 
   // secondary を年度別過去問と分野別に分離
-  const secondaryYearDocs = secondaryGroup?.docs.filter(d =>
-    /secondary-(r|h)\d+$/.test(d.slug || '')
-  ) || [];
-  const secondaryTopicDocs = secondaryGroup?.docs.filter(d =>
-    !/secondary-(r|h)\d+$/.test(d.slug || '')
-  ) || [];
-
-  // 試験ガイドからキャリア・転職系を分離（ソート順は維持）
-  const examGuideDocs = guideGroup?.docs.filter(d => !d.tags?.includes('career')) || [];
-  const careerDocs = guideGroup?.docs.filter(d => d.tags?.includes('career')) || [];
-
-  // テキストブックをエリア別にグループ化
-  const TEXTBOOK_AREAS = [
-    { label: '建設機械', min: 100, max: 149 },
-    { label: '測量', min: 150, max: 169 },
-    { label: '解体工事', min: 170, max: 179 },
-    { label: '施工管理・施工計画', min: 200, max: 230 },
-    { label: '工程管理', min: 250, max: 269 },
-    { label: '品質管理', min: 300, max: 320 },
-    { label: '関係法規', min: 400, max: 449 },
-  ];
-  const textbookAreas = textbookGroup ? TEXTBOOK_AREAS.map(area => ({
-    ...area,
-    docs: textbookGroup.docs.filter(d => {
-      const order = d.textbook_order ?? 999;
-      return order >= area.min && order <= area.max;
-    }),
-  })).filter(a => a.docs.length > 0) : [];
+  const secondaryYearDocs = secondaryGroup?.docs.filter(d => /secondary-(r|h)\d+$/.test(d.slug || '')) || [];
+  const secondaryTopicDocs = secondaryGroup?.docs.filter(d => !/secondary-(r|h)\d+$/.test(d.slug || '')) || [];
 
   return (
     <>
-      {guideGroup && examGuideDocs.length > 0 && (
-        <DocSection group={{ ...guideGroup, docs: examGuideDocs }} />
+      {examGuideDocs.length > 0 && (
+        <CurriculumSection id="guide" title={curriculum.examGuide?.title ?? '受験ガイド'} description={curriculum.examGuide?.description} count={examGuideDocs.length}>
+          <CurriculumList blocks={[{ docs: examGuideDocs }]} />
+        </CurriculumSection>
+      )}
+      {curriculum.fields && (
+        <CurriculumSection id="fields" title={curriculum.fields.title} description={curriculum.fields.description} count={fieldsCount}>
+          <CurriculumList blocks={curriculum.fields.blocks} />
+        </CurriculumSection>
       )}
       {mobileCareerAds[0]}
-      {textbookGroup && (
-        <section id={`sec-${textbookGroup.key}`} className="scroll-mt-24">
-          <div className="mb-6">
-            <div className="flex items-baseline justify-between gap-2 flex-wrap">
-              <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">{textbookGroup.title}</h2>
-              <span className="font-mono text-[11px] text-[var(--ink-muted)]">{textbookGroup.docs.length} docs</span>
-            </div>
-            <p className="text-[14px] text-[var(--ink-muted)] mt-1">{textbookGroup.description}</p>
-          </div>
-          <div className="space-y-8">
-            {textbookAreas.map(area => (
-              <div key={area.label}>
-                <h3 className="font-serif text-lg font-bold text-[var(--ink)] mb-3 border-b border-[var(--rule-soft)] pb-2">{area.label}</h3>
-                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                  {area.docs.map(doc => (
-                    <DocCard key={doc.slug} doc={doc} />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
+      {chapters.length > 0 && (
+        <CurriculumSection id="textbook" title="テキスト" description="分冊・章立てに沿った本文テキスト（本試験の出題順）" count={textbookCount}>
+          <CurriculumList blocks={chapters} numbered />
+        </CurriculumSection>
       )}
       {mobileCareerAds[1]}
       {primaryGroup && (
@@ -93,45 +66,50 @@ export function CivilConstruction1View({ groups, mobileCareerAds = [] }: { group
           }}
         />
       )}
-      {careerDocs.length > 0 && (
-        <DocSection
-          group={{
-            key: 'career',
-            title: 'キャリア・転職',
-            description: '年収・転職・キャリアパス・働き方の実務ガイド',
-            docs: careerDocs,
-          }}
-        />
-      )}
+      <CareerSection
+        featured={curriculum.career.featured}
+        rest={curriculum.career.rest}
+        description="年収・転職・キャリアパス・働き方の実務ガイド"
+      />
     </>
   );
 }
 
-/** civil-construction-2: 2級向け、前期/後期テーブル */
+/** civil-construction-2: 受験ガイド＋分野別をリスト化、過去問は前期/後期テーブル維持（textbook 記事は無し） */
 export function CivilConstruction2View({ groups, mobileCareerAds = [] }: { groups: DocGroup[]; mobileCareerAds?: ReactNode[] }) {
-  const guideGroup = groups.find(g => g.title === getGroupLabel('civil-construction-2', 'guide'));
-  const textbookGroup = groups.find(g => g.title === getGroupLabel('civil-construction-2', 'textbook'));
-  const primaryGroup = groups.find(g => g.title === getGroupLabel('civil-construction-2', 'primary'));
-  const secondaryGroup = groups.find(g => g.title === getGroupLabel('civil-construction-2', 'secondary'));
+  const category = 'civil-construction-2';
+  const guideGroup = groups.find(g => g.key === 'guide');
+  const textbookGroup = groups.find(g => g.key === 'textbook');
+  const primaryGroup = groups.find(g => g.key === 'primary');
+  const secondaryGroup = groups.find(g => g.key === 'secondary');
 
-  const secondaryYearDocs = secondaryGroup?.docs.filter(d =>
-    /secondary-(r|h)\d+$/.test(d.slug || '')
-  ) || [];
-  const secondaryTopicDocs = secondaryGroup?.docs.filter(d =>
-    !/secondary-(r|h)\d+$/.test(d.slug || '')
-  ) || [];
+  const curriculum = resolveCurriculum(category, guideGroup?.docs ?? []);
+  const chapters = resolveTextbookChapters(category, textbookGroup?.docs ?? []);
+  const examGuideDocs = [...(curriculum.examGuide?.docs ?? []), ...curriculum.unassigned];
+  const fieldsCount = curriculum.fields?.blocks.reduce((n, b) => n + b.docs.length, 0) ?? 0;
+  const textbookCount = chapters.reduce((n, c) => n + c.docs.length, 0);
 
-  // 試験ガイドからキャリア・転職系を分離（ソート順は維持）
-  const examGuideDocs = guideGroup?.docs.filter(d => !d.tags?.includes('career')) || [];
-  const careerDocs = guideGroup?.docs.filter(d => d.tags?.includes('career')) || [];
+  const secondaryYearDocs = secondaryGroup?.docs.filter(d => /secondary-(r|h)\d+$/.test(d.slug || '')) || [];
+  const secondaryTopicDocs = secondaryGroup?.docs.filter(d => !/secondary-(r|h)\d+$/.test(d.slug || '')) || [];
 
   return (
     <>
-      {guideGroup && examGuideDocs.length > 0 && (
-        <DocSection group={{ ...guideGroup, docs: examGuideDocs }} />
+      {examGuideDocs.length > 0 && (
+        <CurriculumSection id="guide" title={curriculum.examGuide?.title ?? '受験ガイド'} description={curriculum.examGuide?.description} count={examGuideDocs.length}>
+          <CurriculumList blocks={[{ docs: examGuideDocs }]} />
+        </CurriculumSection>
+      )}
+      {curriculum.fields && (
+        <CurriculumSection id="fields" title={curriculum.fields.title} description={curriculum.fields.description} count={fieldsCount}>
+          <CurriculumList blocks={curriculum.fields.blocks} />
+        </CurriculumSection>
       )}
       {mobileCareerAds[0]}
-      {textbookGroup && <DocSection group={textbookGroup} />}
+      {chapters.length > 0 && (
+        <CurriculumSection id="textbook" title="テキスト" description="章立てに沿った本文テキスト" count={textbookCount}>
+          <CurriculumList blocks={chapters} numbered />
+        </CurriculumSection>
+      )}
       {mobileCareerAds[1]}
       {primaryGroup && (
         <DocSection
@@ -155,15 +133,44 @@ export function CivilConstruction2View({ groups, mobileCareerAds = [] }: { group
           }}
         />
       )}
-      {careerDocs.length > 0 && (
-        <DocSection
-          group={{
-            key: 'career',
-            title: 'キャリア・転職',
-            description: '年収・転職・キャリアパス・働き方の実務ガイド',
-            docs: careerDocs,
-          }}
-        />
+      <CareerSection
+        featured={curriculum.career.featured}
+        rest={curriculum.career.rest}
+        description="年収・転職・キャリアパス・働き方の実務ガイド"
+      />
+    </>
+  );
+}
+
+/** concrete-chief-engineer / concrete-diagnostician: 受験ガイド＋テキスト章目次＋分野別過去問をリスト化（共用） */
+export function ConcreteView({ groups }: { groups: DocGroup[] }) {
+  const guideGroup = groups.find(g => g.key === 'guide');
+  const textbookGroup = groups.find(g => g.key === 'textbook');
+  const primaryGroup = groups.find(g => g.key === 'primary');
+  // 共用 View なので category は実データ（各記事の category は同一）から取る
+  const category = groups.flatMap(g => g.docs)[0]?.category ?? '';
+
+  const curriculum = resolveCurriculum(category, guideGroup?.docs ?? []);
+  const chapters = resolveTextbookChapters(category, textbookGroup?.docs ?? []);
+  const examGuideDocs = [...(curriculum.examGuide?.docs ?? []), ...curriculum.unassigned];
+  const textbookCount = chapters.reduce((n, c) => n + c.docs.length, 0);
+
+  return (
+    <>
+      {examGuideDocs.length > 0 && (
+        <CurriculumSection id="guide" title={curriculum.examGuide?.title ?? '受験ガイド'} description={curriculum.examGuide?.description} count={examGuideDocs.length}>
+          <CurriculumList blocks={[{ docs: examGuideDocs }]} />
+        </CurriculumSection>
+      )}
+      {chapters.length > 0 && (
+        <CurriculumSection id="textbook" title={textbookGroup?.title ?? 'テキスト'} description={textbookGroup?.description} count={textbookCount}>
+          <CurriculumList blocks={chapters} numbered />
+        </CurriculumSection>
+      )}
+      {primaryGroup && primaryGroup.docs.length > 0 && (
+        <CurriculumSection id="primary" title={primaryGroup.title} description={primaryGroup.description} count={primaryGroup.docs.length}>
+          <CurriculumList blocks={[{ docs: primaryGroup.docs }]} numbered />
+        </CurriculumSection>
       )}
     </>
   );
@@ -189,10 +196,24 @@ export function PeComprehensiveView({ groups, mobileCareerAds = [] }: { groups: 
   const keywordGroup = groups.find(g => g.title === getGroupLabel('pe-comprehensive-management', 'keyword'));
   const keywordCount = keywordGroup?.docs.length ?? 0;
 
+  // guide をカード→受験ガイド＋論文対策のリストへ。pillar/pastExam/keyword 導線は現状維持。
+  const curriculum = resolveCurriculum('pe-comprehensive-management', guideGroup?.docs ?? []);
+  const examGuideDocs = [...(curriculum.examGuide?.docs ?? []), ...curriculum.unassigned];
+  const fieldsCount = curriculum.fields?.blocks.reduce((n, b) => n + b.docs.length, 0) ?? 0;
+
   // essay-mlit-* 7 記事は 2026-05-18 撤回済み（旧分離ロジック削除）
   return (
     <>
-      {guideGroup && guideGroup.docs.length > 0 && <DocSection group={guideGroup} />}
+      {examGuideDocs.length > 0 && (
+        <CurriculumSection id="guide" title={curriculum.examGuide?.title ?? '受験ガイド'} description={curriculum.examGuide?.description} count={examGuideDocs.length}>
+          <CurriculumList blocks={[{ docs: examGuideDocs }]} />
+        </CurriculumSection>
+      )}
+      {curriculum.fields && (
+        <CurriculumSection id="fields" title={curriculum.fields.title} description={curriculum.fields.description} count={fieldsCount}>
+          <CurriculumList blocks={curriculum.fields.blocks} />
+        </CurriculumSection>
+      )}
       {mobileCareerAds[0]}
       {pillarGroup && <DocSection group={pillarGroup} />}
       {pastExamGroup && (
@@ -230,18 +251,37 @@ export function PeComprehensiveView({ groups, mobileCareerAds = [] }: { groups: 
   );
 }
 
-/** pe-construction: ガイド・キーワード・科目×年度マトリクス */
+/** pe-construction: 受験ガイド＋論文の書き方をリスト化、キーワード・科目×年度マトリクスは維持 */
 export function PeConstructionView({ groups }: { groups: DocGroup[] }) {
-  const guideGroup = groups.find(g => g.title === getGroupLabel('pe-construction', 'guide'));
-  const keywordGroup = groups.find(g => g.title === getGroupLabel('pe-construction', 'keyword'));
-  const pastExamGroup = groups.find(g => g.title === getGroupLabel('pe-construction', 'pastExam'));
+  const guideGroup = groups.find(g => g.key === 'guide');
+  const keywordGroup = groups.find(g => g.key === 'keyword');
+  const pastExamGroup = groups.find(g => g.key === 'pastExam');
+
+  const curriculum = resolveCurriculum('pe-construction', guideGroup?.docs ?? []);
+  const examGuideDocs = [...(curriculum.examGuide?.docs ?? []), ...curriculum.unassigned];
+  const fieldsCount = curriculum.fields?.blocks.reduce((n, b) => n + b.docs.length, 0) ?? 0;
+
   return (
     <>
-      {guideGroup && <DocSection group={guideGroup} />}
+      {examGuideDocs.length > 0 && (
+        <CurriculumSection id="guide" title={curriculum.examGuide?.title ?? '受験ガイド'} description={curriculum.examGuide?.description} count={examGuideDocs.length}>
+          <CurriculumList blocks={[{ docs: examGuideDocs }]} />
+        </CurriculumSection>
+      )}
+      {curriculum.fields && (
+        <CurriculumSection id="fields" title={curriculum.fields.title} description={curriculum.fields.description} count={fieldsCount}>
+          <CurriculumList blocks={curriculum.fields.blocks} />
+        </CurriculumSection>
+      )}
       {keywordGroup && <DocSection group={keywordGroup} />}
       {pastExamGroup && (
         <DocSection group={pastExamGroup} layout="pe-construction-exam-table" />
       )}
+      <CareerSection
+        featured={curriculum.career.featured}
+        rest={curriculum.career.rest}
+        description="建設部門技術士のキャリア・年収"
+      />
     </>
   );
 }

--- a/src/components/category/CurriculumSections.tsx
+++ b/src/components/category/CurriculumSections.tsx
@@ -1,0 +1,146 @@
+import Link from 'next/link';
+import { type DocMeta } from '@/lib/docs';
+import { DocCard } from '@/components/category/CategorySections';
+
+// カテゴリページの「体系（受験ガイド / 分野別 / テキスト章）」をテキスト目次調のリストで見せる共有コンポーネント群。
+// カード（DocCard）でなくリストにすることで、章立て・出題分野の体系が一目で分かり情報密度を上げる。
+// editorial トークンのみ使用（生 hex なし・rounded/shadow 直書きなし）。真実源: docs/design-system/design-system.md §3。
+
+/** 目次リストの1ブロック（見出し＋所属記事）。volume は冊（テキスト2分冊）をまとめる eyebrow。 */
+export type CurriculumBlockView = {
+  id?: string | undefined;
+  label?: string | undefined;
+  volume?: string | undefined;
+  docs: DocMeta[];
+};
+
+/** セクション枠（h2 ヘッダ＝既存 DocSection と同一様式・`sec-*` アンカー維持）。 */
+export function CurriculumSection({
+  id,
+  title,
+  description,
+  count,
+  children,
+}: {
+  id: string;
+  title: string;
+  description?: string | undefined;
+  count?: number | undefined;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={`sec-${id}`} className="scroll-mt-24">
+      <div className="mb-6">
+        <div className="flex items-baseline justify-between gap-2 flex-wrap">
+          <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">{title}</h2>
+          {typeof count === 'number' && (
+            <span className="font-mono text-[11px] text-[var(--ink-muted)]">{count} docs</span>
+          )}
+        </div>
+        {description && <p className="text-[14px] text-[var(--ink-muted)] mt-1">{description}</p>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function CurriculumRow({ doc, marker }: { doc: DocMeta; marker: React.ReactNode }) {
+  return (
+    <li className="border-b border-[var(--rule-soft)] last:border-b-0">
+      <Link href={`/docs/${doc.slug}`} className="group flex items-baseline gap-3 py-3">
+        <span className="shrink-0 flex items-center justify-center min-w-6" aria-hidden>
+          {marker}
+        </span>
+        <span className="text-[15px] sm:text-base font-medium text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors">
+          {doc.shortTitle || doc.title}
+        </span>
+        {doc.subtitle && (
+          <span className="hidden sm:inline ml-auto max-w-[40%] truncate text-right text-[13px] text-[var(--ink-muted)]">
+            {doc.subtitle}
+          </span>
+        )}
+      </Link>
+    </li>
+  );
+}
+
+/**
+ * ブロック群を目次調リストで描画する。
+ * - numbered: 連番マーカー（テキスト章目次）。ブロックごとに 01 から振り直す。
+ * - 非 numbered: 小さな四角マーカー（分野別）。
+ * - volume が前ブロックと変われば冊 eyebrow を挿入。
+ */
+export function CurriculumList({ blocks, numbered = false }: { blocks: CurriculumBlockView[]; numbered?: boolean }) {
+  const visible = blocks.filter((b) => b.docs.length > 0);
+  return (
+    <div className="space-y-6">
+      {visible.map((block, bi) => {
+          const showVolume = !!block.volume && block.volume !== visible[bi - 1]?.volume;
+          return (
+            <div key={block.id ?? block.label ?? bi}>
+              {showVolume && (
+                <div className="font-mono text-[11px] uppercase tracking-widest text-[var(--ink-muted)] mb-2 mt-1">
+                  {block.volume}
+                </div>
+              )}
+              {block.label && (
+                <h3 className="font-serif text-lg font-bold text-[var(--ink)] mb-1 border-b border-[var(--rule-soft)] pb-2">
+                  {block.label}
+                </h3>
+              )}
+              <ul>
+                {block.docs.map((doc, i) => (
+                  <CurriculumRow
+                    key={doc.slug}
+                    doc={doc}
+                    marker={
+                      numbered ? (
+                        <span className="font-mono text-[11px] tabular-nums text-[var(--ink-muted)]">
+                          {String(i + 1).padStart(2, '0')}
+                        </span>
+                      ) : (
+                        <span className="block h-1.5 w-1.5 rounded-[1px] bg-[var(--accent)] opacity-60" />
+                      )
+                    }
+                  />
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+    </div>
+  );
+}
+
+/**
+ * キャリア・転職セクション。注目記事（数本）を DocCard で強調し、残りを目次リストで密度高く見せる。
+ * featured/rest は resolveCurriculum が career タグから解決済み（画像は使わない）。
+ */
+export function CareerSection({
+  featured,
+  rest,
+  title = 'キャリア・転職',
+  description,
+}: {
+  featured: DocMeta[];
+  rest: DocMeta[];
+  title?: string;
+  description?: string | undefined;
+}) {
+  if (featured.length === 0 && rest.length === 0) return null;
+  return (
+    <CurriculumSection id="career" title={title} description={description} count={featured.length + rest.length}>
+      {featured.length > 0 && (
+        <div className="mb-6">
+          <div className="font-mono text-[10px] uppercase tracking-widest text-[var(--accent)] mb-3">注目</div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {featured.map((doc) => (
+              <DocCard key={doc.slug} doc={doc} />
+            ))}
+          </div>
+        </div>
+      )}
+      {rest.length > 0 && <CurriculumList blocks={[{ docs: rest }]} />}
+    </CurriculumSection>
+  );
+}

--- a/src/config/category-curriculum.json
+++ b/src/config/category-curriculum.json
@@ -1,0 +1,146 @@
+{
+  "$comment": "カテゴリページの体系（受験ガイド / 分野別 / テキスト章 / キャリア注目）の編成 SSOT。slugs はカテゴリ prefix を抜いた suffix。並び順は slugs 記載順（明示編成）。真実源の詳細は docs/design-system/design-system.md §3 と docs/reference の各方針。resolver=src/lib/category-curriculum.ts。未割当 guide は resolver が unassigned で必ず表示に回す（silent drop 禁止）。",
+  "civil-construction-1": {
+    "examGuide": {
+      "title": "受験ガイド",
+      "description": "試験概要・難易度・学習計画・勉強法など、まず全体像をつかむための記事",
+      "slugs": [
+        "guide-exam-overview",
+        "guide-difficulty",
+        "guide-1-vs-2",
+        "guide-vs-pe",
+        "guide-strategy",
+        "guide-study-plan",
+        "guide-study-method",
+        "guide-four-management",
+        "guide-last-minute-2026"
+      ]
+    },
+    "fields": {
+      "title": "分野別対策",
+      "description": "出題分野順（問題A: 土木一般・法規 / 問題B: 共通工学・施工管理法）に要点を整理",
+      "blocks": [
+        {
+          "id": "doboku-ippan",
+          "label": "土木一般（土工・コンクリート・基礎工）",
+          "slugs": ["guide-earthwork-key-points", "guide-concrete-key-points", "guide-concrete-maintenance", "guide-foundation"]
+        },
+        {
+          "id": "kyotsu-kogaku",
+          "label": "共通工学（建設機械・測量・解体）",
+          "slugs": ["guide-machinery", "guide-surveying", "guide-demolition"]
+        },
+        {
+          "id": "seko-kanri",
+          "label": "施工管理法（施工計画・工程・品質・安全・環境）",
+          "slugs": ["guide-construction-plan", "guide-schedule-management", "guide-quality-management", "guide-safety-management", "guide-environment-management"]
+        },
+        {
+          "id": "hoki",
+          "label": "法規",
+          "slugs": ["guide-law-key-points"]
+        }
+      ]
+    },
+    "textbookChapters": [
+      { "volume": "土木一般・共通工学編", "label": "建設機械", "min": 100, "max": 149 },
+      { "volume": "土木一般・共通工学編", "label": "測量", "min": 150, "max": 169 },
+      { "volume": "土木一般・共通工学編", "label": "解体工事", "min": 170, "max": 199 },
+      { "volume": "施工管理・法規編", "label": "施工管理・施工計画", "min": 200, "max": 249 },
+      { "volume": "施工管理・法規編", "label": "工程管理", "min": 250, "max": 299 },
+      { "volume": "施工管理・法規編", "label": "品質管理", "min": 300, "max": 399 },
+      { "volume": "施工管理・法規編", "label": "関係法規", "min": 400, "max": 499 },
+      { "volume": "施工管理・法規編", "label": "安全管理", "min": 500, "max": 599 },
+      { "volume": "施工管理・法規編", "label": "環境保全・建設副産物", "min": 600, "max": 699 }
+    ],
+    "careerFeatured": ["guide-career-salary", "guide-career-agents", "guide-quit-or-stay", "guide-timing"]
+  },
+  "civil-construction-2": {
+    "examGuide": {
+      "title": "受験ガイド",
+      "description": "2級の試験概要・学習計画・勉強法・参考書など、まず全体像をつかむための記事",
+      "slugs": ["guide-overview", "guide-exam-overview", "guide-study-plan", "guide-study-method", "guide-textbooks"]
+    },
+    "fields": {
+      "title": "分野別対策",
+      "description": "出題分野順（土木一般 → 施工管理法 → 法規）に要点を整理",
+      "blocks": [
+        {
+          "id": "doboku-ippan",
+          "label": "土木一般（土工・コンクリート・基礎工）",
+          "slugs": ["guide-earthwork-key-points", "guide-concrete-key-points", "guide-foundation-key-points"]
+        },
+        {
+          "id": "seko-kanri",
+          "label": "施工管理法（施工計画・工程・品質・安全）",
+          "slugs": ["guide-construction-plan-key-points", "guide-schedule-management", "guide-quality-management", "guide-safety-management"]
+        },
+        {
+          "id": "hoki",
+          "label": "法規",
+          "slugs": ["guide-law-key-points"]
+        }
+      ]
+    },
+    "careerFeatured": ["guide-salary", "guide-career-change", "guide-quit-or-stay"]
+  },
+  "concrete-chief-engineer": {
+    "examGuide": {
+      "title": "受験ガイド",
+      "description": "試験概要・出題傾向・小論文対策",
+      "slugs": ["guide-overview", "guide-trends", "guide-essay"]
+    }
+  },
+  "pe-construction": {
+    "$note": "出題テーマ分析・論点キーワード・論文論点（各 group:keyword・計27本）は keyword セクションで維持。ここは guide group（11本）のみ扱う。",
+    "examGuide": {
+      "title": "受験ガイド",
+      "description": "難易度・学習計画・勉強法・コンピテンシー改訂など、二次試験の全体像",
+      "slugs": ["nanido-goukakuritsu", "gakushuu-jikan-schedule", "secondary-study-method", "competency-revision-r8"]
+    },
+    "fields": {
+      "title": "記述式論文の書き方",
+      "description": "答案構成 → 科目の書き分け → 解答例 → 業務経歴票の順に、論述の型を固める",
+      "blocks": [
+        {
+          "id": "kakikata",
+          "label": "論文の書き方・業務経歴票",
+          "slugs": ["pe-secondary-essay-guide", "toan-kousei-template", "sentaku-kamoku-kakiwake", "hissu-kamoku-kaitourei", "guide-required-essay", "gyoumu-keireki-hyou"]
+        }
+      ]
+    }
+  },
+  "pe-comprehensive-management": {
+    "examGuide": {
+      "title": "受験ガイド",
+      "description": "試験ガイド・合格戦略・出願の留意点",
+      "slugs": ["exam-index", "exam-passing-strategy", "course-selection-guide", "exam-application-guide", "general-vs-comprehensive"]
+    },
+    "fields": {
+      "title": "記述式論文の対策",
+      "description": "解答戦略 → 立場別の模範論文ガイド → 白書マップ → 直前対策",
+      "blocks": [
+        {
+          "id": "essay-strategy",
+          "label": "記述式の学習法・戦略",
+          "slugs": ["essay-exam-strategy", "essay-persona-guide", "essay-pattern-cross-year-application", "whitepaper-study-map", "management-tradeoffs", "frequent-topics", "last-minute-2026"]
+        },
+        {
+          "id": "r8-forecast",
+          "label": "R8 予想問題",
+          "slugs": ["r8-essay-keyword-forecast", "r8-essay-theme-climate-adaptation", "r8-essay-theme-disaster-recovery", "r8-essay-theme-circular-economy", "r8-essay-theme-infrastructure-maintenance", "r8-essay-theme-ai-governance", "r8-essay-theme-economic-security"]
+        },
+        {
+          "id": "model-essay",
+          "label": "立場別 模範論文",
+          "slugs": ["pattern-essay-general-contractor", "pattern-essay-river-consultant", "pattern-essay-road-municipality"]
+        },
+        {
+          "id": "why-comprehensive",
+          "label": "総監を取る意味・キャリア",
+          "slugs": ["public-servant-comprehensive-merit", "private-engineer-comprehensive-merit", "public-engineer-qualification-map"]
+        }
+      ]
+    }
+  }
+}

--- a/src/config/category-curriculum.ts
+++ b/src/config/category-curriculum.ts
@@ -1,0 +1,48 @@
+import curriculumData from '@/config/category-curriculum.json';
+
+/** 分野別・キャリアの1ブロック（見出し＋所属記事 suffix 群）。slugs 記載順が表示順。 */
+export type CurriculumBlock = {
+  id: string;
+  label?: string;
+  slugs: string[];
+};
+
+/** 受験ガイド節（単一ブロック）。 */
+export type ExamGuideDef = {
+  title: string;
+  description?: string;
+  slugs: string[];
+};
+
+/** 分野別対策節（複数ブロック）。 */
+export type FieldsDef = {
+  title: string;
+  description?: string;
+  blocks: CurriculumBlock[];
+};
+
+/** テキスト章定義（textbook_order のレンジ→章ラベル）。volume で冊をまとめる。 */
+export type TextbookChapterDef = {
+  volume?: string;
+  label: string;
+  min: number;
+  max: number;
+};
+
+/** 1カテゴリの体系編成。examGuide / fields / textbookChapters / careerFeatured はいずれも任意。 */
+export type CategoryCurriculum = {
+  examGuide?: ExamGuideDef;
+  fields?: FieldsDef;
+  textbookChapters?: TextbookChapterDef[];
+  careerFeatured?: string[];
+};
+
+// JSON 先頭の $comment キーは型に含めない（実データのカテゴリのみ抽出）。
+const raw = curriculumData as Record<string, unknown>;
+const CURRICULUM: Record<string, CategoryCurriculum> = Object.fromEntries(
+  Object.entries(raw).filter(([k]) => !k.startsWith('$')),
+) as Record<string, CategoryCurriculum>;
+
+export function getCategoryCurriculum(category: string): CategoryCurriculum | undefined {
+  return CURRICULUM[category];
+}

--- a/src/config/cross-exam-keywords.json
+++ b/src/config/cross-exam-keywords.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-07-03T22:25:08.433Z",
+  "generated_at": "2026-07-04T02:11:48.282Z",
   "summary": {
     "total_mdx_files": 1096,
     "with_exams_field": 50,

--- a/src/config/doc-meta-index.json
+++ b/src/config/doc-meta-index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-07-04T01:15:41.798Z",
+  "generated_at": "2026-07-04T02:11:47.977Z",
   "summary": {
     "total": 1096,
     "published": 1054,
@@ -598,8 +598,7 @@
       "category": "civil-construction-1",
       "group": "guide",
       "tags": [
-        "guide",
-        "career"
+        "guide"
       ],
       "published": true,
       "publishedAt": "2026-06-01",
@@ -2164,7 +2163,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "コンクリート工 基礎解説｜材料・配合・施工・鉄筋・品質管理【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29"
+      "dateModified": "2026-07-04"
     },
     "civil-construction-1-secondary-concrete-past-problems": {
       "title": "コンクリート工 出題傾向と過去の問題",
@@ -2181,7 +2180,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "コンクリート工 過去問｜R02〜H23 出題傾向と解答例（耐久性・ひび割れ・寒中暑中）【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29"
+      "dateModified": "2026-07-04"
     },
     "civil-construction-1-secondary-construction-plan-basics": {
       "title": "施工計画 基礎解説 - 1級土木 第2次検定",
@@ -2198,7 +2197,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "施工計画 基礎解説｜事前調査・技術計画・仮設・調達・管理【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29",
+      "dateModified": "2026-07-04",
       "ogp": {
         "title": "施工計画 基礎解説"
       }
@@ -2218,7 +2217,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "施工計画 過去問｜R02〜H23 出題傾向と解答例（ボックスカルバート・プレキャスト擁壁）【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29"
+      "dateModified": "2026-07-04"
     },
     "civil-construction-1-secondary-earthwork-basics": {
       "title": "土工 基礎解説 - 1級土木 第2次検定",
@@ -2235,7 +2234,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "土工 基礎解説｜盛土・のり面・軟弱地盤・建設機械・土留め【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29"
+      "dateModified": "2026-07-04"
     },
     "civil-construction-1-secondary-earthwork-past-problems": {
       "title": "土工 出題傾向と過去の問題",
@@ -2252,7 +2251,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "土工 過去問｜R02〜H23 出題傾向と解答例（締固め・軟弱地盤・土留め）【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29"
+      "dateModified": "2026-07-04"
     },
     "civil-construction-1-secondary-experience-writing-examples": {
       "title": "施工経験記述 改善例",
@@ -2269,7 +2268,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "施工経験記述 改善例｜品質・安全・工程・環境のテーマ別 失敗例と改善ポイント【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29"
+      "dateModified": "2026-07-04"
     },
     "civil-construction-1-secondary-experience-writing-guide": {
       "title": "施工経験記述 出題傾向と対策",
@@ -2286,7 +2285,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "施工経験記述 出題傾向と書き方｜品質・安全・工程の記述対策【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29"
+      "dateModified": "2026-07-04"
     },
     "civil-construction-1-secondary-quality-management-basics": {
       "title": "品質管理 基礎解説 - 1級土木 第2次検定",
@@ -2303,7 +2302,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "品質管理 基礎解説｜締固め・レディーミクスト・養生・非破壊検査【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29",
+      "dateModified": "2026-07-04",
       "ogp": {
         "title": "品質管理 基礎解説"
       }
@@ -2323,7 +2322,7 @@
       "publishedAt": "2026-04-15",
       "seoTitle": "品質管理 過去問｜R02〜H23 出題傾向と解答例（ひび割れ防止・盛土・レディーミクスト）【1級土木 第 2 次検定】",
       "created": "2026-04-15",
-      "dateModified": "2026-06-29"
+      "dateModified": "2026-07-04"
     },
     "civil-construction-1-secondary-r03": {
       "title": "令和3年度 第2次検定",
@@ -4578,8 +4577,7 @@
       "category": "civil-construction-2",
       "group": "guide",
       "tags": [
-        "guide",
-        "career"
+        "guide"
       ],
       "published": true,
       "publishedAt": "2026-06-01",
@@ -5310,7 +5308,7 @@
       "publishedAt": "2026-05-29",
       "seoTitle": "施工経験記述 工種別 記入例｜品質・工程・安全のテーマ別 記述の観点【2級土木 第 2 次検定】",
       "created": "2026-05-29",
-      "dateModified": "2026-06-29",
+      "dateModified": "2026-07-04",
       "ogp": {
         "title": "施工経験記述\n工種別 記入例"
       }
@@ -5332,7 +5330,7 @@
       "publishedAt": "2026-05-29",
       "seoTitle": "施工経験記述 出題傾向と書き方｜安全・品質・工程の記述対策【2級土木 第 2 次検定】",
       "created": "2026-05-29",
-      "dateModified": "2026-06-29",
+      "dateModified": "2026-07-04",
       "ogp": {
         "title": "施工経験記述\n出題傾向と対策"
       }

--- a/src/config/tag-dictionary.json
+++ b/src/config/tag-dictionary.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-07-03T22:25:08.711Z",
+  "generated_at": "2026-07-04T02:11:48.504Z",
   "summary": {
     "total_mdx_files": 1096,
     "total_unique_tags": 172,
@@ -1252,7 +1252,7 @@
     },
     {
       "name": "guide",
-      "count": 133,
+      "count": 121,
       "inAllowlist": true,
       "usedIn": [
         "civil-construction-1-guide-1-vs-2",
@@ -1301,16 +1301,6 @@
         "civil-construction-1-guide-white-company",
         "civil-construction-1-guide-women",
         "civil-construction-1-keyword-2026",
-        "civil-construction-1-secondary-concrete-basics",
-        "civil-construction-1-secondary-concrete-past-problems",
-        "civil-construction-1-secondary-construction-plan-basics",
-        "civil-construction-1-secondary-construction-plan-past-problems",
-        "civil-construction-1-secondary-earthwork-basics",
-        "civil-construction-1-secondary-earthwork-past-problems",
-        "civil-construction-1-secondary-experience-writing-examples",
-        "civil-construction-1-secondary-experience-writing-guide",
-        "civil-construction-1-secondary-quality-management-basics",
-        "civil-construction-1-secondary-quality-management-past-problems",
         "civil-construction-2-guide-career",
         "civil-construction-2-guide-career-change",
         "civil-construction-2-guide-concrete-key-points",
@@ -1332,8 +1322,6 @@
         "civil-construction-2-guide-study-plan",
         "civil-construction-2-guide-textbooks",
         "civil-construction-2-guide-young-career",
-        "civil-construction-2-secondary-experience-writing-examples",
-        "civil-construction-2-secondary-experience-writing-guide",
         "concrete-chief-engineer-guide-essay",
         "concrete-chief-engineer-guide-overview",
         "concrete-chief-engineer-guide-trends",
@@ -1921,7 +1909,7 @@
     },
     {
       "name": "career",
-      "count": 34,
+      "count": 32,
       "inAllowlist": true,
       "usedIn": [
         "civil-construction-1-guide-age-career",
@@ -1933,7 +1921,6 @@
         "civil-construction-1-guide-company-types",
         "civil-construction-1-guide-consultant",
         "civil-construction-1-guide-dx-jobs",
-        "civil-construction-1-guide-exam-overview",
         "civil-construction-1-guide-future",
         "civil-construction-1-guide-grade-comparison",
         "civil-construction-1-guide-hatchu-shien",
@@ -1950,7 +1937,6 @@
         "civil-construction-1-guide-women",
         "civil-construction-2-guide-career",
         "civil-construction-2-guide-career-change",
-        "civil-construction-2-guide-exam-overview",
         "civil-construction-2-guide-haken-seishain",
         "civil-construction-2-guide-job-reality",
         "civil-construction-2-guide-quit-or-stay",
@@ -1958,6 +1944,35 @@
         "civil-construction-2-guide-salary",
         "civil-construction-2-guide-young-career",
         "pe-construction-guide-career"
+      ]
+    },
+    {
+      "name": "secondary",
+      "count": 22,
+      "inAllowlist": true,
+      "usedIn": [
+        "civil-construction-1-secondary-concrete-basics",
+        "civil-construction-1-secondary-concrete-past-problems",
+        "civil-construction-1-secondary-construction-plan-basics",
+        "civil-construction-1-secondary-construction-plan-past-problems",
+        "civil-construction-1-secondary-earthwork-basics",
+        "civil-construction-1-secondary-earthwork-past-problems",
+        "civil-construction-1-secondary-experience-writing-examples",
+        "civil-construction-1-secondary-experience-writing-guide",
+        "civil-construction-1-secondary-quality-management-basics",
+        "civil-construction-1-secondary-quality-management-past-problems",
+        "civil-construction-1-secondary-r03",
+        "civil-construction-1-secondary-r04",
+        "civil-construction-1-secondary-r05",
+        "civil-construction-1-secondary-r06",
+        "civil-construction-1-secondary-r07",
+        "civil-construction-2-secondary-experience-writing-examples",
+        "civil-construction-2-secondary-experience-writing-guide",
+        "civil-construction-2-secondary-r03",
+        "civil-construction-2-secondary-r04",
+        "civil-construction-2-secondary-r05",
+        "civil-construction-2-secondary-r06",
+        "civil-construction-2-secondary-r07"
       ]
     },
     {
@@ -2367,23 +2382,6 @@
         "concrete-chief-engineer-textbook-products",
         "concrete-chief-engineer-textbook-properties",
         "concrete-chief-engineer-textbook-structural-design"
-      ]
-    },
-    {
-      "name": "secondary",
-      "count": 10,
-      "inAllowlist": true,
-      "usedIn": [
-        "civil-construction-1-secondary-r03",
-        "civil-construction-1-secondary-r04",
-        "civil-construction-1-secondary-r05",
-        "civil-construction-1-secondary-r06",
-        "civil-construction-1-secondary-r07",
-        "civil-construction-2-secondary-r03",
-        "civil-construction-2-secondary-r04",
-        "civil-construction-2-secondary-r05",
-        "civil-construction-2-secondary-r06",
-        "civil-construction-2-secondary-r07"
       ]
     },
     {

--- a/src/lib/category-curriculum.ts
+++ b/src/lib/category-curriculum.ts
@@ -1,0 +1,120 @@
+import { type DocMeta } from '@/lib/docs';
+import { getCategoryCurriculum } from '@/config/category-curriculum';
+
+// カテゴリページの「体系（受験ガイド / 分野別 / テキスト章 / キャリア）」を config から解決する純関数群。
+// 設計の最重要原則: config 未割当の記事を silent drop しない。resolveCurriculum は必ず unassigned で拾い、
+// resolveTextbookChapters はレンジ外を「その他」章へ回す。View 非依存（テスト可能）。
+
+/** doc.slug（`${category}-${suffix}`）から suffix を取り出す。prefix が無ければ slug そのまま。 */
+function toSuffix(category: string, slug: string): string {
+  const prefix = `${category}-`;
+  return slug.startsWith(prefix) ? slug.slice(prefix.length) : slug;
+}
+
+export type CurriculumBlockResolved = { id: string; label?: string | undefined; docs: DocMeta[] };
+
+export type ResolvedCurriculum = {
+  examGuide: { title: string; description?: string | undefined; docs: DocMeta[] } | null;
+  fields: { title: string; description?: string | undefined; blocks: CurriculumBlockResolved[] } | null;
+  career: { featured: DocMeta[]; rest: DocMeta[] };
+  /** config のどのブロックにも属さない非キャリア guide。View は必ず表示する（silent drop 防止）。 */
+  unassigned: DocMeta[];
+};
+
+/**
+ * guide 記事群を config に従って 受験ガイド / 分野別ブロック / キャリア（注目＋残り）へ振り分ける。
+ * - キャリア判定は既存踏襲（tags.includes('career')）。
+ * - ブロック内の並びは config の slugs 記載順。config に無い非キャリア guide は unassigned。
+ * - careerFeatured の欠落 slug は featured から除外し rest に残る（防御的）。
+ */
+export function resolveCurriculum(category: string, guideDocs: DocMeta[]): ResolvedCurriculum {
+  const cfg = getCategoryCurriculum(category);
+
+  const bySuffix = new Map<string, DocMeta>();
+  for (const d of guideDocs) bySuffix.set(toSuffix(category, d.slug), d);
+
+  const career = guideDocs.filter((d) => d.tags?.includes('career'));
+  const nonCareer = guideDocs.filter((d) => !d.tags?.includes('career'));
+
+  const assigned = new Set<DocMeta>();
+  const pick = (slugs: string[] | undefined): DocMeta[] => {
+    if (!slugs) return [];
+    const out: DocMeta[] = [];
+    for (const s of slugs) {
+      const d = bySuffix.get(s);
+      if (d && !d.tags?.includes('career') && !assigned.has(d)) {
+        assigned.add(d);
+        out.push(d);
+      }
+    }
+    return out;
+  };
+
+  const examGuideDocs = pick(cfg?.examGuide?.slugs);
+  const examGuide = cfg?.examGuide
+    ? { title: cfg.examGuide.title, description: cfg.examGuide.description, docs: examGuideDocs }
+    : null;
+
+  const blocks: CurriculumBlockResolved[] = (cfg?.fields?.blocks ?? [])
+    .map((b) => ({ id: b.id, label: b.label, docs: pick(b.slugs) }))
+    .filter((b) => b.docs.length > 0);
+  const fields = cfg?.fields && blocks.length > 0
+    ? { title: cfg.fields.title, description: cfg.fields.description, blocks }
+    : null;
+
+  // 非キャリア guide で未割当のもの（config 追記漏れ・新規記事）。必ず表示に回す。
+  const unassigned = nonCareer.filter((d) => !assigned.has(d));
+
+  const featuredSuffixes = cfg?.careerFeatured ?? [];
+  const featured: DocMeta[] = [];
+  const featuredSet = new Set<DocMeta>();
+  for (const s of featuredSuffixes) {
+    const d = bySuffix.get(s);
+    if (d && d.tags?.includes('career')) {
+      featured.push(d);
+      featuredSet.add(d);
+    }
+  }
+  const rest = career.filter((d) => !featuredSet.has(d));
+
+  return { examGuide, fields, career: { featured, rest }, unassigned };
+}
+
+/** テキスト記事の並び順キー（textbook_order 優先、無ければ section 数値、無ければ末尾）。 */
+function textbookSortKey(d: DocMeta): number {
+  if (typeof d.textbook_order === 'number') return d.textbook_order;
+  const s = Number(d.section);
+  return Number.isFinite(s) ? s : 9999;
+}
+
+export type TextbookChapterResolved = { volume?: string | undefined; label: string; docs: DocMeta[] };
+
+/**
+ * textbook 記事を config の章レンジ（textbook_order）でグルーピングする。
+ * - config が無い（concrete 系: section 連番）なら単一のフラット章として order 昇順で返す。
+ * - レンジ外の記事は「その他」章へ回す（silent drop 防止）。
+ */
+export function resolveTextbookChapters(category: string, textbookDocs: DocMeta[]): TextbookChapterResolved[] {
+  if (textbookDocs.length === 0) return [];
+  const cfg = getCategoryCurriculum(category);
+  const ranges = cfg?.textbookChapters;
+
+  const sorted = [...textbookDocs].sort((a, b) => textbookSortKey(a) - textbookSortKey(b));
+
+  if (!ranges || ranges.length === 0) {
+    // section ベース（concrete 系）: 章見出しなしのフラット目次。
+    return [{ label: '', docs: sorted }];
+  }
+
+  const chapters: TextbookChapterResolved[] = ranges.map((r) => ({ volume: r.volume, label: r.label, docs: [] }));
+  const leftover: DocMeta[] = [];
+  for (const d of sorted) {
+    const order = typeof d.textbook_order === 'number' ? d.textbook_order : NaN;
+    const idx = ranges.findIndex((r) => Number.isFinite(order) && order >= r.min && order <= r.max);
+    const chapter = idx >= 0 ? chapters[idx] : undefined;
+    if (chapter) chapter.docs.push(d);
+    else leftover.push(d);
+  }
+  if (leftover.length > 0) chapters.push({ label: 'その他', docs: leftover });
+  return chapters.filter((c) => c.docs.length > 0);
+}


### PR DESCRIPTION
## 概要
カテゴリページ (`/category/*`) の試験ガイド・テキストを**カードグリッドから「受験ガイド＋分野別対策＋テキスト章目次」のテキスト/リスト表示**へ刷新し、章立て・出題分野の体系（＝PDF テキストの章構成・試験の出題分野）を一目で伝える。過去問テーブル群は情報密度が高く完成済みのため維持。カテゴリページに新規画像は導入しない（guide-covers 写真は PR #276 で revert 済みの前例）。

## 主な変更
- **編成 SSOT**: `src/config/category-curriculum.json`（slug は suffix）。既存の並び順真実源（`textbook_order`/`section`/`guide_order`）は維持し「どの記事がどのブロックか」だけを config が持つ。resolver=`src/lib/category-curriculum.ts`（純関数・View 非依存）。
- **共有コンポーネント** `CurriculumSections.tsx`: `CurriculumSection`（枠）/`CurriculumList`（目次調リスト・連番or四角マーカー・分冊 eyebrow）/`CareerSection`（注目カード＋残りリスト）。editorial トークンのみ。
- **View 全面リスト化**: civil-1/2・concrete 共用 `ConcreteView` 新設・pe 建設/総監の guide 部分。group 検索を title 文字列一致→`g.key` 一致へ堅牢化。**pe-first-stage は不変（回帰確認済み）**。

## ついでに直した実バグ2件
- **silent drop**: civil-1 textbook の 500/600 番台（安全7＋環境4＝**11本**）が旧 `TEXTBOOK_AREAS(max449)` から漏れて**カテゴリページから不可視**だった（全て published:true）。resolver の章レンジ＋`unassigned` フォールバックで必ず表示（**34→45本**）。
- **career 誤タグ**: civil-1/2 の `guide-exam-overview` が `tags:[guide,career]` で「試験概要」がキャリア枠に誤表示 → career タグ除去し受験ガイドへ。index 再生成。

## CI / SSOT
- `check-category-curriculum`（config slug 実在＋career 整合＋未割当 surface）を pre-commit へ配線（フック regenerate は merge 後の prepare に委譲）。
- `design-system.md §3` に CurriculumSections を追記。

## 検証
- 全7カテゴリ `curl` → HTTP 200 + `<main>`（webpack dev on worktree）
- civil-1 textbook リンク 34→**45**（silent drop 解消）・分冊 eyebrow 表示・civil-2 で試験概要が受験ガイドへ移動・注目キャリアカード表示
- `tsc` 0 / `lint-ui --all` 0 / `eslint` 0 / `check-category-curriculum` 0 / `check-doc-refs` OK / pre-commit 全通過

## 残（レビュー後）
- モバイル 375px / dark の視覚確認（Playwright）と `/design-review` 採点

🤖 Generated with [Claude Code](https://claude.com/claude-code)