### PR TITLE
feat(affiliate): ビルドジョブ露出最大化（面拡大・text/small creative・計測基盤）

### DIFF
--- a/.claude/scripts/fetch-ga4-cta-clicks.mjs
+++ b/.claude/scripts/fetch-ga4-cta-clicks.mjs
@@ -14,6 +14,10 @@
  *   npm run fetch-ga4-cta-clicks -- --days 7     # 過去7日
  *   npm run fetch-ga4-cta-clicks -- --by-device  # eventName × deviceCategory（モバイル vs PC の CTA クリック）
  *                                                #   → ga4-cta-clicks-by-device-*.json（既定の page 別とは別ファイル・downstream 非破壊）
+ *   npm run fetch-ga4-cta-clicks -- --by-label   # eventName × event_label（プログラム/面別＝BuildJob-sidebar 等）
+ *                                                #   → ga4-cta-clicks-by-label-*.json。要 GA4 カスタムディメンション
+ *                                                #     （イベントスコープ・パラメータ event_label）を先に管理画面で登録。
+ *                                                #     未登録なら API がエラー→登録手順を表示して exit 0（CI 非破壊）。
  *
  * 認証は fetch-ga4-data.mjs と同じサービスアカウント鍵（.env.local）。
  * 計測は本番（NODE_ENV=production）でのみ発火するため、デプロイ後に
@@ -32,7 +36,7 @@ const EVENT_NAMES = ["note_cta_click", "affiliate_cta_click", "note_article_clic
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const opts = { days: DEFAULT_DAYS, japanOnly: true, byDevice: false };
+  const opts = { days: DEFAULT_DAYS, japanOnly: true, byDevice: false, byLabel: false };
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
       case "--days":
@@ -46,6 +50,12 @@ function parseArgs() {
         // モバイル/PC 別の CTA クリックを取り、device 別 sessions（fetch-ga4-data --dimension device）を
         // 分母にしてデバイス別 CTR を出す。downstream（report-monetization-coverage = page 別）は非破壊。
         opts.byDevice = true;
+        break;
+      case "--by-label":
+        // pagePath の代わりに event_label（=data-cta-label＝プログラム/面）を 2 つ目の dimension に。
+        // BuildJob-sidebar / KensetsuJobs-sidebar / BuildJob-midtext / ビルドジョブ 等のプログラム×面別
+        // クリック内訳を取り、アフィリ EPC 判定（建設JOBs vs BuildJob）の分子にする。別ファイル・非破壊。
+        opts.byLabel = true;
         break;
     }
   }
@@ -104,7 +114,14 @@ async function fetchCtaClicks(client, propertyId, opts) {
     });
   }
 
-  const firstDim = opts.byDevice ? "deviceCategory" : "pagePath";
+  // event_label は GA4 のイベントスコープ カスタムディメンション（パラメータ event_label）として
+  // 管理画面で登録済みの場合のみ customEvent:event_label で取得できる（未登録なら API がエラー）。
+  const firstDim = opts.byLabel
+    ? "customEvent:event_label"
+    : opts.byDevice
+      ? "deviceCategory"
+      : "pagePath";
+  const rowKey = opts.byLabel ? "label" : opts.byDevice ? "device" : "page";
   const request = {
     property: propertyId,
     dateRanges: [{ startDate, endDate }],
@@ -117,7 +134,7 @@ async function fetchCtaClicks(client, propertyId, opts) {
 
   const [response] = await client.runReport(request);
   const rows = (response.rows || []).map((row) => ({
-    [opts.byDevice ? "device" : "page"]: row.dimensionValues?.[0]?.value || "",
+    [rowKey]: row.dimensionValues?.[0]?.value || "",
     eventName: row.dimensionValues?.[1]?.value || "",
     eventCount: parseInt(row.metricValues?.[0]?.value || "0", 10),
   }));
@@ -129,6 +146,7 @@ async function fetchCtaClicks(client, propertyId, opts) {
       eventNames: EVENT_NAMES,
       japanOnly: opts.japanOnly,
       byDevice: opts.byDevice,
+      byLabel: opts.byLabel,
       propertyId,
     },
     rows,
@@ -142,10 +160,8 @@ async function main() {
 
   if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });
   const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-  const outPath = join(
-    OUTPUT_DIR,
-    `ga4-cta-clicks${opts.byDevice ? "-by-device" : ""}-${stamp}.json`,
-  );
+  const variant = opts.byLabel ? "-by-label" : opts.byDevice ? "-by-device" : "";
+  const outPath = join(OUTPUT_DIR, `ga4-cta-clicks${variant}-${stamp}.json`);
   writeFileSync(outPath, JSON.stringify(data, null, 2));
 
   console.log(`\n期間: ${data.meta.startDate} 〜 ${data.meta.endDate}`);
@@ -166,6 +182,18 @@ async function main() {
 }
 
 main().catch((e) => {
+  // --by-label はカスタムディメンション未登録だと GA4 が「customEvent:event_label」不明で失敗する。
+  // その場合は登録手順を示して exit 0（CI の他 step を止めない・continue-on-error 前提だが明示）。
+  const msg = String(e?.message || e);
+  if (/customEvent:event_label|not.*valid.*dimension|did not match/i.test(msg)) {
+    console.warn(
+      "[fetch-ga4-cta-clicks] --by-label は GA4 カスタムディメンション未登録のためスキップ。\n" +
+        "  GA4 管理画面 → 管理 → データ表示 → カスタム定義 → カスタムディメンション作成:\n" +
+        "    範囲=イベント / イベントパラメータ=event_label / 表示名=event_label\n" +
+        "  登録後 最大 48h で反映し、以降の by-label 取得が有効になる（登録前データは遡及不可）。",
+    );
+    process.exit(0);
+  }
   console.error(e);
   process.exit(1);
 });

--- a/.claude/scripts/report-monetization-coverage.mts
+++ b/.claude/scripts/report-monetization-coverage.mts
@@ -52,7 +52,9 @@ const MIN_USERS = arg("--min-users", 15); // gap 判定の高流入しきい値
 function latest(prefix: string): string | null {
   if (!existsSync(GA4_DIR)) return null;
   const files = readdirSync(GA4_DIR)
-    .filter((f) => f.startsWith(prefix) && f.endsWith(".json"))
+    // prefix の直後が数字（日付）のものだけ＝`ga4-cta-clicks-by-device-*` / `-by-label-*` の別スキーマ
+    // ファイルを誤って拾わない（"b">"2" で sort 末尾に来て latest を乗っ取り TypeError になっていた）。
+    .filter((f) => f.startsWith(prefix) && /^\d/.test(f.slice(prefix.length)) && f.endsWith(".json"))
     .sort();
   return files.length ? join(GA4_DIR, files[files.length - 1]) : null;
 }

--- a/.claude/state/metrics/affiliate/a8-results.json
+++ b/.claude/state/metrics/affiliate/a8-results.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "A8.net アフィリ成果の月次手動スナップショット。A8 は API が無く CI 供給不能なため、A8 管理画面から月1で手入力する（クリック/成果/報酬の突合＝EPC 判定の分母）。GA4 の by-label クリック（ga4-cta-clicks-by-label-*.json）と突き合わせて、建設JOBs vs ビルドジョブ の EPC（報酬/クリック）を比較し ~2026-09 に恒久 A/B の勝者を決める（docs/todo/backlog.md P5）。GA4 側クリックが真実源＝ここは A8 の成果（発生件数・確定報酬）のみ記録。運用: docs/project/04_運営/02_アフィリエイト提携状況.md 参照。",
+  "schema": {
+    "month": "YYYY-MM（A8 レポート期間）",
+    "program": "buildjob | kensetsu-jobs | gks | dx-consulting",
+    "clicks": "A8 管理画面のクリック数（GA4 とは母数が異なりうる＝参考）",
+    "conversions": "成果発生件数（未確定含む）",
+    "approved": "承認確定件数",
+    "revenueYen": "確定報酬（円）",
+    "note": "備考（キャンペーン期間・イレギュラー等）"
+  },
+  "records": []
+}

