### PR TITLE
fix: カテゴリ hub の季節 note CTA を画像オンリーに是正

### DIFF
--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -17,7 +17,6 @@ import {
   PeConstructionView,
 } from '@/components/category/CategoryViews';
 import SidebarMagazineList from '@/components/ui/SidebarMagazineList';
-import MagazineCard from '@/components/ui/MagazineCard/MagazineCard';
 import AuthorSidebarCard from '@/components/ui/AuthorSidebarCard';
 import { resolveCategoryMagazines, resolveSeasonalHubMagazine } from '@/lib/magazine-placement';
 import { getMagazine } from '@/lib/note-magazines';
@@ -99,7 +98,9 @@ export default async function CategoryPage({
   // サイドバーは縦積みのため上位 3 マガジン（placement 優先順）に絞ってコンパクトに保つ。
   const hubMagazines = categoryMagazines.slice(0, 3);
   // 本文フロー用の季節モード CTA（試験日前=直前商品／後=旗艦・ビルド時確定）。sidebar とは別枠。
+  // サイト note CTA は画像オンリー方針（2026-06-26）のため MagazineSidebarCard 系で描画する。
   const seasonalHub = resolveSeasonalHubMagazine(slug);
+  const seasonalMagazine = seasonalHub ? getMagazine(seasonalHub.magazineId) : undefined;
   // モバイル本文中の visible バナー（pixelSrc を渡さない＝PC サイドバー側が唯一の発火源）。
   // 各案件を 1 枚ずつの node にしてビューのグループ境界に分散配置する（カードの隙間に「両方」）。
   const mobileCareerAds = careerAds.map((ad, i) => (
@@ -148,10 +149,11 @@ export default async function CategoryPage({
             </div>
           )}
           {/* 季節モード note CTA（本文フロー・最大送客源のカテゴリ hub を最適化）。直前期は直前商品、
-              試験日以降は旗艦へビルド時に自動切替。未公開なら MagazineCard が null を返す（防御）。 */}
-          {seasonalHub && (
-            <div className="mb-16 max-w-2xl">
-              <MagazineCard id={seasonalHub.magazineId} utmContent={seasonalHub.utmContent} />
+              試験日以降は旗艦へビルド時に自動切替。画像オンリー（テキストはバナー画像に焼込・sidebarImageUrl
+              が無いマガジンは SidebarMagazineList が自動除外）。 */}
+          {seasonalHub && seasonalMagazine?.sidebarImageUrl && (
+            <div className="mb-16">
+              <SidebarMagazineList magazines={[{ slot: seasonalHub, magazine: seasonalMagazine }]} />
             </div>
           )}
           {docs.length === 0 ? (


### PR DESCRIPTION
## 問題
`/category/*` の「よく読まれている記事」直下に置いた季節モード note CTA（PR #365 P3）が、記事本文用の `MagazineCard`（`MagazineInlineCard`＝画像＋タイトル/説明テキスト）を誤用しており、**サイト note CTA の「画像オンリー」方針に反していた**（テキストが表示される）。

## 方針（既存）
`SidebarMagazineList.tsx` のとおり、サイトの note 有料マガジン CTA は**画像オンリー**（文言・価格は 300×250 バナー画像に焼き込む）。テキスト併記版 `MagazineSidebarPromoCard` は 2026-06-26 に退役し画像オンリーへ統一済み。hub サイドバーも `MagazineSidebarCard` を使用。

## 修正
- 季節 CTA を `<MagazineCard>`（画像＋テキスト）→ **`<SidebarMagazineList magazines={[{slot, magazine}]}>`（画像オンリー）** に差し替え。sidebarImageUrl の無いマガジンは自動除外（防御）。
- 未使用の `MagazineCard` import を削除。

対象: `src/app/category/[slug]/page.tsx` 1ファイル。

## 検証
- 全4カテゴリ（civil-1/2・pe-comprehensive・pe-construction）で季節 CTA が**画像バナーのみ**（InlineCard の説明文なし＝line-clamp 0）・HTTP 200
- スクショで hub 直下の note CTA が「note限定」画像バナーのみに変わったことを確認
- `tsc` 0 / `lint-ui` 0 / `eslint` 0 / pre-commit 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)