### PR TITLE
サイト回遊・note 動線最適化（P1 内部回遊計測＋P2 次のステップ導線＋P3 季節hub CTA）

### DIFF
--- a/docs/design-system/design-system.md
+++ b/docs/design-system/design-system.md
@@ -121,6 +121,7 @@
 | `SectionCard`（`ui/SectionCard/`） | カード（radius/border/shadow を token に統一・カード内カード回避） | — |
 | `ArticleHeader`（`ui/ArticleHeader/`） | docs 記事冒頭（breadcrumb + h1 + description リード + byline/meta） | — |
 | `CurriculumSections`（`category/CurriculumSections.tsx`） | カテゴリページの体系表示。試験ガイド・テキストを**カードでなく目次調リスト**で見せ、章立て・出題分野の体系を一目で伝える（`CurriculumSection` 枠 / `CurriculumList` 目次リスト / `CareerSection` 注目カード＋リスト）。編成は `src/config/category-curriculum.json`（SSOT）、解決は `src/lib/category-curriculum.ts`（resolver・silent drop 防止の `unassigned` 付き）、健全性は `check-category-curriculum`（pre-commit）。過去問テーブル群（`CategorySections.tsx`）とは併存 | `CurriculumList`: `blocks`/`numbered`。`CareerSection`: `featured`/`rest` |
+| `NextStepNav`（`ui/NextStepNav/NextStepNav.tsx`） | guide（要点）記事末の「次のステップ」導線。読者を演習（過去問）・テキスト・分野へ送り行き止まりを解消（リンク先はカテゴリ hub の `sec-*` アンカー＝季節 note CTA と同居）。解決は `src/lib/next-step.ts`（カテゴリ別・純関数）。`MetaCard` の `trackNav` で回遊クリックが `internal_nav_click` 計測に乗る。キャリア記事では非描画（転職導線と非競合）。回遊ナビの GA4 計測は `data-cta="nav"`＋`MetaCard trackNav`／`AnalyticsProvider` の `nav` 種別 | `category` |
 
 `not-found` は Header/Footer を持たない設計のため PageShell を使わない（意図的な例外）。
 

--- a/docs/todo/backlog.md
+++ b/docs/todo/backlog.md
@@ -206,6 +206,15 @@ Hero → ExamCards → LatestArticles → AboutSection
 
 ---
 
+### 回遊・note 動線 最適化 P4/P5（P1-P3 は実装済み）🟡
+
+**背景**: 2026-07-04 に回遊・note 動線・アフィリを全面調査。P1（内部回遊の GA4 計測基盤）・P2（guide 記事末「次のステップ」導線 NextStepNav）・P3（カテゴリ hub の季節モード note CTA）は実装済み（PR feat/funnel-tracking）。以下は増分で今回スコープ外。
+
+- **P4: keyword-relations.json の自動レコメンド活用** — `keyword-relations.json`（598KB・refresh-indexes 生成）は存在するが `RelatedKeywords` は MDX ハードコードで未活用。RelatedKeywords 未記述の keyword 記事に build 時 top-N を自動挿入する fallback を入れれば PE 総監 keyword 650 面の回遊が強化される。**要: 挿入品質の監査（自動レコメンドの妥当性）と PE keyword 面での A/B**。既存ハードコードは優先維持。
+- **P5: アフィリ EPC 判定のタイムボックス化** — 建設JOBs vs ビルドジョブ/GKS の恒久 A/B（slug ハッシュ 50/50・`affiliate-creatives.ts`）は EPC 計測中で判定期限が未定。~2026-09 に GA4 の `affiliate_cta_click` × label（arm 別）× A8 成果で EPC 比較→勝者決定・負け arm 撤去。あわせて concrete/pe-first-stage の docs sidebar 空白を既存クリエイティブで埋める是非（セグメント適合を優先し無理に埋めない判断も可）。**まず P1 計測の実データ（2-4 週）を見てから**。
+
+---
+
 ## 3. 収益化（Kindle / note PDF）
 
 ### 読み方ガイド 横展開（建設部門＋土木）🔴

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -17,8 +17,9 @@ import {
   PeConstructionView,
 } from '@/components/category/CategoryViews';
 import SidebarMagazineList from '@/components/ui/SidebarMagazineList';