--- a/.github/workflows/fetch-metrics.yml
+++ b/.github/workflows/fetch-metrics.yml
@@ -114,6 +114,17 @@ jobs:
           GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
         run: npm run fetch-ga4-cta-clicks -- --by-device
 
+      # アフィリ EPC 判定用: プログラム/面別（event_label）の CTA クリック内訳
+      # （BuildJob-sidebar / KensetsuJobs-sidebar / BuildJob-midtext / ビルドジョブ 等）。
+      # 要 GA4 カスタムディメンション（イベントスコープ・event_label）。未登録なら script が
+      # 手順を出して exit 0（continue-on-error でも他 step を止めない）。ga4-cta-clicks-by-label-*.json。
+      - name: Fetch GA4 (CTA clicks by label, for affiliate program/surface EPC)
+        continue-on-error: true
+        env:
+          GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ./credentials/gsc-service-account.json
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+        run: npm run fetch-ga4-cta-clicks -- --by-label
+
       # 週次 NSM スナップショット（.claude/state/weekly-metrics/YYYY-Www.json）。
       # 2026-W18 でローカル手動実行が途絶したのを CI 供給へ移行（measurement-incidents.md
       # 「計測は CI/CD 供給が正」2026-06-05）。metrics-reader が NSM+SNS流入(source別WoW)を

--- a/docs/design-system/design-system.md
+++ b/docs/design-system/design-system.md
@@ -273,7 +273,7 @@ CLAUDE.md §7 と一致:
 | note 要素の総数（footer 含む・暴走検知の緩い上限） | ≤ 30 | **機械**（旗艦ハブは意図的に多数収録＝22 程度まで） |
 | 同一 a8mat のインプレッションピクセル（`<img …0.gif?a8mat=MAT>`） | ≤ 1 /ページ | **機械**（同一 MAT 二重発火を検知。別 MAT の併置＝カテゴリ hub の補完 2 案件 は正当で許可） |
 | サイドバー note カード | 既定 1 枚（TOC 非表示 docGroup のみ 2 枚） | コード（page.tsx 導出） |
-| 本文中間 CTA（`MidArticleCta`） | 1 記事 1 個（guide/pillar/textbook・h2≥5・8,000字以上のみ） | コード（挿入条件） |
+| 本文中間 CTA（`MidArticleCta`） | 1 記事 1 個。**note/related モード**=guide/pillar/textbook・h2≥5・8,000字以上。**career モード**（転職テキスト・affiliate）=career タグ・h2≥4・2,500字以上（career 記事は 3〜4k 字で 8,000字に届かないため専用ゲート）＋ `resolveCareerTextLink` 非 null（arm A・campaign 中のみ＝arm B/9月以降は非表示） | コード（挿入条件） |
 | 記事末尾 footer カード | ≤ 7 目安（旗艦セールスハブは例外的に超過可） | 手動 |
 | AdSense 自動広告 | コードで除外指定不可 → 管理画面「広告掲載率」＋`google-auto-placed` 出現数を週次監査 | 手動 |
 

--- a/docs/project/04_運営/02_アフィリエイト提携状況.md
+++ b/docs/project/04_運営/02_アフィリエイト提携状況.md
@@ -83,6 +83,12 @@ doboku-note で扱うアフィリエイト案件の提携・申請状況・運�
 - **バナー href**: `https://px.a8.net/svt/ejp?a8mat=4B5OO5+FHBA2+5B0Y+NTZCH`
 - **バナー画像（imageSrc、300×250）**: `https://www21.a8.net/svt/bgt?aid=260605733026&wid=002&eno=01&mid=s00000024757004003000&mc=1`
 - **計測ピクセル（pixelSrc）**: `https://www15.a8.net/0.gif?a8mat=4B5OO5+FHBA2+5B0Y+NTZCH`（GKS と同じ www15 だが mat 別＝別プログラム。二重計測なし）
+
+**追加 creative（2026-07-06・露出最大化施策）** — 300×250 が置けない狭い面向け。すべて期間連動（9/1 以降 null＝面自動消滅・GKS の同サイズ mat 未提供）:
+- **本文テキストリンク（NTRMQ）**: href `https://px.a8.net/svt/ejp?a8mat=4B5OO5+FHBA2+5B0Y+NTRMQ`／文言「ビルドジョブ｜建設業界特化の転職エージェントの無料キャリア面談」。creative=`BUILDJOB_TEXT_AD`、解決=`resolveCareerTextLink(slug)`（**arm B は null**＝EPC A/B を汚さない）。career 記事の本文中間 CTA（`MidArticleCta` mode=career）。label=`BuildJob-midtext`。href のみ・PR 表記必須。
+- **120×60 小バナー（NU729）**: href `...+NU729`／imageSrc `https://www24.a8.net/svt/bgt?aid=260605733026&wid=002&eno=01&mid=s00000024757004004000&mc=1`。creative=`BUILDJOB_BANNER_120`、解決=`resolveCareerSmallBanner()`。civil-1 hub の「キャリア・転職」セクションに配置。label=`BuildJob-hubcareer`。href のみ（hub は既に 2 ピクセル発火）。
+- **100×60 小バナー（NUES1・予備）**: `affiliate-mats.json` に登録のみ（未配線）。imageSrc `https://www23.a8.net/svt/bgt?aid=260605733026&wid=002&eno=01&mid=s00000024757004005000&mc=1`。※ suffix `NUES1` は DX コンサル mat と同名だが full mat は別。
+- **計測ラベル追加**: `BuildJob-midtext`（本文中間テキスト）／`BuildJob-hubcareer`（hub 小バナー）。既存 `BuildJob-sidebar`/`ビルドジョブ`（記事末）と分離集計可（`{brand}-{surface}` 規約準拠）。
 - **creative 定数**: `src/config/affiliate-creatives.ts` の `BUILDJOB_CAREER_AD`。`SidebarAdBanner` で描画（PR バッジ・`rel="nofollow sponsored noopener"`・`loading="lazy"`・width/height は自動付与）。
 - **出し分けロジック**: 同ファイル `resolveCareerSidebarAd()` が **2026-09-01 00:00 JST（= 8/31 15:00 UTC）を境**に creative を切替（〜8/31 ビルドジョブ ¥50,000 / 9/1 以降 GKS 自動復帰）。SSG のためビルド時刻で固定 ＝ **9/1 以降の最初の本番再ビルドで自動的に GKS へ戻る**（万一再ビルドが無い場合に備え、定数を手動で `CIVIL_CAREER_AD` に戻すか revert で対応）。
 - **配置**: 全 docs サイドバー上部（位置 A）。期間中はこの 1 枠がビルドジョブの唯一のピクセル発火源。**期間中は GKS のサイドバー枠が止まるため GKS の「表示回数」計測は停止**（クリック・成果は本文インライン href 経由で従来どおり計測される）。

--- a/docs/project/04_運営/02_アフィリエイト提携状況.md
+++ b/docs/project/04_運営/02_アフィリエイト提携状況.md
@@ -355,9 +355,10 @@ A8.net は creative ごとに mat 値・ピクセル配信ドメインが異な�
 
 | 場所 | 役割 |
 |---|---|
-| A8.net 管理画面 | creative・mat 値・クリック/成果レポートの真実源。発行リンクは A8 が自動管理するため、当方側での二重記録は不要 |
+| A8.net 管理画面 | creative・mat 値・クリック/成果レポートの真実源。発行リンクは A8 が自動管理するため、当方側での**発行リンク**二重記録は不要 |
 | 本台帳（HTMLスニペット保管庫 + 提携プログラム表） | 「どの creative をどのページに配置したか」「不採用判断」など A8 にはない情報の記録 |
 | 各 MDX | 実際の埋め込み（リンク本文・文面の真実源） |