+import MagazineCard from '@/components/ui/MagazineCard/MagazineCard';
 import AuthorSidebarCard from '@/components/ui/AuthorSidebarCard';
-import { resolveCategoryMagazines } from '@/lib/magazine-placement';
+import { resolveCategoryMagazines, resolveSeasonalHubMagazine } from '@/lib/magazine-placement';
 import { getMagazine } from '@/lib/note-magazines';
 import SidebarAdBanner from '@/components/ui/SidebarAdBanner';
 import { resolveCategoryCareerAds } from '@/config/affiliate-creatives';
@@ -97,6 +98,8 @@ export default async function CategoryPage({
   // note CTA は冒頭全幅グリッドから PC 右サイドバーへ集約し、モバイルは記事一覧の下に出す（2026-06-20）。
   // サイドバーは縦積みのため上位 3 マガジン（placement 優先順）に絞ってコンパクトに保つ。
   const hubMagazines = categoryMagazines.slice(0, 3);
+  // 本文フロー用の季節モード CTA（試験日前=直前商品／後=旗艦・ビルド時確定）。sidebar とは別枠。
+  const seasonalHub = resolveSeasonalHubMagazine(slug);
   // モバイル本文中の visible バナー（pixelSrc を渡さない＝PC サイドバー側が唯一の発火源）。
   // 各案件を 1 枚ずつの node にしてビューのグループ境界に分散配置する（カードの隙間に「両方」）。
   const mobileCareerAds = careerAds.map((ad, i) => (
@@ -142,6 +145,13 @@ export default async function CategoryPage({
           {popularDocs.length > 0 && (
             <div className="mb-16">
               <PopularShowcase items={popularDocs.slice(0, 3)} />
+            </div>
+          )}
+          {/* 季節モード note CTA（本文フロー・最大送客源のカテゴリ hub を最適化）。直前期は直前商品、
+              試験日以降は旗艦へビルド時に自動切替。未公開なら MagazineCard が null を返す（防御）。 */}
+          {seasonalHub && (
+            <div className="mb-16 max-w-2xl">
+              <MagazineCard id={seasonalHub.magazineId} utmContent={seasonalHub.utmContent} />
             </div>
           )}
           {docs.length === 0 ? (

--- a/src/components/category/CategorySections.tsx
+++ b/src/components/category/CategorySections.tsx
@@ -18,6 +18,8 @@ export function DocCard({ doc }: { doc: DocMeta }) {
   return (
     <Link
       href={`/docs/${doc.slug}`}
+      data-cta="nav"
+      data-cta-label="category-card"
       className="group relative flex flex-col overflow-hidden rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] hover:border-[var(--accent)] hover:shadow-soft transition-all"
     >
       {/* ブランド色の上端アクセント（mockup の category band を mono 化＝硬質エディトリアル維持）。

--- a/src/components/category/CurriculumSections.tsx
+++ b/src/components/category/CurriculumSections.tsx
@@ -47,7 +47,7 @@ export function CurriculumSection({
 function CurriculumRow({ doc, marker }: { doc: DocMeta; marker: React.ReactNode }) {
   return (
     <li className="border-b border-[var(--rule-soft)] last:border-b-0">
-      <Link href={`/docs/${doc.slug}`} className="group flex items-baseline gap-3 py-3">
+      <Link href={`/docs/${doc.slug}`} data-cta="nav" data-cta-label="curriculum-list" className="group flex items-baseline gap-3 py-3">
         <span className="shrink-0 flex items-center justify-center min-w-6" aria-hidden>
           {marker}
         </span>

--- a/src/components/category/PopularSections.tsx
+++ b/src/components/category/PopularSections.tsx
@@ -60,7 +60,7 @@ export function PopularShowcase({ items }: { items: PopularDoc[] }) {
   if (!lead) return null;
   const label = windowLabel();
   return (
-    <section>
+    <section data-cta="nav" data-cta-label="popular-showcase">
       <div className="mb-6">
         <div className="flex items-baseline justify-between gap-2 flex-wrap">
           <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">よく読まれている記事</h2>
@@ -90,7 +90,7 @@ export function PopularRanking({ items }: { items: PopularDoc[] }) {
   if (items.length === 0) return null;
   const label = windowLabel();
   return (
-    <div className="rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] overflow-hidden">
+    <div data-cta="nav" data-cta-label="popular-ranking" className="rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] overflow-hidden">
       <div className="px-4 py-3 border-b border-[var(--rule-soft)] flex items-baseline justify-between gap-2">
         <h3 className="font-serif font-bold text-[var(--ink)] text-sm">人気記事</h3>
         {label && <span className="font-mono text-[10px] text-[var(--ink-muted)] tabular-nums">{label}</span>}

--- a/src/components/providers/AnalyticsProvider.tsx
+++ b/src/components/providers/AnalyticsProvider.tsx
@@ -18,26 +18,34 @@ export default function AnalyticsProvider() {
     gtag.pageview(url);
   }, [pathname, searchParams]);
 
-  // 収益 CTA（note 有料マガジン / アフィリエイト）と note 無料記事への送客リンクの
+  // 収益 CTA（note 有料マガジン / アフィリエイト）・note 無料記事への送客・サイト内回遊ナビの
   // クリックを 1 つのデリゲートリスナーで計測する。各コンポーネントを client 化せず、
-  // サーバー描画の <a> に data-cta="note" | "affiliate" | "note-article"（+ data-cta-label）
+  // サーバー描画の <a> に data-cta="note" | "affiliate" | "note-article" | "nav"（+ data-cta-label）
   // を付けるだけで拾える設計。GA4 はイベントに pagePath を自動付与するため、
-  // eventName × pagePath でページ別クリック数が取れる。
+  // eventName × pagePath × label でページ別・ナビ別クリック数が取れる。
   // note（有料マガジン購入 CTA）と note-article（無料記事ナビ）は別イベントに分離し、
   // 収益ファネルの分母（note_cta_click）を無料記事クリックで汚染しない。
+  // nav（内部回遊ナビ）は data-cta をコンポーネント root に付けてよい（配下リンクの
+  // クリックだけを数えるため「実リンク（<a>）クリック時のみ発火」ガードを敷く。見出し等の
+  // 非リンククリックは計上しない）。
   useEffect(() => {
     const ACTION: Record<string, string> = {
       note: "note_cta_click",
       affiliate: "affiliate_cta_click",
       "note-article": "note_article_click",
+      nav: "internal_nav_click",
     };
     const CATEGORY: Record<string, string> = {
       note: "note-magazine",
       affiliate: "affiliate",
       "note-article": "note-article",
+      nav: "internal-nav",
     };
     const onClick = (e: MouseEvent) => {
       const start = e.target as Element | null;
+      // 実リンク（<a>）のクリックのみ計上（root に data-cta を付けた nav で見出しクリックを除外）。
+      const anchor = start?.closest?.("a") as HTMLAnchorElement | null;
+      if (!anchor) return;
       const el = start?.closest?.("[data-cta]") as HTMLElement | null;
       const kind = el?.dataset.cta;
       if (!el || !kind) return;
@@ -47,7 +55,7 @@ export default function AnalyticsProvider() {
       gtag.event({
         action,
         category,
-        label: el.dataset.ctaLabel || el.getAttribute("href") || "(unknown)",
+        label: el.dataset.ctaLabel || anchor.getAttribute("href") || "(unknown)",
       });
     };
     // capture フェーズ: 子要素が stopPropagation しても確実に拾う。

--- a/src/components/ui/ArticleFooter/ArticleFooter.tsx
+++ b/src/components/ui/ArticleFooter/ArticleFooter.tsx
@@ -19,6 +19,7 @@ import CategoryNavCard from '@/components/ui/CategoryNavCard/CategoryNavCard';
 import FAQCard from '@/components/ui/FAQCard/FAQCard';
 import CareerAffiliate from '@/components/ui/CareerAffiliate/CareerAffiliate';
 import RelatedArticles from '@/components/ui/RelatedArticles';
+import NextStepNav from '@/components/ui/NextStepNav/NextStepNav';
 import AuthorCard from '@/components/ui/AuthorCard/AuthorCard';
 
 interface ArticleFooterProps {
@@ -154,6 +155,14 @@ export default function ArticleFooter({
             />
           </div>
         )}
+
+      {/* guide（キャリア記事を除く）: 次のステップ導線（演習・テキスト・分野へ）。全ビューポート。
+          要点記事の行き止まりを解消し、カテゴリ hub の sec-* アンカー（直前期 note CTA と同居）へ送る。 */}
+      {docGroup === 'guide' && category && !meta.tags?.includes('career') && (
+        <div className="mt-8">
+          <NextStepNav category={category} />
+        </div>
+      )}
 
       {/* よくある質問（frontmatter faqs を持つ記事のみ表示） */}
       {faqs.length > 0 && (

--- a/src/components/ui/CategoryNavCard/CategoryNavCard.tsx
+++ b/src/components/ui/CategoryNavCard/CategoryNavCard.tsx
@@ -278,7 +278,7 @@ function SectionCard({ variant, currentSlug, currentSection }: { variant: 'sideb
 /* ─── ラッパー（デザイン統一） ─── */
 function SidebarWrapper({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <MetaCard as="div" padding="compact">
+    <MetaCard as="div" padding="compact" trackNav="category-nav">
       <div
         className="nav-card-title text-[var(--ink)]"
       >
@@ -291,7 +291,7 @@ function SidebarWrapper({ title, children }: { title: string; children: React.Re
 
 function MobileWrapper({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <MetaCard>
+    <MetaCard trackNav="category-nav">
       <h2 className="text-lg font-bold text-[var(--ink)] mb-4">{title}</h2>
       {children}
     </MetaCard>

--- a/src/components/ui/ExamQuestionNav/ExamQuestionNav.tsx
+++ b/src/components/ui/ExamQuestionNav/ExamQuestionNav.tsx
@@ -52,7 +52,7 @@ export default function ExamQuestionNav({ headings, variant = 'sidebar' }: ExamQ
 
   if (variant === 'mobile') {
     return (
-      <MetaCard>
+      <MetaCard trackNav="exam-question-nav">
         <h2 className="mb-4 text-lg font-bold text-[var(--ink)]">{title}</h2>
         {grid}
       </MetaCard>

--- a/src/components/ui/MetaCard/MetaCard.tsx
+++ b/src/components/ui/MetaCard/MetaCard.tsx
@@ -34,6 +34,12 @@ interface MetaCardProps {
   padding?: 'default' | 'compact' | 'none';
   /** 追加クラス（mt-10、max-h、toc-scroll 等の特殊指定） */
   className?: string;
+  /**
+   * サイト内回遊クリック計測のラベル（任意）。指定すると root に
+   * `data-cta="nav" data-cta-label={trackNav}` を付与し、AnalyticsProvider の
+   * デリゲートリスナーが配下リンクのクリックを internal_nav_click として拾う。
+   */
+  trackNav?: string;
   children: ReactNode;
 }
 
@@ -51,26 +57,28 @@ export default function MetaCard({
   ariaLabel,
   padding = 'default',
   className = '',
+  trackNav,
   children,
 }: MetaCardProps) {
   const finalClassName = [BASE_CLASSES, PADDINGS[padding], className].filter(Boolean).join(' ');
+  const trackAttrs = trackNav ? { 'data-cta': 'nav', 'data-cta-label': trackNav } : {};
 
   if (as === 'aside') {
     return (
-      <aside aria-label={ariaLabel} className={finalClassName}>
+      <aside aria-label={ariaLabel} className={finalClassName} {...trackAttrs}>
         {children}
       </aside>
     );
   }
   if (as === 'div') {
     return (
-      <div aria-label={ariaLabel} className={finalClassName}>
+      <div aria-label={ariaLabel} className={finalClassName} {...trackAttrs}>
         {children}
       </div>
     );
   }
   return (
-    <section aria-label={ariaLabel} className={finalClassName}>
+    <section aria-label={ariaLabel} className={finalClassName} {...trackAttrs}>
       {children}
     </section>
   );

--- a/src/components/ui/NextStepNav/NextStepNav.tsx
+++ b/src/components/ui/NextStepNav/NextStepNav.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import MetaCard from '@/components/ui/MetaCard/MetaCard';
+import { resolveNextSteps } from '@/lib/next-step';
+
+/**
+ * NextStepNav — guide（要点・概要）記事末の「次のステップ」導線。
+ *
+ * 要点をつかんだ読者を演習（過去問）・テキスト・分野へ送り、行き止まりを解消する。
+ * リンク先はカテゴリページの sec-* アンカー（直前期 note CTA と同居＝回遊と収益導線が接続）。
+ * クリックは MetaCard trackNav 経由で internal_nav_click（label=next-step）として計測される。
+ * キャリア記事では呼び出し側で描画しない（転職導線と競合させない）。
+ */
+export default function NextStepNav({ category }: { category: string }) {
+  const steps = resolveNextSteps(category);
+  if (steps.length === 0) return null;
+  return (
+    <MetaCard ariaLabel="次のステップ" trackNav="next-step">
+      <h2 className="text-lg font-bold text-[var(--ink)] mb-1">次のステップ</h2>
+      <p className="text-sm text-[var(--ink-muted)] mb-4">
+        要点をつかんだら、演習と本文で定着させましょう。
+      </p>
+      <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {steps.map((s) => (
+          <li key={s.href}>
+            <Link
+              href={s.href}
+              className="block h-full rounded-sm border border-[var(--rule-soft)] px-4 py-3 transition-colors hover:border-brand dark:hover:border-brand"
+            >
+              <span className="block text-[15px] font-medium text-[var(--ink)]">{s.label}</span>
+              <span className="mt-0.5 block text-[13px] text-[var(--ink-muted)]">{s.hint}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </MetaCard>
+  );
+}

--- a/src/components/ui/PastExamBacklinks/PastExamBacklinks.tsx
+++ b/src/components/ui/PastExamBacklinks/PastExamBacklinks.tsx
@@ -59,7 +59,7 @@ export default function PastExamBacklinks({ category, currentSlug }: PastExamBac
     if (!civilEntries || civilEntries.length === 0) return null;
 
     return (
-      <MetaCard ariaLabel="過去問での出題">
+      <MetaCard ariaLabel="過去問での出題" trackNav="past-exam-backlinks">
         <h2 className="text-lg font-bold text-[var(--ink)] mb-1">
           過去問での出題
         </h2>
@@ -97,7 +97,7 @@ export default function PastExamBacklinks({ category, currentSlug }: PastExamBac
   if (!backlinks || backlinks.length === 0) return null;
 
   return (
-    <MetaCard ariaLabel="過去問での出題">
+    <MetaCard ariaLabel="過去問での出題" trackNav="past-exam-backlinks">
       <h2 className="text-lg font-bold text-[var(--ink)] mb-1">
         過去問での出題
       </h2>

--- a/src/components/ui/PillarNavCard/PillarNavCard.tsx
+++ b/src/components/ui/PillarNavCard/PillarNavCard.tsx
@@ -43,7 +43,7 @@ export default function PillarNavCard({ variant, currentSection }: PillarNavCard
 
   if (variant === "sidebar") {
     return (
-      <MetaCard as="div" padding="compact">
+      <MetaCard as="div" padding="compact" trackNav="pillar-nav">
         <div
           className="nav-card-title text-[var(--ink)]"
         >

--- a/src/components/ui/RelatedArticles/RelatedArticles.tsx
+++ b/src/components/ui/RelatedArticles/RelatedArticles.tsx
@@ -58,7 +58,7 @@ export default function RelatedArticles({ currentMeta, categoryArticles }: Relat
   if (related.length < 2) return null;
 
   return (
-    <MetaCard>
+    <MetaCard trackNav="related-articles">
       <h2 className="mb-1 text-lg font-bold text-[var(--ink)]">関連記事</h2>
       <p className="mb-4 text-sm text-[var(--ink-muted)]">
         同じテーマの記事 ({related.length} 件)

--- a/src/components/ui/RelatedTextbooks/RelatedTextbooks.tsx
+++ b/src/components/ui/RelatedTextbooks/RelatedTextbooks.tsx
@@ -137,7 +137,7 @@ export default function RelatedTextbooks({ currentMeta, categoryArticles }: Rela
   if (entries.length === 0) return null;
 
   return (
-    <MetaCard>
+    <MetaCard trackNav="related-textbooks">
       <h2 className="text-lg font-bold text-[var(--ink)] mb-1">
         この試験で扱われた教材
       </h2>

--- a/src/components/ui/SectionKeywords.tsx
+++ b/src/components/ui/SectionKeywords.tsx
@@ -25,7 +25,7 @@ export default function SectionKeywords({ currentSlug, section }: SectionKeyword
   if (others.length === 0) return null;
 
   return (
-    <MetaCard ariaLabel="同セクションのキーワード">
+    <MetaCard ariaLabel="同セクションのキーワード" trackNav="section-keywords">
       <h2 className="text-lg font-bold text-[var(--ink)] mb-1">
         {sec.title}
       </h2>

--- a/src/components/ui/TextbookNav/TextbookNav.tsx
+++ b/src/components/ui/TextbookNav/TextbookNav.tsx
@@ -26,7 +26,7 @@ export default function TextbookNav({ currentSlug, categoryArticles }: TextbookN
   if (!prev && !next) return null;
 
   return (
-    <MetaCard>
+    <MetaCard trackNav="textbook-nav">
       <h2 className="text-lg font-bold text-[var(--ink)] mb-4">
         テキスト章ナビゲーション
       </h2>

--- a/src/lib/magazine-placement.ts
+++ b/src/lib/magazine-placement.ts
@@ -556,3 +556,27 @@ export function resolveCategoryMagazines(category: string): PlacementSlot[] {
     utmContent: `category-${category}-${i + 1}`,
   }));
 }
+
+// カテゴリ hub 本文フローに置く「季節モード」note CTA（ビルド時確定）。
+// 試験日前は直前商品（R8予想・直前暗記＝直前期の売れ筋）、試験日以降は旗艦パックへ自動切替。
+// アフィリの period 切替（affiliate-creatives.ts campaignEndUtcMs）と同型で、SSG のビルド時刻で確定する。
+// switchUtcMs = 各資格の筆記/二次の概ねの直後（数日ズレは許容）。before/after は published 済みを使用。
+type SeasonalHubSpec = { switchUtcMs: number; before: MagazineId; after: MagazineId };
+const SEASONAL_HUB: Partial<Record<string, SeasonalHubSpec>> = {
+  // 総監・建設部門は 2026 筆記が 7 月中旬 → 7/14 で直前(R8予想)→旗艦へ
+  'pe-comprehensive-management': { switchUtcMs: Date.UTC(2026, 6, 14), before: 'r8-essay-forecast', after: 'essay-complete-pack' },
+  'pe-construction': { switchUtcMs: Date.UTC(2026, 6, 14), before: 'pe-construction-required-magazine', after: 'pe-construction-required-magazine' },
+  // 1・2 級土木の note 商品は二次(10 月上旬)向け → 10/5 で直前(暗記)→まるごと/バンクへ
+  'civil-construction-1': { switchUtcMs: Date.UTC(2026, 9, 5), before: 'civil-1-anki-note', after: 'civil-1-niji-marugoto-pack' },
+  'civil-construction-2': { switchUtcMs: Date.UTC(2026, 9, 5), before: 'civil-2-anki-note', after: 'civil-2-koji-bank' },
+};
+
+export function resolveSeasonalHubMagazine(category: string): PlacementSlot | null {
+  const spec = SEASONAL_HUB[category];
+  if (!spec) return null;
+  const beforeExam = Date.now() < spec.switchUtcMs;
+  return {
+    magazineId: beforeExam ? spec.before : spec.after,
+    utmContent: `category-${category}-seasonal-${beforeExam ? 'chokuzen' : 'flagship'}`,
+  };
+}

--- a/src/lib/next-step.ts
+++ b/src/lib/next-step.ts
@@ -1,0 +1,41 @@
+// guide（要点・概要）記事を読んだ人を「次のステップ（演習・テキスト・分野）」へ送る導線の解決。
+// href はカテゴリページの sec-* アンカー（そこに直前期の note CTA も同居＝回遊と収益導線が接続）。
+// アンカー slug は src/components/category/CategoryViews.tsx / CategorySections.tsx の section id と一致させる。
+
+export type NextStep = { label: string; hint: string; href: string };
+
+type StepSpec = { anchor: string; label: string; hint: string };
+
+const STEPS: Record<string, StepSpec[]> = {
+  'civil-construction-1': [
+    { anchor: 'primary', label: '過去問で実力をためす', hint: '年度別の第1次・第2次検定' },
+    { anchor: 'textbook', label: 'テキストで体系的に学ぶ', hint: '章立ての本文解説' },
+    { anchor: 'fields', label: '他の分野の要点を見る', hint: '出題分野別のまとめ' },
+  ],
+  'civil-construction-2': [
+    { anchor: 'primary', label: '過去問で実力をためす', hint: '年度別の第1次・第2次検定' },
+    { anchor: 'fields', label: '他の分野の要点を見る', hint: '出題分野別のまとめ' },
+  ],
+  'concrete-chief-engineer': [
+    { anchor: 'primary', label: '過去問で実力をためす', hint: '分野別の四肢択一' },
+    { anchor: 'textbook', label: 'テキストで体系的に学ぶ', hint: '章立ての本文解説' },
+  ],
+  'pe-construction': [
+    { anchor: 'pastExam', label: '過去問で答案を練習する', hint: '科目×年度の記述式' },
+    { anchor: 'keyword', label: '論点キーワードを調べる', hint: '科目別の論点集' },
+  ],
+  'pe-comprehensive-management': [
+    { anchor: 'pastExam', label: '過去問で解答戦略を試す', hint: '択一・記述の年度別' },
+    { anchor: 'keyword', label: 'キーワードを調べる', hint: '5管理×26セクションの索引' },
+  ],
+};
+
+export function resolveNextSteps(category: string): NextStep[] {
+  const steps = STEPS[category];
+  if (!steps) return [];
+  return steps.map((s) => ({
+    label: s.label,
+    hint: s.hint,
+    href: `/category/${category}#sec-${s.anchor}`,
+  }));
+}


### PR DESCRIPTION
## 背景
回遊・note 動線・転職アフィリを全面調査した結果、**note 動線とアフィリは既に成熟**（3層ファネル＋magazine-placement＋月次監査／period×A/B×1ページ1ピクセル）で、**伸びしろ最大は内部回遊**＝計測ゼロ・「次のステップ」導線欠落だった。収益エンジン（note 有料・6月¥205k）へ回遊を接続する P1-P3 を実装（P4/P5 は backlog）。

## P1: 内部回遊の GA4 計測基盤（`internal_nav_click`）
内部回遊ナビ（記事→記事の導線）は従来 `data-cta` が無く**完全に未計測**だった。
- `AnalyticsProvider`: `nav` 種別を追加。root に `data-cta` を付けても見出し等の非リンククリックを計上しないよう「実リンク(`<a>`)クリック時のみ発火」ガードを追加（既存 note/affiliate は無影響）。
- `MetaCard`: `trackNav` prop で root に `data-cta="nav"` を透過 → RelatedArticles/RelatedTextbooks/TextbookNav/PastExamBacklinks/SectionKeywords/PillarNavCard/ExamQuestionNav/CategoryNavCard(Sidebar/Mobile) を 1 prop で計測化。
- 非 MetaCard: PopularShowcase/PopularRanking/DocCard(category-card)/CurriculumList を root 直付け。
- `eventName × pagePath × label` でナビ別・ページ別クリックが取れる。

## P2: guide 記事末「次のステップ」導線（NextStepNav）
要点 guide の行き止まりを解消し、読者を過去問・テキスト・分野へ送る（リンク先はカテゴリ hub の `sec-*` アンカー＝P3 の季節 CTA と同居し**回遊と収益導線が接続**）。`src/lib/next-step.ts`（純関数）。**キャリア記事では非描画**（転職導線と非競合）。MetaCard trackNav で P1 計測に自動的に乗る。

## P3: カテゴリ hub の季節モード note CTA
最大送客源のカテゴリ hub（GA4 実測 pe-comprehensive 85click/5週）に、本文フロー（PopularShowcase 直後）へ period 連動 note CTA を 1 枚。**試験日前＝直前商品**（総監=R8予想／建設部門=必須I／1・2級土木=直前暗記）→**以降＝旗艦**へビルド時自動切替（アフィリ campaignEndUtcMs と同型）。既存 `MagazineCard`（SoT 解決・未公開 null）再利用。対象=pe-comprehensive/pe-construction/civil-1/civil-2。

## 検証
- 全ページ型 HTTP 200＋`<main>`（guide/keyword/textbook/exam-themes/category/top・pe-first-stage 回帰なし）
- guide に NextStepNav 表示・**career は非表示**・hub に季節 CTA（chokuzen）・nav 計測タグ出力
- `tsc` 0 / `lint-ui --all` 0 / `eslint` 0 / pre-commit 全通過

## スコープ外（backlog §2 に記録）
- P4: keyword-relations.json の自動レコメンド活用（PE keyword 650 面）
- P5: アフィリ EPC 判定タイムボックス（~2026-09・P1 実データ 2-4 週後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)