+| `.claude/state/metrics/affiliate/a8-results.json` | **A8 成果の月次手動スナップショット**（A8 は API 無し＝CI 供給不能なので月1手入力）。GA4 の `ga4-cta-clicks-by-label-*.json`（プログラム/面別クリック）と突合し EPC（報酬/クリック）を出す。建設JOBs vs ビルドジョブ の恒久 A/B 勝者判定（backlog P5・~2026-09）の分母。※発行リンクの二重記録では**ない**（成果数値のみ） |
 
 現状の A8 案件は 4 件（SAT・独学サポート・GKSキャリア・ビルドジョブ）。うち複数サーフェスで再利用する creative（転職 2 件＝GKS/ビルドジョブ、SAT の一部）は `src/config/affiliate-creatives.ts` に集約済み（`CIVIL_CAREER_AD` / `BUILDJOB_CAREER_AD` / `resolveCareerSidebarAd` / `SCHOOL_SAT`）。講座の単発リンクは各 MDX 直書き＋本保管庫で記録、という二層運用。「2 件だから専用管理は不要」という旧判断は撤回（設定ファイル集約は転職枠で既に部分実施済み）。
 

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -85,7 +85,8 @@ export default async function CategoryPage({
   // 建設JOBs（登録 ¥4,500）＋ビルドジョブ（面談 ¥50,000）の補完 2 案件を出し、読者に選ばせる。
   // PC は右サイドバーに縦積み、モバイルは記事カードの隙間（グループ境界）に配置して可視化する。
   // ピクセルは PC サイドバー側のみ発火（モバイルは href のみ）＝各プログラム 1 ピクセルずつ。
-  // 戻り値 []＝転職枠なし（concrete / pe-first-stage は単一カラム）。記事ページは別途 A/B（直交）。
+  // 戻り値 []＝転職枠なし（総監以外の非建設カテゴリのみ）。civil/建設部門/concrete/pe-first-stage は
+  // 建設業界読者ゆえ [建設JOBs, BuildJob/GKS] を返す（2026-07-06 拡大）。記事ページは別途 A/B（直交）。
   const careerAds = resolveCategoryCareerAds(slug);
   // note CTA（資格別リッチ背景×HTML文字）。幅広面はもくじへ集約、直前期は特定商品へ直リンク。
   // 本文・PC サイドバー・モバイルの 3 面に同一内容を出し、utm で面分離する（旧 上位3誌直リンクを廃止し
@@ -155,13 +156,13 @@ export default async function CategoryPage({
               ) : slug === 'civil-construction-2' ? (
                 <CivilConstruction2View groups={groups} mobileCareerAds={mobileCareerAds} />
               ) : slug === 'pe-first-stage' ? (
-                <PeFirstStageView groups={groups} />
+                <PeFirstStageView groups={groups} mobileCareerAds={mobileCareerAds} />
               ) : slug === 'pe-comprehensive-management' ? (
                 <PeComprehensiveView groups={groups} mobileCareerAds={mobileCareerAds} />
               ) : slug === 'pe-construction' ? (
-                <PeConstructionView groups={groups} />
+                <PeConstructionView groups={groups} mobileCareerAds={mobileCareerAds} />
               ) : slug === 'concrete-chief-engineer' || slug === 'concrete-diagnostician' ? (
-                <ConcreteView groups={groups} />
+                <ConcreteView groups={groups} mobileCareerAds={mobileCareerAds} />
               ) : (
                 groups.map(group => (
                   <DocSection key={group.title} group={group} />

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -34,7 +34,7 @@ import MidArticleCta from '@/components/ui/MidArticleCta/MidArticleCta';
 import { rankRelated } from '@/lib/related-score';
 import { extractReferencesSection } from '@/lib/extract-references';
 import type { Pluggable } from 'unified';
-import { resolveDocsCareerSidebarAd } from '@/config/affiliate-creatives';
+import { resolveDocsCareerSidebarAd, resolveCareerTextLink } from '@/config/affiliate-creatives';
 import type React from 'react';
 
 
@@ -333,17 +333,39 @@ export default async function DocPage({
   // 中身は「footerMagazines[0] が冒頭 CTA と別マガジンなら note、それ以外は関連記事」。
   // MDX ソースは書き換えず rehypeMidCta が <midslot> を挿し、components で MidCtaBound に解決する。
   const midH2Count = headings.filter((h) => h.level === 2).length;
+  const midBodyLen = stripLeadingH1(strippedContent).length;
   const midEligibleGroup =
     docGroup === 'guide' || docGroup === 'pillar' || docGroup === 'textbook';
-  const midEnabled =
-    midEligibleGroup && midH2Count >= 5 && stripLeadingH1(strippedContent).length >= 8000;
+  const midEnabled = midEligibleGroup && midH2Count >= 5 && midBodyLen >= 8000;
+  // career 記事（tags に career）の本文中間 転職テキスト CTA。career 記事は実測 3〜4k 字で上の
+  // midEnabled（8,000字）に届かないため、専用の軽いゲートで拾う（h2>=4・>=2,500字）。
+  // ただし既に本文へ inline <CareerAffiliate> カードがある記事は二重表示になるため除外し、
+  // 「本文に転職導線が無い career 記事」だけを埋める（＝各 career 記事の本文導線は 1 個に保つ）。
+  // resolveCareerTextLink は arm B / campaign 終了時に null＝面ごと自動非表示（EPC A/B 非汚染）。
+  const isCareerArticle =
+    docGroup === 'guide' && Array.isArray(doc.meta.tags) && doc.meta.tags.includes('career');
+  const hasInlineCareerCard = /\bCareerAffiliate\b/.test(strippedContent);
+  const careerMidLink =
+    isCareerArticle && !hasInlineCareerCard && midH2Count >= 4 && midBodyLen >= 2500
+      ? resolveCareerTextLink(slugStr)
+      : null;
   // 中間（floor(h2/2)）だが最終 h2（まとめ）直前は避ける
-  const midCtaPosition = midEnabled
+  const midCtaPosition = (midEnabled || careerMidLink)
     ? Math.min(Math.floor(midH2Count / 2), midH2Count - 2)
     : undefined;
 
   let MidCtaBound: (() => React.ReactElement) | null = null;
-  if (midEnabled) {
+  if (careerMidLink) {
+    // career 記事は最優先で転職テキスト CTA（footerMagazines は career-only で空＝note は元々出ない）。
+    MidCtaBound = () => (
+      <MidArticleCta
+        mode="career"
+        href={careerMidLink.href}
+        text={careerMidLink.text}
+        trackLabel={careerMidLink.trackLabel}
+      />
+    );
+  } else if (midEnabled) {
     const midNote = footerMagazines[0];
     const midNoteMag = midNote?.magazine;
     const differsFromTop = midNoteMag && (!topSlot || topSlot.magazineId !== midNote.slot.magazineId);

--- a/src/components/category/CategoryViews.tsx
+++ b/src/components/category/CategoryViews.tsx
@@ -143,7 +143,7 @@ export function CivilConstruction2View({ groups, mobileCareerAds = [] }: { group
 }
 
 /** concrete-chief-engineer / concrete-diagnostician: 受験ガイド＋テキスト章目次＋分野別過去問をリスト化（共用） */
-export function ConcreteView({ groups }: { groups: DocGroup[] }) {
+export function ConcreteView({ groups, mobileCareerAds = [] }: { groups: DocGroup[]; mobileCareerAds?: ReactNode[] }) {
   const guideGroup = groups.find(g => g.key === 'guide');
   const textbookGroup = groups.find(g => g.key === 'textbook');
   const primaryGroup = groups.find(g => g.key === 'primary');
@@ -162,6 +162,7 @@ export function ConcreteView({ groups }: { groups: DocGroup[] }) {
           <CurriculumList blocks={[{ docs: examGuideDocs }]} />
         </CurriculumSection>
       )}
+      {mobileCareerAds[0]}
       {chapters.length > 0 && (
         <CurriculumSection id="textbook" title={textbookGroup?.title ?? 'テキスト'} description={textbookGroup?.description} count={textbookCount}>
           <CurriculumList blocks={chapters} numbered />
@@ -172,18 +173,21 @@ export function ConcreteView({ groups }: { groups: DocGroup[] }) {
           <CurriculumList blocks={[{ docs: primaryGroup.docs }]} numbered />
         </CurriculumSection>
       )}
+      {mobileCareerAds[1]}
     </>
   );
 }
 
 /** pe-first-stage: 適性・基礎・専門マトリクス */
-export function PeFirstStageView({ groups }: { groups: DocGroup[] }) {
+export function PeFirstStageView({ groups, mobileCareerAds = [] }: { groups: DocGroup[]; mobileCareerAds?: ReactNode[] }) {
   const primaryGroup = groups.find(g => g.title === getGroupLabel('pe-first-stage', 'primary'));
   return (
     <>
       {primaryGroup && (
         <DocSection group={primaryGroup} layout="pe-first-stage-table" />
       )}
+      {/* セクションが1個のためテーブル後ろに転職枠を配置（モバイル・href のみ）。 */}
+      {mobileCareerAds[0]}
     </>
   );
 }
@@ -252,7 +256,7 @@ export function PeComprehensiveView({ groups, mobileCareerAds = [] }: { groups: 
 }
 
 /** pe-construction: 受験ガイド＋論文の書き方をリスト化、キーワード・科目×年度マトリクスは維持 */
-export function PeConstructionView({ groups }: { groups: DocGroup[] }) {
+export function PeConstructionView({ groups, mobileCareerAds = [] }: { groups: DocGroup[]; mobileCareerAds?: ReactNode[] }) {
   const guideGroup = groups.find(g => g.key === 'guide');
   const keywordGroup = groups.find(g => g.key === 'keyword');
   const pastExamGroup = groups.find(g => g.key === 'pastExam');
@@ -273,10 +277,12 @@ export function PeConstructionView({ groups }: { groups: DocGroup[] }) {
           <CurriculumList blocks={curriculum.fields.blocks} />
         </CurriculumSection>
       )}
+      {mobileCareerAds[0]}
       {keywordGroup && <DocSection group={keywordGroup} />}
       {pastExamGroup && (
         <DocSection group={pastExamGroup} layout="pe-construction-exam-table" />
       )}
+      {mobileCareerAds[1]}
       <CareerSection
         featured={curriculum.career.featured}
         rest={curriculum.career.rest}

--- a/src/components/category/CategoryViews.tsx
+++ b/src/components/category/CategoryViews.tsx
@@ -5,6 +5,7 @@ import { type DocGroup } from '@/lib/category-groups';
 import { DocSection } from '@/components/category/CategorySections';
 import { resolveCurriculum, resolveTextbookChapters } from '@/lib/category-curriculum';
 import { CurriculumSection, CurriculumList, CareerSection } from '@/components/category/CurriculumSections';
+import { resolveCareerSmallBanner } from '@/config/affiliate-creatives';
 
 /** civil-construction-1: 受験ガイド＋分野別＋テキスト章目次をリスト化、過去問はテーブル維持 */
 export function CivilConstruction1View({ groups, mobileCareerAds = [] }: { groups: DocGroup[]; mobileCareerAds?: ReactNode[] }) {
@@ -70,6 +71,7 @@ export function CivilConstruction1View({ groups, mobileCareerAds = [] }: { group
         featured={curriculum.career.featured}
         rest={curriculum.career.rest}
         description="年収・転職・キャリアパス・働き方の実務ガイド"
+        smallBanner={resolveCareerSmallBanner()}
       />
     </>
   );

--- a/src/components/category/CurriculumSections.tsx
+++ b/src/components/category/CurriculumSections.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import { type DocMeta } from '@/lib/docs';
 import { DocCard } from '@/components/category/CategorySections';
+import { AFFILIATE_LINK_REL, AffiliatePrBadge } from '@/components/ui/AffiliateParts';
+import { type SmallBannerCreative } from '@/config/affiliate-creatives';
 
 // カテゴリページの「体系（受験ガイド / 分野別 / テキスト章）」をテキスト目次調のリストで見せる共有コンポーネント群。
 // カード（DocCard）でなくリストにすることで、章立て・出題分野の体系が一目で分かり情報密度を上げる。
@@ -169,11 +171,14 @@ export function CareerSection({
   rest,
   title = 'キャリア・転職',
   description,
+  smallBanner = null,
 }: {
   featured: DocMeta[];
   rest: DocMeta[];
   title?: string;
   description?: string | undefined;
+  /** 転職アフィリの小バナー（120×60・href のみ）。campaign 中のみ非 null。 */
+  smallBanner?: SmallBannerCreative | null;
 }) {
   if (featured.length === 0 && rest.length === 0) return null;
   return (
@@ -189,6 +194,31 @@ export function CareerSection({
         </div>
       )}
       {rest.length > 0 && <CurriculumList blocks={[{ docs: rest }]} />}
+      {smallBanner && (
+        // 転職アフィリ小バナー（PR 表記・href のみ・width/height 属性で自然サイズ＝引き伸ばしなし）。
+        // 計測ピクセルは持たない（hub のサイドバー枠が発火源）。景表法: rel=nofollow sponsored。
+        <div className="mt-6 flex items-center gap-2">
+          <AffiliatePrBadge />
+          <a
+            href={smallBanner.href}
+            target="_blank"
+            rel={AFFILIATE_LINK_REL}
+            data-cta="affiliate"
+            data-cta-label={smallBanner.trackLabel}
+            className="inline-block"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element -- A8 外部バナーは next/image 不可 */}
+            <img
+              src={smallBanner.imageSrc}
+              alt={smallBanner.alt}
+              width={smallBanner.width}
+              height={smallBanner.height}
+              loading="lazy"
+              className="block"
+            />
+          </a>
+        </div>
+      )}
     </CurriculumSection>
   );
 }

--- a/src/components/ui/ArticleFooter/ArticleFooter.tsx
+++ b/src/components/ui/ArticleFooter/ArticleFooter.tsx
@@ -177,12 +177,16 @@ export default function ArticleFooter({
         </div>
       )}
 
-      {/* 記事末 転職 CTA（モバイル限定・civil 1/2 + 建設部門・FAQ 直後）。href のみ＝計測はサイドバー側 1 発火を維持。
+      {/* 記事末 転職 CTA（モバイル限定・施工管理/建設業界カテゴリ・FAQ 直後）。href のみ＝計測はサイドバー側 1 発火を維持。
           creative は resolveCareerArticleEndCard が slug ハッシュ A/B（建設JOBs ↔ ビルドジョブ/GKS）で出し分け。
-          slugStr をサイドバーと共有＝同一ページは PC サイドバーと記事末カードが必ず同じ案件になる。 */}
+          slugStr をサイドバーと共有＝同一ページは PC サイドバーと記事末カードが必ず同じ案件になる。
+          concrete/pe-first-stage も建設業界読者ゆえ 2026-07-06 に parity 追加（モバイル収益化）。 */}
       {(category === 'civil-construction-1' ||
         category === 'civil-construction-2' ||
-        category === 'pe-construction') && (
+        category === 'pe-construction' ||
+        category === 'concrete-chief-engineer' ||
+        category === 'concrete-diagnostician' ||
+        category === 'pe-first-stage') && (
         <div className="mt-8 zenn-desktop:hidden">
           <CareerAffiliate {...resolveCareerArticleEndCard(slugStr)} />
         </div>

--- a/src/components/ui/MidArticleCta/MidArticleCta.tsx
+++ b/src/components/ui/MidArticleCta/MidArticleCta.tsx
@@ -1,13 +1,15 @@
 import type { DocMeta } from '@/lib/docs';
 import MagazineInlineCard from '@/components/ui/MagazineInlineCard/MagazineInlineCard';
 import RelatedArticleCard from '@/components/ui/RelatedArticles/RelatedArticleCard';
+import { AFFILIATE_LINK_REL, AffiliatePrBadge } from '@/components/ui/AffiliateParts';
 
 /**
  * MidArticleCta — 長文記事の中間 h2 境界に 1 個だけ挿入する文脈連動 CTA。
  * rehype-mid-cta が置いた <midslot> を page.tsx の components マップで解決する。
  *
- * 2 モード（page.tsx 側で択一決定・props で渡す）:
+ * 3 モード（page.tsx 側で択一決定・props で渡す）:
  *  - note モード: MagazineInlineCard（横長・本文中用）。utmContent は -mid 済み。
+ *  - career モード: 転職アフィリのテキスト CTA（career 記事のみ・PR 表記＋href のみ）。
  *  - related モード: RelatedArticleCard（OGP サムネ）1 枚に「この続きに読みたい」見出し。
  */
 type MidArticleCtaProps =
@@ -18,6 +20,12 @@ type MidArticleCtaProps =
       readonly description: string;
       readonly magazineId: string;
       readonly badge: string;
+      readonly trackLabel: string;
+    }
+  | {
+      readonly mode: 'career';
+      readonly href: string;
+      readonly text: string;
       readonly trackLabel: string;
     }
   | {
@@ -36,6 +44,26 @@ export default function MidArticleCta(props: MidArticleCtaProps) {
         badge={props.badge}
         trackLabel={props.trackLabel}
       />
+    );
+  }
+  if (props.mode === 'career') {
+    // 転職アフィリのテキスト CTA（career 記事の本文中間・href のみ＝計測はサイドバー1発火）。
+    // 景表法: PR 表記・rel="nofollow sponsored"・表示文言は A8 公式テキスト（¥表記なし）。
+    return (
+      <div className="not-prose my-8 max-w-2xl rounded-card-content border border-[var(--rule-soft)] bg-[var(--accent-fill)] px-4 py-3.5">
+        <AffiliatePrBadge className="mb-1.5" />
+        <a
+          href={props.href}
+          target="_blank"
+          rel={AFFILIATE_LINK_REL}
+          data-cta="affiliate"
+          data-cta-label={props.trackLabel}
+          className="group inline-flex items-center gap-1 text-[14px] sm:text-[15px] font-bold text-[var(--accent)] hover:underline"
+        >
+          {props.text}
+          <span aria-hidden className="transition-transform group-hover:translate-x-0.5">›</span>
+        </a>
+      </div>
     );
   }
   return (

--- a/src/config/affiliate-creatives.ts
+++ b/src/config/affiliate-creatives.ts
@@ -284,12 +284,13 @@ export function resolvePeConsultingArticleEndCard(): CareerArticleEndCard {
  * 受験者層に creative をセグメントする（戻り値 null = 転職枠なし＝単一カラム）。
  * page.tsx の careerSidebar 判定（ゲート）も兼ねる。
  *
- * - civil-1 / civil-2 / pe-construction（施工管理・建設業界）→ `resolveCareerSidebarAd()`（期間で BuildJob ↔ GKS）。
- *   pe-construction（建設部門）も BuildJob 適合のため 2026-06-26 にカテゴリ枠を追加（docs は被覆済みだった）。
+ * - civil-1 / civil-2 / pe-construction / concrete 系 / pe-first-stage（施工管理・建設業界エンジニア）
+ *   → `[建設JOBs, resolveCareerSidebarAd()]`（期間で BuildJob ↔ GKS）。concrete（コンクリート主任/診断士）と
+ *   pe-first-stage（技術士一次＝建設部門志望が主）も建設業界読者ゆえ 2026-07-06 に枠を追加（露出最大化）。
  * - pe-comprehensive-management（総監＝シニア技術者・管理職層）→ ハイクラス DX/コンサル転職
  *   （`PE_CONSULTING_CAREER_AD`）。GKS の「20代未経験/施工管理」ミスマッチを解消（2026-06-16 差替）。
  *   GA4 流入 2 位の高トラフィックページの収益導線ゼロも解消。
- * - それ以外（concrete 系 / pe-first-stage）→ null（カテゴリ hub に転職枠なし）。
+ * - それ以外 → null（カテゴリ hub に転職枠なし）。
  *
  * 真実源: docs/project/04_運営/02_アフィリエイト提携状況.md。
  */
@@ -302,7 +303,10 @@ export function resolveCategoryCareerAds(
   if (
     category === "civil-construction-1" ||
     category === "civil-construction-2" ||
-    category === "pe-construction"
+    category === "pe-construction" ||
+    category === "concrete-chief-engineer" ||
+    category === "concrete-diagnostician" ||
+    category === "pe-first-stage"
   ) {
     // カテゴリ hub は低意図のブラウジング文脈。建設JOBs（登録 ¥4,500）とビルドジョブ（面談 ¥50,000）は
     // 行動が異なる**補完案件**（代替でない＝A8 は別プログラムで別々に成果課金）ため、A/B で 1 つに

--- a/src/config/affiliate-creatives.ts
+++ b/src/config/affiliate-creatives.ts
@@ -79,6 +79,30 @@ const KENSETSU_JOBS_CAREER_AD = {
   height: 250,
 } as const;
 
+/**
+ * ビルドジョブ 本文テキストリンク（NTRMQ）。300×250 バナーが置けない狭い面（記事中間）に
+ * テキストで露出するための creative。文言は A8 発行の公式テキスト（景表法整合・¥表記なし）。
+ * href のみ（計測ピクセルなし）。note 用テキストリンク（NTJWY）とは別 mat（サイト用）。
+ */
+const BUILDJOB_TEXT_AD = {
+  href: "https://px.a8.net/svt/ejp?a8mat=4B5OO5+FHBA2+5B0Y+NTRMQ",
+  text: "ビルドジョブ｜建設業界特化の転職エージェントの無料キャリア面談",
+} as const;
+
+/**
+ * ビルドジョブ 120×60 小バナー（NU729）。カテゴリ hub の「キャリア・転職」セクションなど、
+ * 300×250 では大きすぎる面に置く小型バナー。href のみ（ピクセルなし）。
+ * ※ 100×60（NUES1）も affiliate-mats.json に登録済み（別サイズが要るとき用の予備）。
+ */
+const BUILDJOB_BANNER_120 = {
+  href: "https://px.a8.net/svt/ejp?a8mat=4B5OO5+FHBA2+5B0Y+NU729",
+  imageSrc:
+    "https://www24.a8.net/svt/bgt?aid=260605733026&wid=002&eno=01&mid=s00000024757004004000&mc=1",
+  alt: "建設業界特化 転職エージェント ビルドジョブ",
+  width: 120,
+  height: 60,
+} as const;
+
 /** FNV-1a 32bit ハッシュ。slug 単位で決定論的に A/B を振り分ける（同じページは常に同じ arm＝SSG 安定）。 */
 function fnv1a(s: string): number {
   let h = 0x811c9dc5;
@@ -120,13 +144,21 @@ function resolveCareerSidebarAbArm(slug: string | undefined): {
  *     「表示回数」は計測されなくなる（クリック・成果は href 経由で従来どおり計測される）。
  * 人間向け真実源: docs/project/04_運営/02_アフィリエイト提携状況.md
  */
+/**
+ * ビルドジョブ増額キャンペーン期間中か（ビルド時=SSG 評価）。
+ * 2026-09-01 00:00 JST = 2026-08-31 15:00 UTC（月は 0 始まりのため 8 月 = 7）以降 false。
+ * 9/1 以降の最初の本番再ビルドで、ビルドジョブ依存の面（サイドバー/テキスト/小バナー）が
+ * 自動的に GKS 復帰 or 非表示になる。全アフィリ resolver が共有する単一の期間境界。
+ */
+function isCampaignActive(): boolean {
+  return Date.now() < Date.UTC(2026, 7, 31, 15, 0, 0);
+}
+
 function resolveCareerSidebarAd(): {
   creative: SidebarAdCreative;
   trackLabel: string;
 } {
-  // 2026-09-01 00:00 JST = 2026-08-31 15:00 UTC（月は 0 始まりのため 8 月 = 7）
-  const campaignEndUtcMs = Date.UTC(2026, 7, 31, 15, 0, 0);
-  if (Date.now() < campaignEndUtcMs) {
+  if (isCampaignActive()) {
     return { creative: BUILDJOB_CAREER_AD, trackLabel: "BuildJob-sidebar" };
   }
   return { creative: CIVIL_CAREER_AD, trackLabel: "GKS-sidebar" };
@@ -283,4 +315,59 @@ export function resolveCategoryCareerAds(
     ];
   }
   return [];
+}
+
+/** 本文中間テキスト CTA の型（career 記事用・href のみ・ピクセルなし）。 */
+export type CareerTextLink = {
+  readonly href: string;
+  readonly text: string;
+  readonly trackLabel: string;
+};
+
+/**
+ * career 記事の本文中間テキスト CTA を解決する（2026-07・ビルドジョブ増額キャンペーン限定）。
+ * 300×250 バナーが置けない本文フローに、テキストリンクで露出する（テキストは一般にバナーより CTR 高）。
+ * - arm B（建設JOBs slug ハッシュ）: **null**。建設JOBs のテキスト mat が無く、arm B に別ブランドの
+ *   テキストを混ぜると恒久 A/B の EPC 比較が汚れるため、面を出さず related fallback に委ねる。
+ * - arm A かつ campaign 中: ビルドジョブ テキストリンク（NTRMQ）。label=BuildJob-midtext。
+ * - 2026-09-01 以降: null（GKS のテキスト mat 未提供＝面ごと自動消滅）。
+ * href のみ（1 ページ 1 ピクセル維持）。表示側で PR 開示を必ず付ける。
+ */
+export function resolveCareerTextLink(slug?: string): CareerTextLink | null {
+  if (isKensetsuJobsArm(slug)) return null;
+  if (isCampaignActive()) {
+    return {
+      href: BUILDJOB_TEXT_AD.href,
+      text: BUILDJOB_TEXT_AD.text,
+      trackLabel: "BuildJob-midtext",
+    };
+  }
+  return null;
+}
+
+/** hub キャリアセクション用の小バナー creative 型（href のみ・ピクセルなし）。 */
+export type SmallBannerCreative = {
+  readonly href: string;
+  readonly imageSrc: string;
+  readonly alt: string;
+  readonly width: number;
+  readonly height: number;
+  readonly trackLabel: string;
+};
+
+/**
+ * カテゴリ hub の「キャリア・転職」セクションに置く小バナー（120×60）を解決する。
+ * campaign 中のみ返す（9/1 以降 null＝GKS 小バナー mat 未提供）。href のみ（hub は既に
+ * 建設JOBs＋BuildJob の 2 ピクセルを発火中のため、この小バナーはピクセルを持たない）。
+ */
+export function resolveCareerSmallBanner(): SmallBannerCreative | null {
+  if (!isCampaignActive()) return null;
+  return {
+    href: BUILDJOB_BANNER_120.href,
+    imageSrc: BUILDJOB_BANNER_120.imageSrc,
+    alt: BUILDJOB_BANNER_120.alt,
+    width: BUILDJOB_BANNER_120.width,
+    height: BUILDJOB_BANNER_120.height,
+    trackLabel: "BuildJob-hubcareer",
+  };
 }

--- a/src/config/affiliate-mats.json
+++ b/src/config/affiliate-mats.json
@@ -28,6 +28,33 @@
       "note": "note.com は外部 ASP バナー不可のため A8「リンク先URLコピー」URL を URL 単独行で貼りリンクカード化（A8 公式手順）。景表法のため PR 表記を併記。check-affiliate-mats は docs/note を走査しないため本登録はゲート対象外＝SSOT 衛生目的。注意: note 記事は静的で、サイトの resolveCareerSidebarAd のような期間自動復帰が効かない。8/31 の ¥50,000 キャンペーン終了後は手動で見直す（リンクは生き続けるが報酬が通常レートに戻る）。"
     },
     {
+      "mat": "4B5OO5+FHBA2+5B0Y+NTRMQ",
+      "program": "buildjob",
+      "label": "ビルドジョブ（建設業界特化 転職エージェント）／本文テキストリンク",
+      "surfaces": ["inline"],
+      "definedIn": "src/config/affiliate-creatives.ts (BUILDJOB_TEXT_AD / resolveCareerTextLink)",
+      "expiresAt": "2026-08-31",
+      "note": "career 記事の本文中間テキスト CTA（MidArticleCta mode=career）。テキストはバナーより CTR 高。arm B（建設JOBs slug）は null＝EPC A/B を汚さない。9/1 以降 null（GKS テキスト mat なし＝面自動消滅）。href のみ・PR 表記必須。label=BuildJob-midtext。"
+    },
+    {
+      "mat": "4B5OO5+FHBA2+5B0Y+NU729",
+      "program": "buildjob",
+      "label": "ビルドジョブ（建設業界特化 転職エージェント）／120×60 小バナー",
+      "surfaces": ["inline"],
+      "definedIn": "src/config/affiliate-creatives.ts (BUILDJOB_BANNER_120 / resolveCareerSmallBanner)",
+      "expiresAt": "2026-08-31",
+      "note": "カテゴリ hub「キャリア・転職」セクションの小バナー（300×250 が大きすぎる面用）。href のみ（hub は既に 2 ピクセル発火中）。9/1 以降 null。label=BuildJob-hubcareer。"
+    },
+    {
+      "mat": "4B5OO5+FHBA2+5B0Y+NUES1",
+      "program": "buildjob",
+      "label": "ビルドジョブ（建設業界特化 転職エージェント）／100×60 小バナー（予備・未配線）",
+      "surfaces": ["inline"],
+      "definedIn": "未配線（別サイズが要るとき用の予備。suffix NUES1 は DX コンサル mat と同名だが full mat は別）",
+      "expiresAt": "2026-08-31",
+      "note": "A8 発行の 100×60 小バナー。現状はコード未使用（120×60=NU729 を hub に配線）。将来別面で使う場合に creative 化。DX コンサルの 4B5OO5+NTCZ6+4SXU+NUES1 とは先頭 program 部が異なる別 mat。"
+    },
+    {
       "mat": "4B5OO5+NTCZ6+4SXU+NUES1",
       "program": "dx-consulting",
       "label": "ハイクラス DX・コンサル転職（技術士/総監 シニア層向け）",


### PR DESCRIPTION
## 背景

ビルドジョブ（A8・建設転職）が **〜2026-08-31 は ¥50,000/件 の増額キャンペーン**（9/1 に GKS 自動復帰）＝8週間の期限付き施策。サイト内の露出面を最大化し、アフィリ計測基盤を整える。学習面=note独占・総監=DX単独・1ページ1ピクセル・景表法は不変の制約。

## 変更（C1-C5・すべて period 設計で 9/1 に自動消滅/GKS復帰）

- **C1 creatives**: ビルドジョブ text(NTRMQ)/120×60 banner(NU729) 追加＋mats登録。`isCampaignActive()` 共有化、`resolveCareerTextLink`（arm B=null で EPC A/B 非汚染）/`resolveCareerSmallBanner`。
- **C2 面拡大**: concrete-chief/diagnostician/pe-first-stage/pe-construction の hub（show-both）＋モバイル記事末カードを追加（従来ゼロ→4 hub で BuildJob+建設JOBs 描画確認）。
- **C3 career mid CTA**: career 記事の本文に転職導線が無いものへテキスト CTA（inline カードがある記事は二重回避で除外）。arm A・campaign 中のみ。
- **C4 hub 小バナー**: civil-1 hub キャリアセクションに 120×60（PR 表記・非引き伸ばし・href のみ）。
- **C5 計測**: coverage レポートの `latest()` 無音バグ修正（06-20 から死んでいた）＋ `--by-label`（プログラム/面別クリック）＋ a8-results.json（EPC 判定の分母）。

## 検証

- type-check / lint-ui / check-affiliate-mats / check-affiliate-prose green（各コミット）
- dev 実測: 4 hub の career 枠描画・career mid CTA（arm A で発火/inline カードで抑止）・hub 小バナー（スクショ）
- ピクセルは show-both で各プログラム1発火（同一 mat 二重発火なし）

## 要ユーザー操作（計測）

GA4 管理画面でイベントスコープのカスタムディメンション（parameter=`event_label`）を登録（コード代替不可・遡及なし・反映〜48h）。登録前は by-label が手順表示でスキップ。

## 別途（この PR 外）

- note 展開（既存6記事強化＋新規2-3本）は develop 直（content）で別途。
- 9/1 GKS 自動復帰は 9月最初の本番ビルドで発効（SSG）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
