### PR TITLE
feat(admin): 運営管理画面ローカルサーバー Phase0-2（ギャラリー+SNS状態板）

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
       "port": 3020
+    },
+    {
+      "name": "admin",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "admin"],
+      "port": 3021
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "node scripts/install-pre-commit.mjs",
     "predev": "node scripts/kill-port.mjs 3020",
     "dev": "next dev -p 3020",
+    "admin": "node scripts/kill-port.mjs 3021 && node tools/admin/server.mjs",
     "build-backlinks": "node .claude/skills/quality/exam-backlinks/scripts/build-exam-backlinks.mjs",
     "build-indexes": "node .claude/scripts/build-doc-meta-index.mjs && node .claude/scripts/build-cross-exam-keyword-index.mjs && node .claude/scripts/build-tag-index.mjs",
     "build-keyword-relations": "node .claude/skills/quality/exam-backlinks/scripts/build-keyword-relations.mjs",

--- a/tools/admin/README.md
+++ b/tools/admin/README.md
@@ -11,7 +11,7 @@ npm run admin        # → http://127.0.0.1:3021
 
 `127.0.0.1` バインドのみ（LAN 非公開）。依存追加ゼロ（node:http のみ）。
 
-## タブ（Phase 0〜2 実装済み）
+## タブ（Phase 0〜3 実装済み）
 
 | タブ | 内容 | データソース |
 |---|---|---|
@@ -20,8 +20,18 @@ npm run admin        # → http://127.0.0.1:3021
 | note画像 | カバー / 図版（試験×種別フィルタ） | `docs/note/**/img/{cover*,figure-*}.png` |
 | SNSパック | IG パック・X ドラフトの画像目視 + posted バッジ | `docs/sns/instagram/**`、`docs/sns/x/draft/**` |
 | SNS状態板 | IG 進捗サマリ・X 予約状況・直近スケジュール（読み取り専用） | `docs/sns/schedule.json`、posted.json、x status.json |
+| 投稿/予約 | X 4ステップパイプライン・IG 予約投稿・note 公開（2段階UI + SSEログ） | 既存 CLI を child_process 実行（`lib/jobs.mjs`） |
 
 件数は既存ギャラリースクリプト（`ogp-gallery` / `note-cover-gallery` / `svg-gallery`）と一致する。
+
+## 投稿/予約タブ（Phase 3）の安全設計
+
+- **ホワイトリストのみ実行**（`lib/jobs.mjs` の `ACTIONS`）: `ig-mark` / `ig-unmark` / `x-guard` / `x-publish` / `x-sync` / `ig-publish` / `note-publish`。任意コマンドは走らない。
+- **引数は厳格検証 + shell なし**: pack/draft/date/format を正規表現で検証し、`spawn(shell:false)` の配列引数（シェル連結しない）。最終ガードで metachar/`..` を拒否。
+- **本番(commit)は明示フラグ必須**: `mode!=='commit'` の間は投稿系に `--dry-run` を強制付与。UI は dry-run/ガード成功まで本番ボタンを disabled にし、実行時は対象名タイプ確認。
+- **X は 4 ステップ固定**: `x-schedule-guard`（BLOCK 判定）→ dry-run → 本番 → `x-sync-status`（予約→posted 昇格の偽成功検証）。
+- **同時 1 ジョブ**（Playwright SingletonLock 対策）。ログは SSE ストリーム。
+- **CSRF ガード**: POST は `Origin=127.0.0.1` 検査 + `X-Admin: 1` ヘッダ必須（drive-by POST を遮断）。
 
 ## 設計方針
 
@@ -34,15 +44,15 @@ npm run admin        # → http://127.0.0.1:3021
 
 ```
 tools/admin/
-  server.mjs         node:http ルーター（/ + /media/* + /api/*）
+  server.mjs         node:http ルーター（/ + /media/* + /api/* + POST /api/job/*）
   lib/media.mjs      /media/* パスマッピング + traversal ガード + MIME allowlist
   lib/scan.mjs       ギャラリー走査（ogp / figures / note / sns）
   lib/sot.mjs        SNS 状態板の SoT 統合
+  lib/jobs.mjs       投稿アクションのホワイトリスト実行 + 引数検証 + SSE（P3）
   public/            Vanilla JS SPA（no-build）
 ```
 
 ## 未実装（ロードマップ）
 
-- P3 投稿/予約アクション（child_process + SSE ログ + 2 段階 UI + X 偽成功検証）
 - P4 記事/note/マガジン一覧（doc-meta-index / note-magazines）
 - P5 売上ダッシュボード（sales-log + 月次チャート）

--- a/tools/admin/README.md
+++ b/tools/admin/README.md
@@ -1,0 +1,48 @@
+# tools/admin — 運営管理画面（ローカル専用）
+
+SNS 投稿・記事画像・note カバーを目視確認し、投稿状態を一覧する**ローカル専用**ダッシュボード。
+デプロイしない（運用コスト 0 円）。データ SoT は git 作業ツリー内ファイルを直読。
+
+## 起動
+
+```bash
+npm run admin        # → http://127.0.0.1:3021
+```
+
+`127.0.0.1` バインドのみ（LAN 非公開）。依存追加ゼロ（node:http のみ）。
+
+## タブ（Phase 0〜2 実装済み）
+
+| タブ | 内容 | データソース |
+|---|---|---|
+| OGP | 全 ogp.png（資格×分類フィルタ） | `.local/r2/posts/**/ogp.png` |
+| 記事図版 | SVG / PNG・WebP クロップ（監査 severity バッジ） | `.local/r2/posts/**/img/*`、`.claude/state/svg-audit.json` |
+| note画像 | カバー / 図版（試験×種別フィルタ） | `docs/note/**/img/{cover*,figure-*}.png` |
+| SNSパック | IG パック・X ドラフトの画像目視 + posted バッジ | `docs/sns/instagram/**`、`docs/sns/x/draft/**` |
+| SNS状態板 | IG 進捗サマリ・X 予約状況・直近スケジュール（読み取り専用） | `docs/sns/schedule.json`、posted.json、x status.json |
+
+件数は既存ギャラリースクリプト（`ogp-gallery` / `note-cover-gallery` / `svg-gallery`）と一致する。
+
+## 設計方針
+
+- **投稿系はローカル実行必須**: Playwright ログインプロファイル（`.local/playwright-*-profile`）がこの PC にあるため。クラウドにデプロイしても投稿・書き込み不可。
+- **書き込みは既存 CLI 経由に一本化**（Phase 3 以降）: `scripts/ig-status.mjs mark`、`note-publish.mjs`、publish-x 系を child_process 実行。ガード（`--commit` ゲート・dobokunote assert）を UI から迂回させない。直接 fs 書き込みはしない。
+- **走査ロジックは既存資産を再利用**: `ig-status.mjs` の export（`walkPacks`/`packInfo`/`normalizePosted`）を import、ギャラリー走査は既存 `.tmp` ギャラリーの移植。
+- `tools/` は eslint / tsc / knip / next build のどのスコープにも入らない（CI 影響ゼロ）。
+
+## 構成
+
+```
+tools/admin/
+  server.mjs         node:http ルーター（/ + /media/* + /api/*）
+  lib/media.mjs      /media/* パスマッピング + traversal ガード + MIME allowlist
+  lib/scan.mjs       ギャラリー走査（ogp / figures / note / sns）
+  lib/sot.mjs        SNS 状態板の SoT 統合
+  public/            Vanilla JS SPA（no-build）
+```
+
+## 未実装（ロードマップ）
+
+- P3 投稿/予約アクション（child_process + SSE ログ + 2 段階 UI + X 偽成功検証）
+- P4 記事/note/マガジン一覧（doc-meta-index / note-magazines）
+- P5 売上ダッシュボード（sales-log + 月次チャート）

--- a/tools/admin/README.md
+++ b/tools/admin/README.md
@@ -11,7 +11,7 @@ npm run admin        # → http://127.0.0.1:3021
 
 `127.0.0.1` バインドのみ（LAN 非公開）。依存追加ゼロ（node:http のみ）。
 
-## タブ（Phase 0〜3 実装済み）
+## タブ（Phase 0〜5 実装済み）
 
 | タブ | 内容 | データソース |
 |---|---|---|
@@ -21,8 +21,10 @@ npm run admin        # → http://127.0.0.1:3021
 | SNSパック | IG パック・X ドラフトの画像目視 + posted バッジ | `docs/sns/instagram/**`、`docs/sns/x/draft/**` |
 | SNS状態板 | IG 進捗サマリ・X 予約状況・直近スケジュール（読み取り専用） | `docs/sns/schedule.json`、posted.json、x status.json |
 | 投稿/予約 | X 4ステップパイプライン・IG 予約投稿・note 公開（2段階UI + SSEログ） | 既存 CLI を child_process 実行（`lib/jobs.mjs`） |
+| 記事/note/マガジン | サイト記事 / note 原稿 / マガジンの一覧・公開状態（読み取り専用） | `doc-meta-index.json`、`docs/note/**/article*.md`、`note-magazines.ts`（`lib/content.mjs`） |
+| 売上 | 月次売上推移（インライン SVG 棒グラフ）+ 商品別内訳・¥15k マイルストーン | `.claude/state/sales/sales-log.json`（`lib/sales.mjs`） |
 
-件数は既存ギャラリースクリプト（`ogp-gallery` / `note-cover-gallery` / `svg-gallery`）と一致する。
+件数は既存スクリプト（`ogp-gallery` / `note-cover-gallery` / `svg-gallery` / `sales-summary`）と一致する。
 
 ## 投稿/予約タブ（Phase 3）の安全設計
 
@@ -49,10 +51,10 @@ tools/admin/
   lib/scan.mjs       ギャラリー走査（ogp / figures / note / sns）
   lib/sot.mjs        SNS 状態板の SoT 統合
   lib/jobs.mjs       投稿アクションのホワイトリスト実行 + 引数検証 + SSE（P3）
+  lib/content.mjs    記事/note/マガジン一覧（P4）
+  lib/sales.mjs      売上集計（P5）
   public/            Vanilla JS SPA（no-build）
 ```
 
-## 未実装（ロードマップ）
-
-- P4 記事/note/マガジン一覧（doc-meta-index / note-magazines）
-- P5 売上ダッシュボード（sales-log + 月次チャート）
+Phase 0〜5 実装済み。追加候補: 計測ダッシュボード統合（GA4/GSC weekly-metrics）、
+IG ライブ照合（`verify-ig-status`）の UI 化、note ライブ照合（`verify-note-magazines`）ボタン。

--- a/tools/admin/lib/content.mjs
+++ b/tools/admin/lib/content.mjs
@@ -1,0 +1,98 @@
+/**
+ * content.mjs — 記事 / note 記事 / マガジン一覧（P4・読み取り専用）。
+ *
+ *   articlesIndex() … src/config/doc-meta-index.json（refresh-indexes 生成・1056 published）
+ *   magazines()     … src/lib/note-magazines.ts を regex 抽出（verify-note-magazines.mjs L107 と同方式・tsx 不要）
+ *   noteArticles()  … docs/note/** の article*.md frontmatter（notePricing / noteUrl / noteSeries）
+ */
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+
+const ROOT = resolve(join(dirname(fileURLToPath(import.meta.url)), "..", "..", ".."));
+const DOC_META = join(ROOT, "src", "config", "doc-meta-index.json");
+const SOT = join(ROOT, "src", "lib", "note-magazines.ts");
+const NOTE = join(ROOT, "docs", "note");
+
+function readJson(p) {
+  try { return JSON.parse(readFileSync(p, "utf8")); } catch { return null; }
+}
+
+// ─── サイト記事一覧（doc-meta-index.json）────────────────────
+export function articlesIndex() {
+  const d = readJson(DOC_META);
+  if (!d) return { summary: {}, docs: [] };
+  const docs = Object.entries(d.docs || {}).map(([slug, m]) => ({
+    slug,
+    title: m.title || slug,
+    category: m.category || "?",
+    group: m.group || "other",
+    published: m.published !== false,
+    publishedAt: m.publishedAt || m.created || null,
+    dateModified: m.dateModified || null,
+    reviewStatus: m.reviewStatus || null,
+  }));
+  docs.sort((a, b) => (b.publishedAt || "").localeCompare(a.publishedAt || "") || a.slug.localeCompare(b.slug));
+  return { summary: d.summary || {}, generatedAt: d.generated_at || null, docs };
+}
+
+// ─── マガジン一覧（note-magazines.ts の regex 抽出）──────────
+export function magazines() {
+  if (!existsSync(SOT)) return [];
+  const ts = readFileSync(SOT, "utf8");
+  // id / published / noteUrl はこの順で固定（ファイル規約・verify-note-magazines.mjs と同じ）
+  const re = /id:\s*'([^']+)',\s*published:\s*(true|false),\s*noteUrl:\s*'([^']*)'/g;
+  const idx = [];
+  let m;
+  while ((m = re.exec(ts)) !== null) {
+    idx.push({ id: m[1], published: m[2] === "true", noteUrl: m[3], at: m.index });
+  }
+  return idx.map((cur, i) => {
+    const slice = ts.slice(cur.at, idx[i + 1] ? idx[i + 1].at : ts.length);
+    const pick = (re2) => { const mm = slice.match(re2); return mm ? mm[1] : null; };
+    const priceStr = pick(/price:\s*'([^']*)'/);
+    return {
+      id: cur.id,
+      published: cur.published,
+      noteUrl: cur.noteUrl,
+      key: (cur.noteUrl.match(/\/m\/(m[0-9a-f]+)/) || [])[1] || null,
+      title: pick(/title:\s*'([^']*)'/) || pick(/title:\s*"([^"]*)"/),
+      badge: pick(/badge:\s*'([^']*)'/),
+      priceStr,
+      priceNum: priceStr ? Number((priceStr.match(/¥?\s*([\d,]+)/) || [])[1]?.replace(/,/g, "")) || null : null,
+    };
+  });
+}
+
+// ─── note 記事一覧（docs/note の article*.md frontmatter）────
+export function noteArticles() {
+  const items = [];
+  const walk = (absDir, rel) => {
+    let entries;
+    try { entries = readdirSync(absDir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (e.name === "img") continue;
+        walk(join(absDir, e.name), rel ? `${rel}/${e.name}` : e.name);
+      } else if (/^article[A-Za-z0-9-]*\.md$/.test(e.name)) {
+        let fm = {};
+        try { fm = matter(readFileSync(join(absDir, e.name), "utf8")).data || {}; } catch { /* skip */ }
+        items.push({
+          rel: `${rel}/${e.name}`,
+          dir: rel,
+          file: e.name,
+          title: fm.title || rel.split("/").pop(),
+          pricing: fm.notePricing || "unknown",
+          series: fm.noteSeries || fm.noteMagazine || null,
+          noteUrl: fm.noteUrl || null,
+          published: !!fm.noteUrl, // noteUrl があれば公開済みと見なす
+          exam: rel.split("/")[0],
+        });
+      }
+    }
+  };
+  if (existsSync(NOTE)) walk(NOTE, "");
+  items.sort((a, b) => a.rel.localeCompare(b.rel));
+  return items;
+}

--- a/tools/admin/lib/jobs.mjs
+++ b/tools/admin/lib/jobs.mjs
@@ -1,0 +1,230 @@
+/**
+ * jobs.mjs — 投稿/予約アクションの実行層（P3）。
+ *
+ * 設計不変条件:
+ *   1. **ホワイトリストのみ実行**: action id → 固定コマンド spec。任意コマンドは走らせない。
+ *   2. **ガードは既存 CLI 側に残す**: UI は引数を組み立てるだけ。--commit ゲート・
+ *      dobokunote assert・x-schedule-guard の BLOCK は各スクリプト内で発火する（UI は迂回不能）。
+ *   3. **引数は厳格検証 + shell なし**: pack/draft/date/format を正規表現で検証し、
+ *      spawn は shell:false・args 配列（シェル連結しない）。最終ガードで metachar を拒否。
+ *   4. **同時 1 ジョブ**: Playwright 永続プロファイルの SingletonLock 衝突を防ぐ。
+ *   5. **本番(commit)は明示フラグ必須**: mode!=='commit' の間は投稿系に --dry-run を強制付与。
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const ROOT = resolve(join(dirname(fileURLToPath(import.meta.url)), "..", "..", ".."));
+const isWin = process.platform === "win32";
+
+// ─── バリデータ ────────────────────────────────────────────
+const RE = {
+  packRel: /^[A-Za-z0-9][A-Za-z0-9/_-]{0,120}$/, // instagram の相対パス（cem/exam-packs/r07/pack-01 等）
+  draft: /^[0-9]{3}(-[A-Za-z0-9-]{1,80})?$/, // X ドラフト（"060" or "060-pe-...-w1"）
+  dateJST: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/, // 予約日時 JST
+  dateYMD: /^\d{4}-\d{2}-\d{2}$/, // 投稿日（ig-status mark --date）
+  format: /^(carousel|reels|stories)$/,
+  tweetNo: /^([1-9]|[1-4][0-9]|50)$/, // 1..50
+  url: /^https:\/\/(www\.)?(instagram\.com|x\.com|twitter\.com|note\.com)\/[A-Za-z0-9/_.?=&%-]{1,200}$/,
+  note: /^[\wぁ-んァ-ヶ一-龠々ー 　.,!?:_/()（）-]{1,60}$/u,
+  articlePath: /^docs\/note\/[A-Za-z0-9ぁ-んァ-ヶ一-龠々ー/_.-]+\/article[A-Za-z0-9-]*\.md$/u,
+};
+// path traversal / シェル metachar の最終拒否（全 arg に適用）
+const BAD = /(\.\.|[;&|`$<>(){}\n\r"'\\*])/;
+
+function must(re, val, name) {
+  if (typeof val !== "string" || !re.test(val)) throw new Error(`invalid ${name}: ${JSON.stringify(val)}`);
+  return val;
+}
+
+// tsx スクリプトは npx 経由（win は npx.cmd）。node スクリプトは process.execPath。
+const NPX = isWin ? "npx.cmd" : "npx";
+const nodeCmd = (rel, args) => ({ exe: process.execPath, args: [join(ROOT, rel), ...args] });
+const tsxCmd = (rel, args) => ({ exe: NPX, args: ["tsx", join(ROOT, rel), ...args] });
+
+// ─── アクション ホワイトリスト ─────────────────────────────
+// build(params, mode) → { exe, args } を返す。mode: 'dry' | 'commit'。
+export const ACTIONS = {
+  // IG 投稿済み状態を記録（browserless・低リスク）
+  "ig-mark": {
+    label: "IG 投稿済みを記録",
+    needsBrowser: false,
+    supportsCommit: true, // dry では何もせず表示、commit で posted.json 書込
+    build(p, mode) {
+      const pack = must(RE.packRel, p.pack, "pack");
+      const fmt = must(RE.format, p.format || "carousel", "format");
+      if (mode !== "commit") return null; // mark は dry 相当が無い（実行=書込）ので commit のみ
+      const extra = [];
+      if (p.url) extra.push(`--url=${must(RE.url, p.url, "url")}`);
+      if (p.note) extra.push(`--note=${must(RE.note, p.note, "note")}`);
+      if (p.date) extra.push(`--date=${must(RE.dateYMD, p.date, "date")}`);
+      return nodeCmd("scripts/ig-status.mjs", ["mark", pack, fmt, ...extra]);
+    },
+  },
+  "ig-unmark": {
+    label: "IG 投稿記録を取消",
+    needsBrowser: false,
+    supportsCommit: true,
+    build(p, mode) {
+      const pack = must(RE.packRel, p.pack, "pack");
+      if (mode !== "commit") return null;
+      const args = ["unmark", pack];
+      if (p.format) args.push(must(RE.format, p.format, "format"));
+      return nodeCmd("scripts/ig-status.mjs", args);
+    },
+  },
+  // X 予約ガード（門番・browserless。--queue は Playwright）
+  "x-guard": {
+    label: "X 予約ガード（凍結/二重投稿チェック）",
+    needsBrowser: false,
+    supportsCommit: false, // 常に読み取り検査
+    build(p) {
+      const args = [];
+      if (p.queue) args.push("--queue");
+      return nodeCmd("scripts/x-schedule-guard.mjs", args);
+    },
+  },
+  // X 投稿（dry-run 必須 → 本番）
+  "x-publish": {
+    label: "X 投稿/予約",
+    needsBrowser: true,
+    supportsCommit: true,
+    build(p, mode) {
+      const draft = must(RE.draft, p.draft, "draft");
+      const args = [draft];
+      if (p.dates) {
+        for (const d of p.dates) args.push(must(RE.dateJST, d, "date"));
+      }
+      if (p.tweet) args.push("--tweet", must(RE.tweetNo, String(p.tweet), "tweet"));
+      if (p.immediate) args.push("--immediate");
+      if (mode !== "commit") args.push("--dry-run"); // dry を強制
+      return tsxCmd(".claude/skills/social/publish-x/publish-x.ts", args);
+    },
+  },
+  // X 予約の実キュー昇格（偽成功検証）。--dry で確認のみ
+  "x-sync": {
+    label: "X 予約→posted 昇格検証",
+    needsBrowser: true,
+    supportsCommit: true,
+    build(p, mode) {
+      return nodeCmd("scripts/x-sync-status.mjs", mode === "commit" ? [] : ["--dry"]);
+    },
+  },
+  // IG カルーセル予約投稿（Business Suite・dry-run 必須 → 本番）
+  "ig-publish": {
+    label: "IG カルーセル予約投稿",
+    needsBrowser: true,
+    supportsCommit: true,
+    build(p, mode) {
+      const pack = must(RE.packRel, p.pack, "pack");
+      const date = must(RE.dateJST, p.date, "date");
+      const args = ["post", pack, "--schedule", date];
+      if (mode !== "commit") args.push("--dry-run");
+      return tsxCmd(".claude/skills/social/publish-ig-bs/publish-ig-bs.ts", args);
+    },
+  },
+  // note 公開/予約（既定 draft、--commit で公開）
+  "note-publish": {
+    label: "note 公開/予約",
+    needsBrowser: true,
+    supportsCommit: true,
+    build(p, mode) {
+      const article = must(RE.articlePath, p.article, "article");
+      if (!existsSync(join(ROOT, article))) throw new Error(`article not found: ${article}`);
+      const args = ["--article", article];
+      if (mode === "commit") {
+        args.push("--commit");
+        if (p.date) args.push("--schedule", must(RE.dateJST, p.date, "date"));
+      }
+      // mode!=='commit' は --commit を付けない = note-publish 既定の下書き（安全）
+      return nodeCmd("scripts/note-publish.mjs", args);
+    },
+  },
+};
+
+// ─── 実行状態（同時 1 ジョブ）───────────────────────────────
+let current = null; // { id, action, mode, exe, args, code, done, buffer[], subscribers:Set }
+
+export function jobStatus() {
+  if (!current) return { running: false, last: null };
+  return {
+    running: !current.done,
+    id: current.id,
+    action: current.action,
+    mode: current.mode,
+    code: current.code,
+    done: current.done,
+    lines: current.buffer.length,
+  };
+}
+
+/** action を検証・起動し job オブジェクトを返す。既に実行中なら例外。 */
+export function startJob({ action, mode = "dry", params = {} }) {
+  if (current && !current.done) throw new Error("別のジョブが実行中です（同時 1 本まで）");
+  const spec = ACTIONS[action];
+  if (!spec) throw new Error(`unknown action: ${action}`);
+  if (mode === "commit" && !spec.supportsCommit) throw new Error(`${action} は commit 非対応`);
+
+  const built = spec.build(params, mode);
+  if (!built) throw new Error(`${action} は mode=${mode} で実行できません`);
+
+  // 最終ガード: ユーザー由来 arg に危険文字が無いか（flag 形式は許可）。
+  // 先頭の固定スクリプトパス（ROOT 配下の絶対パス・Windows は \ を含む）は信頼済みなので除外。
+  for (const a of built.args) {
+    const s = String(a);
+    if (s.startsWith(ROOT)) continue; // 我々が組み立てた固定スクリプトパス
+    if (/^--?[a-z-]+$/.test(s)) continue; // 素のフラグ（--dry-run 等）
+    const val = s.replace(/^--?[a-z-]+=/, ""); // --key=value の value 側を検査
+    if (BAD.test(val)) throw new Error(`unsafe argument blocked: ${a}`);
+  }
+
+  const job = {
+    id: randomUUID().slice(0, 8),
+    action,
+    mode,
+    exe: built.exe,
+    args: built.args,
+    code: null,
+    done: false,
+    buffer: [],
+    subscribers: new Set(),
+  };
+  current = job;
+
+  const emit = (line) => {
+    job.buffer.push(line);
+    for (const res of job.subscribers) {
+      try { res.write(`data: ${JSON.stringify(line)}\n\n`); } catch { /* client gone */ }
+    }
+  };
+  emit({ t: "start", action, mode, cmd: `${built.exe === process.execPath ? "node" : built.exe} ${built.args.map((a) => (a.startsWith(ROOT) ? a.slice(ROOT.length + 1) : a)).join(" ")}` });
+
+  const child = spawn(built.exe, built.args, {
+    cwd: ROOT,
+    shell: false,
+    env: process.env,
+    windowsHide: true,
+  });
+  const onData = (stream) => (chunk) => {
+    for (const l of chunk.toString("utf8").split(/\r?\n/)) {
+      if (l.length) emit({ t: stream, line: l });
+    }
+  };
+  child.stdout.on("data", onData("out"));
+  child.stderr.on("data", onData("err"));
+  child.on("error", (err) => { emit({ t: "err", line: `spawn error: ${err.message}` }); });
+  child.on("close", (code) => {
+    job.code = code;
+    job.done = true;
+    emit({ t: "end", code });
+    for (const res of job.subscribers) { try { res.end(); } catch { /* noop */ } }
+  });
+
+  return job;
+}
+
+export function currentJob() {
+  return current;
+}

--- a/tools/admin/lib/media.mjs
+++ b/tools/admin/lib/media.mjs
@@ -1,0 +1,72 @@
+/**
+ * media.mjs — /media/* をリポジトリ内 3 ルートへマッピングする static serve。
+ *
+ *   /media/posts/... → .local/r2/posts/...
+ *   /media/sns/...   → docs/sns/...
+ *   /media/note/...  → docs/note/...
+ *
+ * path.resolve 後に許可ルートの startsWith 検査（traversal ガード）。
+ * ローカル専用サーバー（127.0.0.1）だが、他サイトからの drive-by 読み出しを
+ * 想定して許可ルート外は一律 403。
+ */
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { join, resolve, sep, extname, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(join(dirname(fileURLToPath(import.meta.url)), "..", "..", ".."));
+
+export const MEDIA_ROOTS = {
+  posts: resolve(join(ROOT, ".local", "r2", "posts")),
+  sns: resolve(join(ROOT, "docs", "sns")),
+  note: resolve(join(ROOT, "docs", "note")),
+};
+
+const MIME = {
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".mp4": "video/mp4",
+  ".wav": "audio/wav",
+  ".json": "application/json; charset=utf-8",
+  ".txt": "text/plain; charset=utf-8",
+  ".md": "text/plain; charset=utf-8",
+};
+
+/** /media/{root}/{rel} を解決。許可ルート外・非対応拡張子は null を返す。 */
+export function resolveMediaPath(urlPath) {
+  const m = /^\/media\/(posts|sns|note)\/(.+)$/.exec(urlPath);
+  if (!m) return null;
+  const base = MEDIA_ROOTS[m[1]];
+  const rel = decodeURIComponent(m[2]);
+  const full = resolve(join(base, rel));
+  if (full !== base && !full.startsWith(base + sep)) return null; // traversal
+  const mime = MIME[extname(full).toLowerCase()];
+  if (!mime) return null;
+  return { full, mime };
+}
+
+/** /media/* リクエストを処理。担当外 URL なら false を返す。 */
+export function serveMedia(req, res) {
+  if (!req.url.startsWith("/media/")) return false;
+  const hit = resolveMediaPath(req.url.split("?")[0]);
+  if (!hit) {
+    res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("403 Forbidden");
+    return true;
+  }
+  if (!existsSync(hit.full) || !statSync(hit.full).isFile()) {
+    res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("404 Not Found");
+    return true;
+  }
+  res.writeHead(200, {
+    "Content-Type": hit.mime,
+    "Content-Length": statSync(hit.full).size,
+    "Cache-Control": "no-cache",
+  });
+  createReadStream(hit.full).pipe(res);
+  return true;
+}

--- a/tools/admin/lib/sales.mjs
+++ b/tools/admin/lib/sales.mjs
@@ -1,0 +1,49 @@
+/**
+ * sales.mjs — 収益実績（P5・読み取り専用）。
+ * .claude/state/sales/sales-log.json を読み、月次・商品別に集計（sales-summary.mjs と同義）。
+ */
+import { readFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(join(dirname(fileURLToPath(import.meta.url)), "..", "..", ".."));
+const LOG = join(ROOT, ".claude", "state", "sales", "sales-log.json");
+const MILESTONE = 15000; // Web 月収マイルストーン（iOS 着手判断トリガー）
+
+const monthOf = (d) => d.slice(0, 7);
+
+export function salesSummary() {
+  let data;
+  try { data = JSON.parse(readFileSync(LOG, "utf8")); } catch { return { months: [], total: {}, source: null }; }
+  const sales = data.sales || [];
+
+  const byMonth = {};
+  for (const s of sales) {
+    const m = monthOf(s.date);
+    (byMonth[m] ??= { month: m, count: 0, revenue: 0, products: {} });
+    byMonth[m].count++;
+    byMonth[m].revenue += s.price;
+    const k = s.title;
+    (byMonth[m].products[k] ??= { title: k, count: 0, revenue: 0 });
+    byMonth[m].products[k].count++;
+    byMonth[m].products[k].revenue += s.price;
+  }
+
+  const months = Object.keys(byMonth).sort().map((m) => {
+    const mm = byMonth[m];
+    return {
+      month: m,
+      count: mm.count,
+      revenue: mm.revenue,
+      milestone: mm.revenue >= MILESTONE,
+      products: Object.values(mm.products).sort((a, b) => b.revenue - a.revenue),
+    };
+  });
+
+  const total = {
+    count: sales.length,
+    revenue: sales.reduce((s, x) => s + x.price, 0),
+    months: months.length,
+  };
+  return { source: data.source || null, updatedAt: data.updatedAt || null, currency: data.currency || "JPY", milestone: MILESTONE, months, total };
+}

--- a/tools/admin/lib/scan.mjs
+++ b/tools/admin/lib/scan.mjs
@@ -1,0 +1,279 @@
+/**
+ * scan.mjs — ギャラリー走査（管理画面 API のデータソース）。
+ *
+ * 既存ギャラリースクリプトの走査部を移植して JSON を返す:
+ *   scanOgp()        … scripts/ogp-gallery.mjs（frontmatter.group 分類）
+ *   scanFigures()    … scripts/svg-gallery.mjs collectSite（+ png/webp クロップも含める）
+ *   scanNoteImages() … scripts/note-cover-gallery.mjs + svg-gallery collectNote
+ *   scanSnsPacks()   … 新規（IG パック単位 + X ドラフト。posted/status バッジ付き）
+ *
+ * 画像 URL はすべて /media/{posts|sns|note}/... 形式で返し、フロントがロードする。
+ */
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+
+const ROOT = resolve(join(dirname(fileURLToPath(import.meta.url)), "..", "..", ".."));
+const POSTS = join(ROOT, ".local", "r2", "posts");
+const NOTE = join(ROOT, "docs", "note");
+const SNS = join(ROOT, "docs", "sns");
+const AUDIT_STATE = join(ROOT, ".claude", "state", "svg-audit.json");
+
+const toPosix = (p) => String(p).replace(/\\/g, "/");
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// ─── OGP（ogp-gallery.mjs 移植）──────────────────────────────
+const GROUP_LABEL = {
+  guide: "ガイド",
+  textbook: "テキスト",
+  keyword: "キーワード",
+  pillar: "まとめ",
+  primary: "過去問（一次）",
+  secondary: "過去問（二次）",
+  "past-exam": "過去問",
+  other: "その他",
+};
+
+export function scanOgp() {
+  const categories = readJson(join(ROOT, "src", "config", "categories.json")) || [];
+  const catLabel = Object.fromEntries(categories.map((c) => [c.slug, c.label]));
+  const catOrder = Object.fromEntries(categories.map((c) => [c.slug, c.order ?? 999]));
+
+  const rels = readdirSync(POSTS, { recursive: true, withFileTypes: false })
+    .map(toPosix)
+    .filter((p) => p.endsWith("/ogp.png"));
+
+  const items = rels
+    .map((rel) => {
+      const slugDir = dirname(rel);
+      const category = slugDir.split("/")[0];
+      // 記事本体の解決順は ogp-gallery.mjs と同じ（Convention B / A / フラット slug）
+      let mdx = join(POSTS, slugDir, "article.mdx");
+      if (!existsSync(mdx)) mdx = join(POSTS, slugDir + ".mdx");
+      if (!existsSync(mdx)) mdx = join(POSTS, slugDir.replace(/\//g, "-"), "article.mdx");
+      let group = "other";
+      if (existsSync(mdx)) {
+        try {
+          const g = matter(readFileSync(mdx, "utf8")).data.group;
+          if (g && GROUP_LABEL[g]) group = g;
+        } catch {
+          /* keep other */
+        }
+      }
+      return { rel, slugDir, category, group, url: `/media/posts/${rel}` };
+    })
+    .sort((a, b) => a.rel.localeCompare(b.rel));
+
+  return { items, catLabel, catOrder, groupLabel: GROUP_LABEL };
+}
+
+// ─── 記事図版（svg-gallery.mjs collectSite 拡張: svg + png/webp クロップ）──
+const EXAM_DIR_RE = /\/(h\d+-primary|primary-h\d+[^/]*)\//;
+
+export function scanFigures() {
+  const audit = readJson(AUDIT_STATE);
+  const fileSeverity = {};
+  for (const f of audit?.findings || []) {
+    const path = toPosix(f.file);
+    if (!fileSeverity[path]) fileSeverity[path] = { HIGH: 0, MEDIUM: 0, LOW: 0 };
+    if (f.severity && fileSeverity[path][f.severity] !== undefined) fileSeverity[path][f.severity]++;
+  }
+  const sevOf = (auditKey) => {
+    const s = fileSeverity[auditKey];
+    if (!s) return "clean";
+    if (s.HIGH > 0) return "high";
+    if (s.MEDIUM > 0) return "medium";
+    if (s.LOW > 0) return "low";
+    return "clean";
+  };
+
+  const rels = readdirSync(POSTS, { recursive: true, withFileTypes: false })
+    .map(toPosix)
+    .filter((p) => /\/img\/[^/]+\.(svg|png|webp|jpg)$/i.test(p));
+
+  const items = rels
+    .map((rel) => {
+      const parts = dirname(rel).split("/");
+      const category = parts[0];
+      const slug = parts.slice(0, 2).join("/");
+      const ext = rel.split(".").pop().toLowerCase();
+      const kind = ext === "svg"
+        ? (EXAM_DIR_RE.test("/" + rel) ? "exam-svg" : "svg")
+        : "raster";
+      return {
+        rel,
+        category,
+        slug,
+        name: rel.split("/").pop(),
+        kind,
+        severity: kind === "svg" ? sevOf(".local/r2/posts/" + rel) : null,
+        url: `/media/posts/${rel}`,
+      };
+    })
+    .sort((a, b) => a.rel.localeCompare(b.rel));
+
+  return { items };
+}
+
+// ─── note カバー・図版（note-cover-gallery.mjs + svg-gallery collectNote 移植）──
+export function scanNoteImages() {
+  const tokens = readJson(join(ROOT, "docs", "design-system", "note-cover-tokens.json"));
+  const exams = tokens?.exams || {};
+  const examKeys = Object.keys(exams).filter((k) => k !== "comment");
+
+  // dir セグメントから exam キーを解決（note-cover-gallery.mjs と同義・級別を combined より先に）
+  const resolveExam = (rel) => {
+    const segs = String(rel).split("/");
+    for (const key of examKeys) {
+      if (key === "civil-1-2") continue;
+      if (exams[key]?.dir && segs.includes(exams[key].dir)) return key;
+    }
+    if (exams["civil-1-2"]?.dir && segs.includes(exams["civil-1-2"].dir)) return "civil-1-2";
+    return "pe-comprehensive";
+  };
+
+  const items = [];
+  const walk = (absDir, rel) => {
+    for (const e of readdirSync(absDir, { withFileTypes: true })) {
+      if (e.isDirectory() && e.name !== "img") {
+        walk(join(absDir, e.name), rel ? `${rel}/${e.name}` : e.name);
+      }
+    }
+    const imgDir = join(absDir, "img");
+    if (!existsSync(imgDir)) return;
+    for (const f of readdirSync(imgDir)) {
+      const isCover = /^cover(-[A-Za-z0-9-]+)?\.png$/.test(f);
+      const isFigure = /^figure-[^/]+\.png$/.test(f);
+      if (!isCover && !isFigure) continue;
+      const item = {
+        rel: `${rel}/img/${f}`,
+        dir: rel,
+        name: f,
+        exam: resolveExam(rel),
+        kind: isCover ? "cover" : "figure",
+        url: `/media/note/${rel}/img/${f}`,
+      };
+      if (isCover) {
+        // cover.png → article.md / cover-II1.png → article-II1.md（種別バッジ用）
+        const suffix = f.replace(/^cover/, "").replace(/\.png$/, "");
+        const articlePath = join(absDir, `article${suffix}.md`);
+        item.pricing = "unknown";
+        item.inMagazine = rel.split("/").includes("magazines");
+        if (existsSync(articlePath)) {
+          try {
+            const { data } = matter(readFileSync(articlePath, "utf8"));
+            item.pricing = data.notePricing || "unknown";
+          } catch {
+            /* keep unknown */
+          }
+        }
+      }
+      items.push(item);
+    }
+  };
+  walk(NOTE, "");
+  items.sort((a, b) => a.rel.localeCompare(b.rel));
+
+  const examMeta = Object.fromEntries(
+    examKeys.map((k) => [k, { label: exams[k].label, base: exams[k].base, short: exams[k].short }]),
+  );
+  return { items, examMeta, examOrder: examKeys };
+}
+
+// ─── SNS パック（IG パック + X ドラフト）────────────────────────
+const R2_SNS_BASE = "https://storage.doboku-note.com/sns";
+
+/** パック配下のフォーマット別画像・動画を集める（IG: carousel/reels/stories サブディレクトリ）。 */
+function collectPackMedia(packDir, packRel) {
+  const media = { carousel: [], reels: [], stories: [] };
+  for (const fmt of ["carousel", "reels", "stories"]) {
+    const fmtDir = join(packDir, fmt);
+    if (!existsSync(fmtDir)) continue;
+    const files = readdirSync(fmtDir, { recursive: true, withFileTypes: false })
+      .map(toPosix)
+      .filter((f) => /\.(png|webp|jpg|mp4)$/i.test(f))
+      .sort();
+    for (const f of files) {
+      const relFromSns = `${packRel}/${fmt}/${f}`;
+      const isVideo = /\.mp4$/i.test(f);
+      media[fmt].push({
+        name: f,
+        video: isVideo,
+        url: `/media/sns/${relFromSns}`,
+        r2Url: isVideo ? `${R2_SNS_BASE}/${relFromSns}` : null,
+      });
+    }
+    // reels の mp4 が R2 退避済み（SoT は残るが動画実体なし）の場合はバッジ用フラグ
+    if (fmt === "reels" && !files.some((f) => /\.mp4$/i.test(f))) {
+      media.reelsOffloaded = true;
+    }
+  }
+  // 直下 img/（キーワードパック等の平置き構成）
+  const flatImg = join(packDir, "img");
+  if (existsSync(flatImg)) {
+    for (const f of readdirSync(flatImg).filter((f) => /\.(png|webp|jpg)$/i.test(f)).sort()) {
+      media.carousel.push({ name: `img/${f}`, video: false, url: `/media/sns/${packRel}/img/${f}`, r2Url: null });
+    }
+  }
+  return media;
+}
+
+export async function scanSnsPacks() {
+  // ig-status.mjs の export 済みヘルパを再利用（ロジック二重化しない）
+  const ig = await import(
+    new URL("../../../scripts/ig-status.mjs", import.meta.url).href
+  );
+  const igPacks = ig.walkPacks(ig.IG_DIR).map((dir) => {
+    const info = ig.packInfo(dir);
+    const packRel = `instagram/${info.rel}`;
+    return {
+      channel: "instagram",
+      rel: packRel,
+      exam: info.exam,
+      slug: info.slug,
+      posted: info.posted, // { carousel, reels, stories } | null
+      status: readJson(join(dir, "status.json")),
+      media: collectPackMedia(dir, packRel),
+    };
+  });
+
+  // X ドラフト（docs/sns/x/draft/{NNN}-*/: tweets.md + status.json）
+  const xDraftDir = join(SNS, "x", "draft");
+  const xDrafts = [];
+  if (existsSync(xDraftDir)) {
+    for (const name of readdirSync(xDraftDir).sort()) {
+      const dir = join(xDraftDir, name);
+      if (!statSync(dir).isDirectory()) continue;
+      const status = readJson(join(dir, "status.json"));
+      const counts = { draft: 0, scheduled: 0, posted: 0, other: 0 };
+      for (const t of Object.values(status?.tweets || {})) {
+        if (t.status in counts) counts[t.status]++;
+        else counts.other++;
+      }
+      const images = existsSync(join(dir, "img"))
+        ? readdirSync(join(dir, "img"))
+            .filter((f) => /\.(png|webp|jpg)$/i.test(f))
+            .map((f) => ({ name: f, url: `/media/sns/x/draft/${name}/img/${f}` }))
+        : [];
+      xDrafts.push({
+        channel: "x",
+        rel: `x/draft/${name}`,
+        name,
+        counts,
+        total: Object.keys(status?.tweets || {}).length,
+        updatedAt: status?.updated_at || null,
+        images,
+      });
+    }
+  }
+
+  return { igPacks, xDrafts };
+}

--- a/tools/admin/lib/sot.mjs
+++ b/tools/admin/lib/sot.mjs
@@ -1,0 +1,116 @@
+/**
+ * sot.mjs — SNS 投稿状態板（読み取り専用）のデータ統合。
+ *
+ * 読む SoT:
+ *   - docs/sns/schedule.json           全チャネル統合スケジュール（slug × 日付）
+ *   - IG posted.json                   scripts/ig-status.mjs の export を import 再利用
+ *   - X draft の status.json + tweets.md  ツイート別 scheduled/posted/draft
+ *
+ * 集計ロジックは ig-status.mjs printSummary と同義（検証時に CLI 出力と突合する）。
+ */
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(join(dirname(fileURLToPath(import.meta.url)), "..", "..", ".."));
+const SNS = join(ROOT, "docs", "sns");
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** IG: パック一覧 + 試験別サマリ（ig-status.mjs summary と同じ集計）。 */
+export async function igBoard() {
+  const ig = await import(new URL("../../../scripts/ig-status.mjs", import.meta.url).href);
+  const packs = ig.walkPacks(ig.IG_DIR).map(ig.packInfo);
+  const anyPosted = (posted) => !!posted && ig.FORMATS.some((f) => posted[f]);
+
+  const byExam = {};
+  for (const p of packs) {
+    if (!byExam[p.exam]) byExam[p.exam] = { done: 0, total: 0, carousel: 0, reels: 0, stories: 0 };
+    byExam[p.exam].total++;
+    if (anyPosted(p.posted)) byExam[p.exam].done++;
+    for (const f of ig.FORMATS) if (p.posted?.[f]) byExam[p.exam][f]++;
+  }
+  const totalDone = packs.filter((p) => anyPosted(p.posted)).length;
+
+  return {
+    packs: packs.map((p) => ({
+      rel: p.rel,
+      exam: p.exam,
+      slug: p.slug,
+      year: p.year,
+      posted: p.posted,
+      status: statusStr(p.posted, ig.FORMATS),
+      latest: latestDate(p.posted, ig.FORMATS),
+    })),
+    byExam,
+    total: packs.length,
+    totalDone,
+  };
+}
+
+const FMT_LETTER = { carousel: "C", reels: "R", stories: "S" };
+
+function statusStr(posted, formats) {
+  return formats.map((f) => (posted?.[f] ? FMT_LETTER[f] : "-")).join("");
+}
+
+function latestDate(posted, formats) {
+  const dates = formats.map((f) => posted?.[f]?.at).filter(Boolean).sort();
+  return dates.length ? dates[dates.length - 1] : "";
+}
+
+/** X: draft ディレクトリごとの tweet 状態 + 直近予約日時。 */
+export function xBoard() {
+  const draftDir = join(SNS, "x", "draft");
+  const drafts = [];
+  if (!existsSync(draftDir)) return { drafts, totals: {} };
+  for (const name of readdirSync(draftDir).sort()) {
+    const dir = join(draftDir, name);
+    if (!statSync(dir).isDirectory()) continue;
+    const status = readJson(join(dir, "status.json"));
+    const tweets = Object.entries(status?.tweets || {}).map(([no, t]) => ({
+      no,
+      title: t.title || "",
+      status: t.status || "draft",
+      scheduledAt: t.scheduled_at || null,
+      postedAt: t.posted_at || null,
+    }));
+    const counts = { draft: 0, scheduled: 0, posted: 0, other: 0 };
+    for (const t of tweets) (t.status in counts ? counts[t.status]++ : counts.other++);
+    drafts.push({
+      name,
+      rel: `x/draft/${name}`,
+      updatedAt: status?.updated_at || null,
+      counts,
+      total: tweets.length,
+      tweets,
+    });
+  }
+  const totals = { draft: 0, scheduled: 0, posted: 0, other: 0, tweets: 0 };
+  for (const d of drafts) {
+    totals.tweets += d.total;
+    for (const k of ["draft", "scheduled", "posted", "other"]) totals[k] += d.counts[k];
+  }
+  return { drafts, totals };
+}
+
+/** 統合スケジュール（slug × yt/ig 日付、650 件規模）。 */
+export function readSchedule() {
+  return readJson(join(SNS, "schedule.json")) || [];
+}
+
+/** 状態板の一括レスポンス。 */
+export async function snsBoard() {
+  return {
+    ig: await igBoard(),
+    x: xBoard(),
+    schedule: readSchedule(),
+    generatedAt: new Date().toISOString(),
+  };
+}

--- a/tools/admin/public/app.js
+++ b/tools/admin/public/app.js
@@ -1,0 +1,50 @@
+/* app.js — タブ SPA シェル。各タブの render 関数は tabs/*.js が App.tabs に登録する。 */
+window.App = (function () {
+  const tabs = {}; // name → { render(main, filterbar) }
+  let current = "ogp";
+
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    }[c]));
+  }
+
+  async function fetchJson(url) {
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(`${url} → ${r.status}`);
+    return r.json();
+  }
+
+  function setTab(name) {
+    current = name;
+    document.querySelectorAll(".tab").forEach((b) =>
+      b.classList.toggle("active", b.dataset.tab === name)
+    );
+    const main = document.getElementById("main");
+    const filterbar = document.getElementById("filterbar");
+    main.innerHTML = '<div class="loading">読み込み中…</div>';
+    filterbar.innerHTML = "";
+    const t = tabs[name];
+    if (!t) {
+      main.innerHTML = '<div class="loading">未実装のタブです</div>';
+      return;
+    }
+    Promise.resolve(t.render(main, filterbar)).catch((err) => {
+      main.innerHTML = `<div class="loading">エラー: ${esc(err.message)}</div>`;
+    });
+  }
+
+  function register(name, def) {
+    tabs[name] = def;
+  }
+
+  function init() {
+    document.getElementById("tabs").addEventListener("click", (e) => {
+      const btn = e.target.closest(".tab");
+      if (btn) setTab(btn.dataset.tab);
+    });
+    setTab(current);
+  }
+
+  return { init, register, setTab, esc, fetchJson };
+})();

--- a/tools/admin/public/app.js
+++ b/tools/admin/public/app.js
@@ -15,6 +15,36 @@ window.App = (function () {
     return r.json();
   }
 
+  // POST /api/job/run を叩き、SSE 行を onLine(obj) でストリーム。完了時に resolve。
+  // EventSource は POST 不可なので fetch + ReadableStream で SSE を手動パースする。
+  async function runJob(action, mode, params, onLine) {
+    const r = await fetch("/api/job/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Admin": "1" },
+      body: JSON.stringify({ action, mode, params }),
+    });
+    if (!r.ok) {
+      let msg = `${r.status}`;
+      try { msg = (await r.json()).error || msg; } catch { /* noop */ }
+      throw new Error(msg);
+    }
+    const reader = r.body.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      let idx;
+      while ((idx = buf.indexOf("\n\n")) >= 0) {
+        const chunk = buf.slice(0, idx);
+        buf = buf.slice(idx + 2);
+        const line = chunk.replace(/^data: /, "");
+        if (line) { try { onLine(JSON.parse(line)); } catch { /* skip */ } }
+      }
+    }
+  }
+
   function setTab(name) {
     current = name;
     document.querySelectorAll(".tab").forEach((b) =>
@@ -46,5 +76,5 @@ window.App = (function () {
     setTab(current);
   }
 
-  return { init, register, setTab, esc, fetchJson };
+  return { init, register, setTab, esc, fetchJson, runJob };
 })();

--- a/tools/admin/public/index.html
+++ b/tools/admin/public/index.html
@@ -15,6 +15,7 @@
     <button class="tab" data-tab="note">note画像</button>
     <button class="tab" data-tab="sns">SNSパック</button>
     <button class="tab" data-tab="board">SNS状態板</button>
+    <button class="tab" data-tab="publish">投稿/予約</button>
   </nav>
   <div class="filterbar" id="filterbar"></div>
 </header>
@@ -24,6 +25,7 @@
 <script src="/app.js"></script>
 <script src="/tabs/gallery.js"></script>
 <script src="/tabs/sns.js"></script>
+<script src="/tabs/publish.js"></script>
 <script>App.init();</script>
 </body>
 </html>

--- a/tools/admin/public/index.html
+++ b/tools/admin/public/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>doboku-note 管理画面</title>
+<link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<header>
+  <div class="brand">doboku-note <span>admin</span> <em>local only · 127.0.0.1</em></div>
+  <nav class="tabs" id="tabs">
+    <button class="tab active" data-tab="ogp">OGP</button>
+    <button class="tab" data-tab="figures">記事図版</button>
+    <button class="tab" data-tab="note">note画像</button>
+    <button class="tab" data-tab="sns">SNSパック</button>
+    <button class="tab" data-tab="board">SNS状態板</button>
+  </nav>
+  <div class="filterbar" id="filterbar"></div>
+</header>
+<main id="main">
+  <div class="loading">読み込み中…</div>
+</main>
+<script src="/app.js"></script>
+<script src="/tabs/gallery.js"></script>
+<script src="/tabs/sns.js"></script>
+<script>App.init();</script>
+</body>
+</html>

--- a/tools/admin/public/index.html
+++ b/tools/admin/public/index.html
@@ -16,6 +16,8 @@
     <button class="tab" data-tab="sns">SNSパック</button>
     <button class="tab" data-tab="board">SNS状態板</button>
     <button class="tab" data-tab="publish">投稿/予約</button>
+    <button class="tab" data-tab="content">記事/note/マガジン</button>
+    <button class="tab" data-tab="sales">売上</button>
   </nav>
   <div class="filterbar" id="filterbar"></div>
 </header>
@@ -26,6 +28,8 @@
 <script src="/tabs/gallery.js"></script>
 <script src="/tabs/sns.js"></script>
 <script src="/tabs/publish.js"></script>
+<script src="/tabs/content.js"></script>
+<script src="/tabs/sales.js"></script>
 <script>App.init();</script>
 </body>
 </html>

--- a/tools/admin/public/style.css
+++ b/tools/admin/public/style.css
@@ -204,3 +204,65 @@ table.summary th { background: #f8f8f8; font-weight: 600; color: #666; }
   letter-spacing: -1px;
   color: #16365c;
 }
+
+/* 投稿/予約タブ */
+.pub-wrap { max-width: 780px; display: flex; flex-direction: column; gap: 16px; }
+.pub-note {
+  font-size: 12px;
+  background: #fff8ec;
+  border: 1px solid #f0d9a8;
+  color: #7a5a1e;
+  border-radius: 8px;
+  padding: 8px 12px;
+}
+.pub-card {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.pub-card h3 { margin: 0 0 10px; font-size: 14px; color: #16365c; }
+.pub-row { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; margin-bottom: 8px; }
+.pub-row label { font-size: 12px; color: #555; display: flex; gap: 6px; align-items: center; }
+.pub-row select, .pub-row input {
+  font-size: 12px;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+.pub-steps { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-top: 4px; }
+.pub-sep { width: 1px; height: 22px; background: #e0e0e0; margin: 0 4px; }
+.pub-btn {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 14px;
+  border: 1px solid #16365c;
+  border-radius: 6px;
+  background: #16365c;
+  color: #fff;
+  cursor: pointer;
+}
+.pub-btn:hover:not(:disabled) { background: #0f2846; }
+.pub-btn:disabled { background: #e8e8e8; color: #aaa; border-color: #ddd; cursor: not-allowed; }
+.pub-btn.armed { background: #b8341f; border-color: #b8341f; }
+.pub-btn.armed:hover:not(:disabled) { background: #97291799; background: #8f2417; }
+.pub-btn.armed-off { background: #e8e8e8; color: #aaa; border-color: #ddd; }
+.pub-hint { font-size: 11px; color: #999; margin-top: 8px; }
+.pub-log {
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  background: #0f1720;
+  color: #d6deeb;
+  border-radius: 8px;
+  padding: 10px 12px;
+  max-height: 320px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.pub-log .log-cmd { color: #7fd1ff; }
+.pub-log .log-ok { color: #6ade8f; font-weight: 700; }
+.pub-log .log-ng { color: #ff8a7a; font-weight: 700; }
+.pub-log .log-out { color: #d6deeb; }
+.pub-log:empty::before { content: "（ここに実行ログが表示されます）"; color: #55627a; }

--- a/tools/admin/public/style.css
+++ b/tools/admin/public/style.css
@@ -205,6 +205,35 @@ table.summary th { background: #f8f8f8; font-weight: 600; color: #666; }
   color: #16365c;
 }
 
+/* 一覧タブ（記事/note/マガジン・売上） */
+.cinfo {
+  font-size: 13px;
+  color: #444;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+}
+.cfilter {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.cfilter b { font-size: 12px; color: #666; margin-right: 2px; }
+.cfilter .sep { width: 1px; height: 18px; background: #e0e0e0; margin: 0 4px; }
+.cfcount { margin-left: auto; font-size: 12px; color: #888; }
+.chip.sub { font-weight: 600; }
+table.summary.listing td { font-size: 12px; }
+table.summary.listing td.mono {
+  font-family: ui-monospace, Consolas, monospace;
+  font-size: 11px;
+  color: #777;
+}
+table.summary.listing a { color: #16365c; }
+
 /* 投稿/予約タブ */
 .pub-wrap { max-width: 780px; display: flex; flex-direction: column; gap: 16px; }
 .pub-note {

--- a/tools/admin/public/style.css
+++ b/tools/admin/public/style.css
@@ -1,0 +1,206 @@
+* { box-sizing: border-box; }
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  margin: 0;
+  background: #f4f4f5;
+  color: #222;
+}
+header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+  padding: 10px 16px;
+}
+.brand {
+  font-weight: 700;
+  font-size: 15px;
+  color: #16365c;
+}
+.brand span {
+  font-weight: 600;
+  color: #a36b2c;
+}
+.brand em {
+  font-style: normal;
+  font-size: 11px;
+  font-weight: 500;
+  color: #999;
+  margin-left: 6px;
+}
+.tabs {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.tab {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 16px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #f4f4f5;
+  cursor: pointer;
+}
+.tab:hover { border-color: #16365c; color: #16365c; }
+.tab.active { background: #16365c; color: #fff; border-color: #16365c; }
+.filterbar {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px dashed #e5e5e5;
+  min-height: 20px;
+}
+.filterbar:empty { display: none; }
+.filterbar b {
+  font-size: 12px;
+  color: #666;
+  margin-right: 4px;
+}
+.filterbar .sep {
+  width: 1px;
+  height: 18px;
+  background: #e0e0e0;
+  margin: 0 4px;
+}
+.chip {
+  font-size: 12px;
+  padding: 4px 10px;
+  border: 1px solid #ccc;
+  border-radius: 999px;
+  background: #fff;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.chip:hover { border-color: #16365c; color: #16365c; }
+.chip.active { background: #16365c; color: #fff; border-color: #16365c; }
+.chip .n { opacity: .7; font-size: 11px; }
+.chip.active .n { opacity: .9; }
+.chip[hidden] { display: none; }
+.dot { width: 10px; height: 10px; border-radius: 999px; display: inline-block; }
+.count { margin-left: auto; font-size: 12px; color: #888; }
+
+main { padding: 16px; }
+.loading { padding: 40px; text-align: center; color: #999; }
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+}
+.grid.dense {
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+.card {
+  margin: 0;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.card img {
+  width: 100%;
+  display: block;
+  background: #fafafa;
+}
+.card.raster img, .card.svg img { padding: 8px; }
+.card figcaption {
+  font-size: 11px;
+  color: #555;
+  padding: 6px 8px;
+  word-break: break-all;
+  border-top: 1px solid #f0f0f0;
+}
+.badge {
+  color: #fff;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 10px;
+  white-space: nowrap;
+  margin-right: 4px;
+}
+.badge.gray { background: #8a8a8a; }
+.badge.high { background: #d33; }
+.badge.medium { background: #e0a400; }
+.badge.low { background: #3a3; }
+.badge.clean { background: #bbb; }
+.badge.offloaded { background: #6a0dad; }
+
+/* SNS パックカード */
+.pack {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.pack h3 {
+  margin: 0;
+  font-size: 13px;
+  color: #16365c;
+  word-break: break-all;
+}
+.pack .status-row { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+.pack .thumbs {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+.pack .thumbs img, .pack .thumbs video {
+  height: 120px;
+  border-radius: 4px;
+  border: 1px solid #eee;
+  flex: 0 0 auto;
+  background: #fafafa;
+}
+.pill {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+.pill.posted { background: #e6f4ea; color: #1a7f37; }
+.pill.scheduled { background: #fff4e0; color: #a36b2c; }
+.pill.draft { background: #f0f0f0; color: #888; }
+.pill.empty { background: #fafafa; color: #bbb; border: 1px dashed #ddd; }
+
+/* 状態板 */
+.board-section { margin-bottom: 24px; }
+.board-section h2 {
+  font-size: 15px;
+  color: #16365c;
+  border-bottom: 2px solid #16365c;
+  padding-bottom: 4px;
+}
+table.summary {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 13px;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  overflow: hidden;
+}
+table.summary th, table.summary td {
+  padding: 6px 10px;
+  text-align: left;
+  border-bottom: 1px solid #f0f0f0;
+}
+table.summary th { background: #f8f8f8; font-weight: 600; color: #666; }
+.bar {
+  display: inline-block;
+  font-family: monospace;
+  letter-spacing: -1px;
+  color: #16365c;
+}

--- a/tools/admin/public/tabs/content.js
+++ b/tools/admin/public/tabs/content.js
@@ -1,0 +1,123 @@
+/* content.js — 記事/note/マガジン一覧（P4・読み取り専用）。
+ * 表示値はリポジトリ内の slug/title/カテゴリ等。App.esc() でエスケープして挿入する。 */
+(function () {
+  const { esc, fetchJson } = App;
+
+  const GROUP_LABEL = {
+    guide: "ガイド", textbook: "テキスト", keyword: "キーワード", pillar: "まとめ",
+    primary: "過去問(一次)", secondary: "過去問(二次)", "past-exam": "過去問", other: "その他",
+  };
+
+  function subnav(active) {
+    const tabs = [["site", "サイト記事"], ["note", "note記事"], ["mag", "マガジン"]];
+    return `<div class="pub-steps" style="margin-bottom:12px">` +
+      tabs.map(([k, l]) => `<button class="chip sub ${k === active ? "active" : ""}" data-sub="${k}">${l}</button>`).join("") +
+      `</div>`;
+  }
+
+  App.register("content", {
+    async render(main, filterbar) {
+      filterbar.innerHTML = "";
+      let view = "site";
+
+      async function draw() {
+        main.innerHTML = subnav(view) + '<div class="loading">読み込み中…</div>';
+        main.querySelector(".pub-steps").addEventListener("click", (e) => {
+          const b = e.target.closest(".chip.sub");
+          if (b) { view = b.dataset.sub; draw(); }
+        });
+        const body = document.createElement("div");
+        try {
+          if (view === "site") body.innerHTML = await renderSite();
+          else if (view === "note") body.innerHTML = await renderNote();
+          else body.innerHTML = await renderMag();
+        } catch (err) {
+          body.innerHTML = `<div class="loading">エラー: ${esc(err.message)}</div>`;
+        }
+        main.querySelector(".loading")?.replaceWith(body);
+        wireFilter(main);
+      }
+
+      // クライアント側フィルタ（data-* 一致）
+      function wireFilter(root) {
+        const bar = root.querySelector(".cfilter");
+        if (!bar) return;
+        const sel = {};
+        bar.addEventListener("click", (e) => {
+          const b = e.target.closest(".chip[data-key]");
+          if (!b) return;
+          const key = b.dataset.key;
+          sel[key] = sel[key] === b.dataset.val ? "" : b.dataset.val;
+          bar.querySelectorAll(`.chip[data-key="${key}"]`).forEach((x) =>
+            x.classList.toggle("active", x.dataset.val === sel[key] && sel[key] !== ""));
+          let shown = 0;
+          root.querySelectorAll("tr.row").forEach((tr) => {
+            const ok = Object.keys(sel).every((k) => !sel[k] || tr.dataset[k] === sel[k]);
+            tr.style.display = ok ? "" : "none";
+            if (ok) shown++;
+          });
+          const c = root.querySelector(".cfcount");
+          if (c) c.textContent = `${shown} 件`;
+        });
+      }
+
+      await draw();
+    },
+  });
+
+  async function renderSite() {
+    const { summary, docs } = await fetchJson("/api/content/articles");
+    const cats = [...new Set(docs.map((d) => d.category))].sort();
+    const groups = [...new Set(docs.map((d) => d.group))];
+    const rows = docs.map((d) =>
+      `<tr class="row" data-category="${esc(d.category)}" data-group="${esc(d.group)}" data-pub="${d.published ? "y" : "n"}">` +
+      `<td><span class="badge gray">${esc(GROUP_LABEL[d.group] || d.group)}</span></td>` +
+      `<td>${esc(d.title)}</td>` +
+      `<td class="mono">${esc(d.slug)}</td>` +
+      `<td>${d.published ? '<span class="pill posted">公開</span>' : '<span class="pill draft">非公開</span>'}</td>` +
+      `<td>${esc(d.publishedAt || "")}</td></tr>`
+    ).join("");
+    return `<div class="cinfo">全 ${summary.total} 記事（公開 ${summary.published} / 非公開 ${summary.unpublished}）</div>` +
+      `<div class="cfilter">` +
+      `<b>資格</b>` + cats.map((c) => `<button class="chip" data-key="category" data-val="${esc(c)}">${esc(c)}</button>`).join("") +
+      `<span class="sep"></span><b>分類</b>` + groups.map((g) => `<button class="chip" data-key="group" data-val="${esc(g)}">${esc(GROUP_LABEL[g] || g)}</button>`).join("") +
+      `<span class="sep"></span><button class="chip" data-key="pub" data-val="n">非公開のみ</button>` +
+      `<span class="cfcount"></span></div>` +
+      `<table class="summary listing"><thead><tr><th>分類</th><th>タイトル</th><th>slug</th><th>状態</th><th>公開日</th></tr></thead><tbody>${rows}</tbody></table>`;
+  }
+
+  async function renderNote() {
+    const items = await fetchJson("/api/content/note");
+    const exams = [...new Set(items.map((i) => i.exam))].sort();
+    const pub = items.filter((i) => i.published).length;
+    const rows = items.map((i) =>
+      `<tr class="row" data-exam="${esc(i.exam)}" data-pricing="${esc(i.pricing)}" data-pub="${i.published ? "y" : "n"}">` +
+      `<td>${esc(i.title)}</td>` +
+      `<td class="mono">${esc(i.dir)}</td>` +
+      `<td>${i.pricing === "paid" ? '<span class="pill scheduled">有料</span>' : i.pricing === "free" ? '<span class="pill posted">無料</span>' : '<span class="pill draft">?</span>'}</td>` +
+      `<td>${i.published ? `<a href="${esc(i.noteUrl)}" target="_blank" rel="noopener">公開</a>` : '<span class="pill draft">未</span>'}</td></tr>`
+    ).join("");
+    return `<div class="cinfo">note 原稿 ${items.length} 本（noteUrl あり = 公開済み ${pub}）</div>` +
+      `<div class="cfilter"><b>資格</b>` + exams.map((e) => `<button class="chip" data-key="exam" data-val="${esc(e)}">${esc(e)}</button>`).join("") +
+      `<span class="sep"></span><button class="chip" data-key="pricing" data-val="paid">有料</button>` +
+      `<button class="chip" data-key="pub" data-val="n">未公開のみ</button>` +
+      `<span class="cfcount"></span></div>` +
+      `<table class="summary listing"><thead><tr><th>タイトル</th><th>ディレクトリ</th><th>価格</th><th>公開</th></tr></thead><tbody>${rows}</tbody></table>`;
+  }
+
+  async function renderMag() {
+    const mags = await fetchJson("/api/content/magazines");
+    const pub = mags.filter((m) => m.published).length;
+    const rows = mags.map((m) =>
+      `<tr class="row" data-pub="${m.published ? "y" : "n"}">` +
+      `<td>${esc(m.title || m.id)}</td>` +
+      `<td class="mono">${esc(m.id)}</td>` +
+      `<td>${esc(m.priceStr || "")}</td>` +
+      `<td>${m.published ? `<a href="${esc(m.noteUrl)}" target="_blank" rel="noopener">公開</a>` : '<span class="pill draft">未公開</span>'}</td>` +
+      `<td>${esc(m.badge || "")}</td></tr>`
+    ).join("");
+    return `<div class="cinfo">マガジン ${mags.length} 件（公開 ${pub} / 未公開 ${mags.length - pub}）— SoT: src/lib/note-magazines.ts</div>` +
+      `<div class="cfilter"><button class="chip" data-key="pub" data-val="n">未公開のみ</button><span class="cfcount"></span></div>` +
+      `<table class="summary listing"><thead><tr><th>タイトル</th><th>id</th><th>価格</th><th>公開</th><th>バッジ</th></tr></thead><tbody>${rows}</tbody></table>`;
+  }
+})();

--- a/tools/admin/public/tabs/gallery.js
+++ b/tools/admin/public/tabs/gallery.js
@@ -1,0 +1,202 @@
+/* gallery.js — 画像ギャラリー系タブ（OGP / 記事図版 / note画像）。
+ * 表示する値はすべてリポジトリ内のファイルパス・slug。App.esc() でエスケープして挿入する。 */
+(function () {
+  const { esc, fetchJson } = App;
+
+  // ── 共通: フィルタチップ生成 + 適用 ────────────────────────
+  function chip(label, value, attr, count) {
+    const n = count != null ? ` <span class="n">${count}</span>` : "";
+    const dot = attr && attr.dot ? `<span class="dot" style="background:${esc(attr.dot)}"></span>` : "";
+    return `<button class="chip" data-key="${esc(attr.key)}" data-val="${esc(value)}">${dot}${esc(label)}${n}</button>`;
+  }
+
+  // state: { cat: '', group: '' } のような選択。data-* とマッチした .card のみ表示。
+  function wireFilters(filterbar, main, keys) {
+    const sel = {};
+    keys.forEach((k) => (sel[k] = ""));
+    function apply() {
+      let shown = 0;
+      main.querySelectorAll(".card").forEach((el) => {
+        const ok = keys.every((k) => !sel[k] || el.dataset[k] === sel[k]);
+        el.style.display = ok ? "" : "none";
+        if (ok) shown++;
+      });
+      const c = filterbar.querySelector(".count");
+      if (c) c.textContent = `${shown} 件表示`;
+    }
+    filterbar.addEventListener("click", (e) => {
+      const btn = e.target.closest(".chip");
+      if (!btn) return;
+      const key = btn.dataset.key;
+      sel[key] = btn.dataset.val;
+      filterbar.querySelectorAll(`.chip[data-key="${key}"]`).forEach((b) =>
+        b.classList.toggle("active", b === btn)
+      );
+      // 資格切替時、その資格に無い分類チップを隠す（OGP タブ用）
+      if (typeof filterbar._onFilter === "function") filterbar._onFilter(key, sel);
+      apply();
+    });
+    filterbar._apply = apply;
+    apply();
+  }
+
+  // ── OGP タブ ──────────────────────────────────────────────
+  App.register("ogp", {
+    async render(main, filterbar) {
+      const data = await fetchJson("/api/gallery/ogp");
+      const { items, catLabel, catOrder, groupLabel } = data;
+      const catCount = {};
+      items.forEach((i) => (catCount[i.category] = (catCount[i.category] || 0) + 1));
+      const cats = [...new Set(items.map((i) => i.category))].sort(
+        (a, b) => (catOrder[a] ?? 999) - (catOrder[b] ?? 999) || a.localeCompare(b)
+      );
+      const groupsByCat = {};
+      items.forEach((i) => ((groupsByCat[i.category] ??= new Set()).add(i.group)));
+      const allGroups = [...new Set(items.map((i) => i.group))];
+
+      filterbar.innerHTML =
+        `<b>資格</b>` +
+        `<button class="chip active" data-key="category" data-val="">全て <span class="n">${items.length}</span></button>` +
+        cats.map((c) => chip(catLabel[c] || c, c, { key: "category" }, catCount[c])).join("") +
+        `<span class="sep"></span><b>分類</b>` +
+        `<button class="chip active" data-key="group" data-val="">全分類</button>` +
+        allGroups.map((g) => chip(groupLabel[g] || g, g, { key: "group" })).join("") +
+        `<span class="count"></span>`;
+
+      main.innerHTML =
+        '<div class="grid">' +
+        items.map((o) =>
+          `<figure class="card" data-category="${esc(o.category)}" data-group="${esc(o.group)}">` +
+          `<img loading="lazy" src="${esc(o.url)}" alt="${esc(o.slugDir)}">` +
+          `<figcaption>${esc(o.slugDir)}</figcaption></figure>`
+        ).join("") +
+        "</div>";
+
+      // 資格に無い分類チップを隠す
+      filterbar._onFilter = (key, sel) => {
+        if (key !== "category") return;
+        const allow = sel.category ? groupsByCat[sel.category] : null;
+        filterbar.querySelectorAll('.chip[data-key="group"]').forEach((b) => {
+          const g = b.dataset.val;
+          const ok = !g || !allow || allow.has(g);
+          b.hidden = !ok;
+          if (!ok && b.classList.contains("active")) {
+            b.classList.remove("active");
+            filterbar.querySelector('.chip[data-key="group"][data-val=""]').classList.add("active");
+            sel.group = "";
+          }
+        });
+      };
+      wireFilters(filterbar, main, ["category", "group"]);
+    },
+  });
+
+  // ── 記事図版タブ（svg / raster / exam-svg + severity）──────
+  App.register("figures", {
+    async render(main, filterbar) {
+      const { items } = await fetchJson("/api/gallery/figures");
+      const cats = [...new Set(items.map((i) => i.category))].sort();
+      const kinds = [
+        ["svg", "コンテンツSVG"],
+        ["exam-svg", "試験原図SVG"],
+        ["raster", "PNG/WebPクロップ"],
+      ].filter(([k]) => items.some((i) => i.kind === k));
+
+      filterbar.innerHTML =
+        `<b>資格</b>` +
+        `<button class="chip active" data-key="category" data-val="">全て <span class="n">${items.length}</span></button>` +
+        cats.map((c) => chip(c, c, { key: "category" }, items.filter((i) => i.category === c).length)).join("") +
+        `<span class="sep"></span><b>種別</b>` +
+        `<button class="chip active" data-key="kind" data-val="">全種別</button>` +
+        kinds.map(([k, l]) => chip(l, k, { key: "kind" })).join("") +
+        `<span class="sep"></span><b>監査</b>` +
+        `<button class="chip active" data-key="severity" data-val="">全</button>` +
+        ["high", "medium", "low", "clean"].map((s) => chip(s.toUpperCase(), s, { key: "severity" })).join("") +
+        `<span class="count"></span>`;
+
+      main.innerHTML =
+        '<div class="grid dense">' +
+        items.map((o) => {
+          const sev = o.severity || "clean";
+          const sevBadge = o.kind === "svg"
+            ? `<span class="badge ${esc(sev)}">${esc(sev)}</span>`
+            : "";
+          return `<figure class="card ${esc(o.kind === "raster" ? "raster" : "svg")}" ` +
+            `data-category="${esc(o.category)}" data-kind="${esc(o.kind)}" data-severity="${esc(sev)}">` +
+            `<img loading="lazy" src="${esc(o.url)}" alt="${esc(o.slug)}">` +
+            `<figcaption>${sevBadge}${esc(o.slug + "/" + o.name)}</figcaption></figure>`;
+        }).join("") +
+        "</div>";
+      wireFilters(filterbar, main, ["category", "kind", "severity"]);
+    },
+  });
+
+  // ── note画像タブ（cover / figure + 試験 + 種別）─────────────
+  App.register("note", {
+    async render(main, filterbar) {
+      const { items, examMeta, examOrder } = await fetchJson("/api/gallery/note");
+      const examCount = {};
+      items.forEach((i) => (examCount[i.exam] = (examCount[i.exam] || 0) + 1));
+      const exams = examOrder.filter((k) => examCount[k]);
+      const kinds = [
+        ["cover", "カバー"],
+        ["figure", "図版"],
+        ["paid", "有料"],
+        ["free", "無料"],
+        ["magazine", "マガジン収録"],
+      ];
+
+      filterbar.innerHTML =
+        `<b>資格</b>` +
+        `<button class="chip active" data-key="exam" data-val="">全て <span class="n">${items.length}</span></button>` +
+        exams.map((k) =>
+          chip(examMeta[k]?.label || k, k, { key: "exam", dot: examMeta[k]?.base }, examCount[k])
+        ).join("") +
+        `<span class="sep"></span><b>種別</b>` +
+        `<button class="chip active" data-key="kindfilter" data-val="">全種別</button>` +
+        kinds.filter(([k]) =>
+          items.some((i) => i.kind === k || i.pricing === k || (k === "magazine" && i.inMagazine))
+        ).map(([k, l]) => chip(l, k, { key: "kindfilter" })).join("") +
+        `<span class="count"></span>`;
+
+      main.innerHTML =
+        '<div class="grid">' +
+        items.map((o) => {
+          const kinds = [o.kind];
+          if (o.pricing === "paid") kinds.push("paid");
+          if (o.pricing === "free") kinds.push("free");
+          if (o.inMagazine) kinds.push("magazine");
+          const meta = examMeta[o.exam] || {};
+          return `<figure class="card" data-exam="${esc(o.exam)}" data-kindfilter="${esc(kinds.join(" "))}">` +
+            `<img loading="lazy" src="${esc(o.url)}" alt="${esc(o.rel)}">` +
+            `<figcaption><span class="badge" style="background:${esc(meta.base || "#888")}">` +
+            `${esc(meta.short || o.exam)}</span>${esc(o.dir + "/" + o.name)}</figcaption></figure>`;
+        }).join("") +
+        "</div>";
+
+      // 種別は space 区切り複数値 → カスタム apply
+      const sel = { exam: "", kindfilter: "" };
+      function apply() {
+        let shown = 0;
+        main.querySelectorAll(".card").forEach((el) => {
+          const okE = !sel.exam || el.dataset.exam === sel.exam;
+          const okK = !sel.kindfilter || el.dataset.kindfilter.split(" ").includes(sel.kindfilter);
+          el.style.display = okE && okK ? "" : "none";
+          if (okE && okK) shown++;
+        });
+        filterbar.querySelector(".count").textContent = `${shown} 件表示`;
+      }
+      filterbar.addEventListener("click", (e) => {
+        const btn = e.target.closest(".chip");
+        if (!btn) return;
+        const key = btn.dataset.key;
+        sel[key] = btn.dataset.val;
+        filterbar.querySelectorAll(`.chip[data-key="${key}"]`).forEach((b) =>
+          b.classList.toggle("active", b === btn)
+        );
+        apply();
+      });
+      apply();
+    },
+  });
+})();

--- a/tools/admin/public/tabs/publish.js
+++ b/tools/admin/public/tabs/publish.js
@@ -1,0 +1,176 @@
+/* publish.js — 投稿/予約アクション（P3）。
+ * 設計: UI は引数を組み立てて既存 CLI を叩くだけ。ガード（--commit ゲート・dobokunote
+ * assert・x-schedule-guard の BLOCK）は CLI 側にある。本番ボタンは dry-run/guard 成功まで
+ * disabled + 対象名タイプ確認。ジョブは同時 1 本（サーバが強制）。 */
+(function () {
+  const { esc, fetchJson, runJob } = App;
+
+  let logEl = null;
+  let busy = false;
+
+  function log(obj) {
+    if (!logEl) return;
+    let cls = "log-out", text = "";
+    if (obj.t === "start") { cls = "log-cmd"; text = `$ ${obj.cmd}`; }
+    else if (obj.t === "end") { cls = obj.code === 0 ? "log-ok" : "log-ng"; text = `— 終了コード ${obj.code} —`; }
+    else if (obj.t === "err") { cls = "log-ng"; text = obj.line; }
+    else { text = obj.line; }
+    const div = document.createElement("div");
+    div.className = cls;
+    div.textContent = text;
+    logEl.appendChild(div);
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+
+  function clearLog() { if (logEl) logEl.innerHTML = ""; }
+
+  // ジョブ実行。code===0 を解決値に返す。busy 中は例外。
+  async function run(action, mode, params) {
+    if (busy) throw new Error("実行中です");
+    busy = true;
+    setBusy(true);
+    let code = null;
+    try {
+      await runJob(action, mode, params, (obj) => {
+        log(obj);
+        if (obj.t === "end") code = obj.code;
+      });
+    } finally {
+      busy = false;
+      setBusy(false);
+    }
+    return code === 0;
+  }
+
+  function setBusy(on) {
+    document.querySelectorAll(".pub-btn").forEach((b) => {
+      if (b.dataset.keepEnabled === "1") return;
+      b.disabled = on || b.dataset.gated === "1";
+    });
+  }
+
+  // 本番ボタンの解錠: gated 解除 + タイプ確認
+  function unlock(btn) { btn.dataset.gated = "0"; btn.disabled = false; btn.classList.add("armed"); }
+
+  function confirmType(target) {
+    const typed = prompt(`本番実行します。確認のため対象名を入力してください:\n${target}`);
+    return typed === target;
+  }
+
+  App.register("publish", {
+    async render(main, filterbar) {
+      filterbar.innerHTML = "";
+      const { igPacks, xDrafts } = await fetchJson("/api/gallery/sns");
+
+      const xOptions = xDrafts.map((d) => `<option value="${esc(d.name)}">${esc(d.name)} (投稿${d.counts.posted}/予約${d.counts.scheduled}/下書${d.counts.draft})</option>`).join("");
+      const igOptions = igPacks.map((p) => `<option value="${esc(p.rel.replace(/^instagram\//, ""))}">${esc(p.exam)} / ${esc(p.slug)}</option>`).join("");
+
+      main.innerHTML = `
+<div class="pub-wrap">
+  <div class="pub-note">投稿系はローカルの Playwright ログインプロファイルを使います。<b>本番ボタンは dry-run / ガードが成功するまで押せません</b>。ジョブは同時 1 本。</div>
+
+  <section class="pub-card">
+    <h3>X（4ステップ固定パイプライン）</h3>
+    <div class="pub-row">
+      <label>ドラフト <select id="x-draft">${xOptions}</select></label>
+      <label>tweet番号(任意) <input id="x-tweet" type="number" min="1" max="50" style="width:64px"></label>
+    </div>
+    <div class="pub-row">
+      <label>予約日時(任意・複数可 空白区切り) <input id="x-dates" placeholder="2026-07-10T08:00 2026-07-11T08:00" style="width:320px"></label>
+    </div>
+    <div class="pub-steps">
+      <button class="pub-btn" data-keep-enabled="1" id="x-guard">① ガード</button>
+      <button class="pub-btn" data-keep-enabled="1" id="x-dry">② dry-run</button>
+      <button class="pub-btn armed-off" data-gated="1" id="x-commit" disabled>③ 本番投稿</button>
+      <button class="pub-btn" data-keep-enabled="1" id="x-sync">④ 昇格検証</button>
+    </div>
+    <div class="pub-hint" id="x-hint">① ガード → ② dry-run の両方が成功すると ③ が解錠されます。</div>
+  </section>
+
+  <section class="pub-card">
+    <h3>Instagram カルーセル（予約投稿）</h3>
+    <div class="pub-row">
+      <label>パック <select id="ig-pack" style="min-width:320px">${igOptions}</select></label>
+      <label>予約日時 <input id="ig-date" placeholder="2026-07-10T07:00" style="width:180px"></label>
+    </div>
+    <div class="pub-steps">
+      <button class="pub-btn" data-keep-enabled="1" id="ig-dry">dry-run</button>
+      <button class="pub-btn armed-off" data-gated="1" id="ig-commit" disabled>本番予約</button>
+      <span class="pub-sep"></span>
+      <button class="pub-btn" data-keep-enabled="1" id="ig-mark">投稿済みを記録(carousel)</button>
+    </div>
+    <div class="pub-hint" id="ig-hint">dry-run 成功で本番予約が解錠されます。</div>
+  </section>
+
+  <section class="pub-card">
+    <h3>note 記事（下書き→公開）</h3>
+    <div class="pub-row">
+      <label>article.md パス <input id="note-article" placeholder="docs/note/技術士総監/.../article.md" style="width:420px"></label>
+    </div>
+    <div class="pub-row">
+      <label>予約日時(任意) <input id="note-date" placeholder="2026-07-10T07:00" style="width:180px"></label>
+    </div>
+    <div class="pub-steps">
+      <button class="pub-btn" data-keep-enabled="1" id="note-draft">下書き作成(安全)</button>
+      <button class="pub-btn armed-off" data-gated="1" id="note-commit" disabled>公開/予約</button>
+    </div>
+    <div class="pub-hint" id="note-hint">下書き作成が成功すると公開が解錠されます（note-publish の --commit ゲート）。</div>
+  </section>
+
+  <section class="pub-card">
+    <h3>実行ログ</h3>
+    <div class="pub-log" id="pub-log"></div>
+  </section>
+</div>`;
+
+      logEl = main.querySelector("#pub-log");
+      const $ = (id) => main.querySelector(id);
+
+      // ── X パイプライン ──
+      let xGuardOk = false, xDryOk = false;
+      const xParams = () => {
+        const p = { draft: $("#x-draft").value };
+        const tw = $("#x-tweet").value.trim();
+        if (tw) p.tweet = tw;
+        const dates = $("#x-dates").value.trim().split(/\s+/).filter(Boolean);
+        if (dates.length) p.dates = dates;
+        return p;
+      };
+      const xMaybeUnlock = () => {
+        if (xGuardOk && xDryOk) { unlock($("#x-commit")); $("#x-hint").textContent = "③ 本番投稿が解錠されました。対象名の入力確認があります。"; }
+      };
+      $("#x-guard").onclick = async () => { clearLog(); xGuardOk = await run("x-guard", "dry", {}); xMaybeUnlock(); };
+      $("#x-dry").onclick = async () => { clearLog(); xDryOk = await run("x-publish", "dry", xParams()); xMaybeUnlock(); };
+      $("#x-commit").onclick = async () => {
+        const draft = $("#x-draft").value;
+        if (!confirmType(draft)) return;
+        await run("x-publish", "commit", xParams());
+      };
+      $("#x-sync").onclick = async () => { await run("x-sync", "dry", {}); };
+
+      // ── IG ──
+      let igDryOk = false;
+      const igParams = () => ({ pack: $("#ig-pack").value, date: $("#ig-date").value.trim() });
+      $("#ig-dry").onclick = async () => { clearLog(); igDryOk = await run("ig-publish", "dry", igParams()); if (igDryOk) unlock($("#ig-commit")); };
+      $("#ig-commit").onclick = async () => {
+        if (!confirmType($("#ig-pack").value)) return;
+        await run("ig-publish", "commit", igParams());
+      };
+      $("#ig-mark").onclick = async () => { clearLog(); await run("ig-mark", "commit", { pack: $("#ig-pack").value, format: "carousel" }); };
+
+      // ── note ──
+      let noteDraftOk = false;
+      const noteParams = () => {
+        const p = { article: $("#note-article").value.trim() };
+        const d = $("#note-date").value.trim();
+        if (d) p.date = d;
+        return p;
+      };
+      $("#note-draft").onclick = async () => { clearLog(); noteDraftOk = await run("note-publish", "dry", noteParams()); if (noteDraftOk) unlock($("#note-commit")); };
+      $("#note-commit").onclick = async () => {
+        if (!confirmType($("#note-article").value.trim())) return;
+        await run("note-publish", "commit", noteParams());
+      };
+    },
+  });
+})();

--- a/tools/admin/public/tabs/sales.js
+++ b/tools/admin/public/tabs/sales.js
@@ -1,0 +1,54 @@
+/* sales.js — 売上ダッシュボード（P5・読み取り専用）。
+ * .claude/state/sales/sales-log.json の月次集計 + インライン SVG 棒グラフ。 */
+(function () {
+  const { esc, fetchJson } = App;
+  const yen = (n) => "¥" + Number(n).toLocaleString("en-US");
+
+  function barChart(months, milestone) {
+    if (!months.length) return "";
+    const W = 720, H = 220, padL = 48, padB = 28, padT = 16;
+    const max = Math.max(milestone, ...months.map((m) => m.revenue)) * 1.1;
+    const bw = (W - padL - 12) / months.length;
+    const y = (v) => padT + (H - padT - padB) * (1 - v / max);
+    const bars = months.map((m, i) => {
+      const x = padL + i * bw + bw * 0.15;
+      const w = bw * 0.7;
+      const top = y(m.revenue);
+      const col = m.milestone ? "#1a7f37" : "#16365c";
+      return `<rect x="${x.toFixed(1)}" y="${top.toFixed(1)}" width="${w.toFixed(1)}" height="${(H - padB - top).toFixed(1)}" fill="${col}" rx="2"></rect>` +
+        `<text x="${(x + w / 2).toFixed(1)}" y="${(top - 4).toFixed(1)}" text-anchor="middle" font-size="10" fill="#555">${(m.revenue / 1000).toFixed(0)}k</text>` +
+        `<text x="${(x + w / 2).toFixed(1)}" y="${(H - padB + 14).toFixed(1)}" text-anchor="middle" font-size="10" fill="#888">${esc(m.month.slice(2))}</text>`;
+    }).join("");
+    const my = y(milestone);
+    const mline = `<line x1="${padL}" y1="${my.toFixed(1)}" x2="${W - 12}" y2="${my.toFixed(1)}" stroke="#d33" stroke-dasharray="4 3" stroke-width="1"></line>` +
+      `<text x="${padL + 2}" y="${(my - 3).toFixed(1)}" font-size="9" fill="#d33">¥15k マイルストーン</text>`;
+    return `<svg viewBox="0 0 ${W} ${H}" style="width:100%;max-width:${W}px;height:auto;background:#fff;border:1px solid #e5e5e5;border-radius:8px">${mline}${bars}</svg>`;
+  }
+
+  App.register("sales", {
+    async render(main, filterbar) {
+      filterbar.innerHTML = "";
+      const data = await fetchJson("/api/sales");
+      const { months, total, source, updatedAt } = data;
+
+      const monthCards = months.slice().reverse().map((m) => {
+        const prods = m.products.map((p) =>
+          `<tr class="row"><td>${esc(p.title)}</td><td style="text-align:right">${p.count}</td><td style="text-align:right">${yen(p.revenue)}</td></tr>`
+        ).join("");
+        return `<div class="board-section">` +
+          `<h2>${esc(m.month)}　${yen(m.revenue)}　<small style="font-weight:400;color:#888">（${m.count}件）</small>` +
+          `${m.milestone ? '　<span class="pill posted">¥15k 達成</span>' : ""}</h2>` +
+          `<table class="summary"><thead><tr><th>商品</th><th style="text-align:right">件数</th><th style="text-align:right">売上</th></tr></thead>` +
+          `<tbody>${prods}</tbody></table></div>`;
+      }).join("");
+
+      main.innerHTML =
+        `<div class="pub-wrap" style="max-width:760px">` +
+        `<div class="cinfo">累計 ${yen(total.revenue)}　/　${total.count} 件　/　${total.months} ヶ月<br>` +
+        `<small style="color:#888">真実源: ${esc(source || "")}　最終更新: ${esc(updatedAt || "")}</small></div>` +
+        `<div class="board-section"><h2>月次売上推移</h2>${barChart(months, data.milestone)}</div>` +
+        monthCards +
+        `</div>`;
+    },
+  });
+})();

--- a/tools/admin/public/tabs/sns.js
+++ b/tools/admin/public/tabs/sns.js
@@ -1,0 +1,154 @@
+/* sns.js — SNSパックタブ（画像/動画目視 + posted バッジ）と SNS状態板タブ（読み取り専用）。
+ * 表示値はすべてリポジトリ内のパス・slug・日付。App.esc() でエスケープして挿入する。 */
+(function () {
+  const { esc, fetchJson } = App;
+
+  function fmtPill(fmt, entry) {
+    if (!entry) return `<span class="pill empty">${esc(fmt)} 未</span>`;
+    const at = entry.at ? ` ${esc(entry.at)}` : "";
+    return `<span class="pill posted">${esc(fmt)}${at}</span>`;
+  }
+
+  function thumb(m) {
+    if (m.video) {
+      // ローカルに mp4 があれば再生、無ければ R2 退避バッジ
+      return `<video controls preload="metadata" src="${esc(m.url)}" ` +
+        `onerror="this.replaceWith(Object.assign(document.createElement('span'),{className:'badge offloaded',textContent:'R2退避 mp4'}))"></video>`;
+    }
+    return `<img loading="lazy" src="${esc(m.url)}" alt="${esc(m.name)}">`;
+  }
+
+  // ── SNSパックタブ ─────────────────────────────────────────
+  App.register("sns", {
+    async render(main, filterbar) {
+      const { igPacks, xDrafts } = await fetchJson("/api/gallery/sns");
+      const exams = [...new Set(igPacks.map((p) => p.exam))].sort();
+
+      filterbar.innerHTML =
+        `<b>チャネル</b>` +
+        `<button class="chip active" data-key="channel" data-val="">全て</button>` +
+        `<button class="chip" data-key="channel" data-val="instagram">Instagram <span class="n">${igPacks.length}</span></button>` +
+        `<button class="chip" data-key="channel" data-val="x">X <span class="n">${xDrafts.length}</span></button>` +
+        `<span class="sep"></span><b>IG資格</b>` +
+        `<button class="chip active" data-key="exam" data-val="">全</button>` +
+        exams.map((e) =>
+          `<button class="chip" data-key="exam" data-val="${esc(e)}">${esc(e)} ` +
+          `<span class="n">${igPacks.filter((p) => p.exam === e).length}</span></button>`
+        ).join("") +
+        `<span class="sep"></span>` +
+        `<button class="chip" data-key="posted" data-val="pending">未投稿のみ</button>` +
+        `<span class="count"></span>`;
+
+      const igCards = igPacks.map((p) => {
+        const allMedia = [...(p.media.carousel || []), ...(p.media.reels || []), ...(p.media.stories || [])];
+        const thumbs = allMedia.slice(0, 12).map(thumb).join("");
+        const reelBadge = p.media.reelsOffloaded ? `<span class="badge offloaded">reels R2退避</span>` : "";
+        const anyPosted = p.posted && ["carousel", "reels", "stories"].some((f) => p.posted[f]);
+        return `<div class="pack" data-channel="instagram" data-exam="${esc(p.exam)}" data-posted="${anyPosted ? "done" : "pending"}">` +
+          `<h3>${esc(p.slug)}</h3>` +
+          `<div class="status-row">${reelBadge}` +
+          ["carousel", "reels", "stories"].map((f) => fmtPill(f, p.posted && p.posted[f])).join("") +
+          `</div>` +
+          (thumbs ? `<div class="thumbs">${thumbs}</div>` : `<div style="font-size:11px;color:#bbb">画像なし</div>`) +
+          `</div>`;
+      });
+
+      const xCards = xDrafts.map((d) => {
+        const imgs = (d.images || []).slice(0, 12)
+          .map((i) => `<img loading="lazy" src="${esc(i.url)}" alt="${esc(i.name)}">`).join("");
+        const c = d.counts;
+        return `<div class="pack" data-channel="x" data-exam="" data-posted="${c.posted > 0 ? "done" : "pending"}">` +
+          `<h3>${esc(d.name)}</h3>` +
+          `<div class="status-row">` +
+          `<span class="pill posted">投稿 ${c.posted}</span>` +
+          `<span class="pill scheduled">予約 ${c.scheduled}</span>` +
+          `<span class="pill draft">下書 ${c.draft}</span>` +
+          `<span style="font-size:11px;color:#999">/ ${d.total}件</span></div>` +
+          (imgs ? `<div class="thumbs">${imgs}</div>` : "") +
+          `</div>`;
+      });
+
+      main.innerHTML = `<div class="grid">${igCards.join("") + xCards.join("")}</div>`;
+
+      const sel = { channel: "", exam: "", posted: "" };
+      function apply() {
+        let shown = 0;
+        main.querySelectorAll(".pack").forEach((el) => {
+          const okC = !sel.channel || el.dataset.channel === sel.channel;
+          const okE = !sel.exam || el.dataset.exam === sel.exam;
+          const okP = !sel.posted || el.dataset.posted === sel.posted;
+          el.style.display = okC && okE && okP ? "" : "none";
+          if (okC && okE && okP) shown++;
+        });
+        filterbar.querySelector(".count").textContent = `${shown} パック表示`;
+      }
+      filterbar.addEventListener("click", (e) => {
+        const btn = e.target.closest(".chip");
+        if (!btn) return;
+        const key = btn.dataset.key;
+        // posted は toggle（同値クリックで解除）
+        if (key === "posted") {
+          sel.posted = sel.posted === btn.dataset.val ? "" : btn.dataset.val;
+          btn.classList.toggle("active", sel.posted === btn.dataset.val);
+        } else {
+          sel[key] = btn.dataset.val;
+          filterbar.querySelectorAll(`.chip[data-key="${key}"]`).forEach((b) =>
+            b.classList.toggle("active", b === btn)
+          );
+        }
+        apply();
+      });
+      apply();
+    },
+  });
+
+  // ── SNS状態板タブ（読み取り専用）───────────────────────────
+  App.register("board", {
+    async render(main, filterbar) {
+      const { ig, x, schedule } = await fetchJson("/api/sns/board");
+      filterbar.innerHTML = "";
+
+      // IG 試験別サマリ（ig-status summary と同義）
+      const igRows = Object.entries(ig.byExam).map(([exam, s]) => {
+        const pct = s.total > 0 ? Math.round((s.done / s.total) * 20) : 0;
+        const bar = "█".repeat(pct) + "░".repeat(20 - pct);
+        return `<tr><td>${esc(exam)}</td><td>${s.done} / ${s.total}</td>` +
+          `<td><span class="bar">${bar}</span></td>` +
+          `<td>${s.carousel} / ${s.reels} / ${s.stories}</td></tr>`;
+      }).join("");
+
+      // 直近の予約/投稿予定（schedule から未来日を近い順に）
+      const today = new Date().toISOString().slice(0, 10);
+      const upcoming = [];
+      for (const s of schedule) {
+        for (const [k, label] of [["ig_carousel_date", "IG carousel"], ["ig_reels_date", "IG reels"], ["yt_post_date", "YouTube"]]) {
+          if (s[k] && s[k] >= today) upcoming.push({ date: s[k], label, slug: s.slug });
+        }
+      }
+      upcoming.sort((a, b) => a.date.localeCompare(b.date));
+      const upRows = upcoming.slice(0, 40).map((u) =>
+        `<tr><td>${esc(u.date)}</td><td>${esc(u.label)}</td><td>${esc(u.slug)}</td></tr>`
+      ).join("");
+
+      // X ドラフトの予約/投稿状況
+      const xRows = x.drafts.map((d) =>
+        `<tr><td>${esc(d.name)}</td><td>${d.counts.posted} / ${d.counts.scheduled} / ${d.counts.draft}</td>` +
+        `<td>${d.total}</td><td>${esc(d.updatedAt ? d.updatedAt.slice(0, 10) : "")}</td></tr>`
+      ).join("");
+
+      main.innerHTML =
+        `<div class="board-section"><h2>Instagram 進捗（いずれか投稿済み: ${ig.totalDone} / ${ig.total}）</h2>` +
+        `<table class="summary"><thead><tr><th>資格</th><th>DONE / 合計</th><th>進捗</th><th>C / R / S</th></tr></thead>` +
+        `<tbody>${igRows}</tbody></table></div>` +
+
+        `<div class="board-section"><h2>X ドラフト（投稿 / 予約 / 下書き）</h2>` +
+        `<table class="summary"><thead><tr><th>ドラフト</th><th>投稿/予約/下書</th><th>tweet数</th><th>更新</th></tr></thead>` +
+        `<tbody>${xRows}</tbody></table>` +
+        `<p style="font-size:12px;color:#888">合計 tweet: ${x.totals.tweets}　投稿 ${x.totals.posted} / 予約 ${x.totals.scheduled} / 下書 ${x.totals.draft}</p></div>` +
+
+        `<div class="board-section"><h2>直近の予定（schedule.json・今日以降 ${upcoming.length} 件中 40 件）</h2>` +
+        `<table class="summary"><thead><tr><th>日付</th><th>チャネル</th><th>slug</th></tr></thead>` +
+        `<tbody>${upRows}</tbody></table></div>`;
+    },
+  });
+})();

--- a/tools/admin/server.mjs
+++ b/tools/admin/server.mjs
@@ -9,9 +9,13 @@
  *   /media/*      … .local/r2/posts | docs/sns | docs/note の画像/動画（lib/media.mjs）
  *   /api/gallery/{ogp|figures|note|sns} … ギャラリー走査 JSON（lib/scan.mjs）
  *   /api/sns/board                      … SNS 投稿状態板 JSON（lib/sot.mjs）
+ *   /api/actions                        … 実行可能アクション一覧（GET）
+ *   /api/job/run   (POST, SSE)          … アクション実行 + ログストリーム（lib/jobs.mjs）
+ *   /api/job/status (GET)               … 実行中ジョブ状態
  *
- * 127.0.0.1 バインドのみ（LAN 非公開）。書き込み API は無し（Phase 3 で
- * 既存 CLI の child_process 実行として追加予定 — 直接 fs 書き込みはしない方針）。
+ * 127.0.0.1 バインドのみ（LAN 非公開）。POST は Origin=127.0.0.1 検査 +
+ * X-Admin ヘッダ必須（他サイトからの drive-by POST を遮断）。書き込みは
+ * 既存 CLI の child_process 実行に一本化（直接 fs 書き込みしない）。
  */
 import { createServer } from "node:http";
 import { createReadStream, existsSync, statSync } from "node:fs";
@@ -20,6 +24,7 @@ import { fileURLToPath } from "node:url";
 import { serveMedia } from "./lib/media.mjs";
 import { scanOgp, scanFigures, scanNoteImages, scanSnsPacks } from "./lib/scan.mjs";
 import { snsBoard } from "./lib/sot.mjs";
+import { ACTIONS, startJob, jobStatus } from "./lib/jobs.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PUBLIC = resolve(join(HERE, "public"));
@@ -65,6 +70,14 @@ async function handleApi(req, res, url) {
         return sendJson(res, 200, await cached("sns", scanSnsPacks, refresh));
       case "/api/sns/board":
         return sendJson(res, 200, await cached("board", snsBoard, refresh));
+      case "/api/actions":
+        return sendJson(res, 200, {
+          actions: Object.entries(ACTIONS).map(([id, a]) => ({
+            id, label: a.label, needsBrowser: a.needsBrowser, supportsCommit: a.supportsCommit,
+          })),
+        });
+      case "/api/job/status":
+        return sendJson(res, 200, jobStatus());
       default:
         return sendJson(res, 404, { error: "not found" });
     }
@@ -72,6 +85,58 @@ async function handleApi(req, res, url) {
     console.error(`[admin] API error ${url.pathname}:`, err);
     return sendJson(res, 500, { error: String(err?.message || err) });
   }
+}
+
+// ─── POST（CSRF ガード + ジョブ実行）────────────────────────
+// localhost への drive-by POST を防ぐ: Origin が admin 自身 + カスタムヘッダ必須。
+function csrfOk(req) {
+  const origin = req.headers["origin"];
+  const okOrigin = !origin || origin === `http://${HOST}:${PORT}` || origin === `http://localhost:${PORT}`;
+  const okHeader = req.headers["x-admin"] === "1";
+  return okOrigin && okHeader;
+}
+
+function readBody(req, limit = 64 * 1024) {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    req.on("data", (c) => {
+      buf += c;
+      if (buf.length > limit) reject(new Error("body too large"));
+    });
+    req.on("end", () => resolve(buf));
+    req.on("error", reject);
+  });
+}
+
+async function handlePost(req, res, url) {
+  if (!csrfOk(req)) return sendJson(res, 403, { error: "CSRF guard: Origin/X-Admin 不正" });
+  if (url.pathname !== "/api/job/run") return sendJson(res, 404, { error: "not found" });
+
+  let payload;
+  try {
+    payload = JSON.parse((await readBody(req)) || "{}");
+  } catch {
+    return sendJson(res, 400, { error: "invalid JSON" });
+  }
+
+  let job;
+  try {
+    job = startJob({ action: payload.action, mode: payload.mode || "dry", params: payload.params || {} });
+  } catch (err) {
+    return sendJson(res, 409, { error: String(err?.message || err) });
+  }
+
+  // SSE でログをストリーム
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  // 既に流れたバッファを再送してから購読
+  for (const line of job.buffer) res.write(`data: ${JSON.stringify(line)}\n\n`);
+  if (job.done) return res.end();
+  job.subscribers.add(res);
+  req.on("close", () => job.subscribers.delete(res));
 }
 
 function serveStatic(req, res, pathname) {
@@ -92,8 +157,16 @@ function serveStatic(req, res, pathname) {
 
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://${HOST}:${PORT}`);
+  if (req.method === "POST") {
+    try {
+      return await handlePost(req, res, url);
+    } catch (err) {
+      console.error("[admin] POST error:", err);
+      return sendJson(res, 500, { error: String(err?.message || err) });
+    }
+  }
   if (req.method !== "GET") {
-    return sendJson(res, 405, { error: "read-only server (Phase 0-2)" });
+    return sendJson(res, 405, { error: "method not allowed" });
   }
   if (serveMedia(req, res)) return;
   if (url.pathname.startsWith("/api/")) return handleApi(req, res, url);

--- a/tools/admin/server.mjs
+++ b/tools/admin/server.mjs
@@ -25,6 +25,8 @@ import { serveMedia } from "./lib/media.mjs";
 import { scanOgp, scanFigures, scanNoteImages, scanSnsPacks } from "./lib/scan.mjs";
 import { snsBoard } from "./lib/sot.mjs";
 import { ACTIONS, startJob, jobStatus } from "./lib/jobs.mjs";
+import { articlesIndex, magazines, noteArticles } from "./lib/content.mjs";
+import { salesSummary } from "./lib/sales.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PUBLIC = resolve(join(HERE, "public"));
@@ -70,6 +72,14 @@ async function handleApi(req, res, url) {
         return sendJson(res, 200, await cached("sns", scanSnsPacks, refresh));
       case "/api/sns/board":
         return sendJson(res, 200, await cached("board", snsBoard, refresh));
+      case "/api/content/articles":
+        return sendJson(res, 200, await cached("articles", articlesIndex, refresh));
+      case "/api/content/magazines":
+        return sendJson(res, 200, await cached("magazines", magazines, refresh));
+      case "/api/content/note":
+        return sendJson(res, 200, await cached("note-articles", noteArticles, refresh));
+      case "/api/sales":
+        return sendJson(res, 200, await cached("sales", salesSummary, refresh));
       case "/api/actions":
         return sendJson(res, 200, {
           actions: Object.entries(ACTIONS).map(([id, a]) => ({

--- a/tools/admin/server.mjs
+++ b/tools/admin/server.mjs
@@ -1,0 +1,106 @@
+/**
+ * doboku-note 運営管理画面 — ローカル専用サーバー（デプロイなし・依存追加なし）。
+ *
+ * Usage:
+ *   npm run admin   →  http://127.0.0.1:3021
+ *
+ * ルート:
+ *   /             … public/ の SPA シェル（Vanilla JS・no-build）
+ *   /media/*      … .local/r2/posts | docs/sns | docs/note の画像/動画（lib/media.mjs）
+ *   /api/gallery/{ogp|figures|note|sns} … ギャラリー走査 JSON（lib/scan.mjs）
+ *   /api/sns/board                      … SNS 投稿状態板 JSON（lib/sot.mjs）
+ *
+ * 127.0.0.1 バインドのみ（LAN 非公開）。書き込み API は無し（Phase 3 で
+ * 既存 CLI の child_process 実行として追加予定 — 直接 fs 書き込みはしない方針）。
+ */
+import { createServer } from "node:http";
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { join, resolve, sep, extname, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { serveMedia } from "./lib/media.mjs";
+import { scanOgp, scanFigures, scanNoteImages, scanSnsPacks } from "./lib/scan.mjs";
+import { snsBoard } from "./lib/sot.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PUBLIC = resolve(join(HERE, "public"));
+const HOST = "127.0.0.1";
+const PORT = Number(process.env.ADMIN_PORT || 3021);
+
+const STATIC_MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+};
+
+// 走査はフルスキャン（数千ファイル）なので短い TTL でキャッシュ。?refresh=1 で強制再走査。
+const cache = new Map(); // key → { at, data }
+const TTL_MS = 60_000;
+
+async function cached(key, fn, refresh) {
+  const hit = cache.get(key);
+  if (!refresh && hit && Date.now() - hit.at < TTL_MS) return hit.data;
+  const data = await fn();
+  cache.set(key, { at: Date.now(), data });
+  return data;
+}
+
+function sendJson(res, status, data) {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-cache" });
+  res.end(JSON.stringify(data));
+}
+
+async function handleApi(req, res, url) {
+  const refresh = url.searchParams.has("refresh");
+  try {
+    switch (url.pathname) {
+      case "/api/gallery/ogp":
+        return sendJson(res, 200, await cached("ogp", scanOgp, refresh));
+      case "/api/gallery/figures":
+        return sendJson(res, 200, await cached("figures", scanFigures, refresh));
+      case "/api/gallery/note":
+        return sendJson(res, 200, await cached("note", scanNoteImages, refresh));
+      case "/api/gallery/sns":
+        return sendJson(res, 200, await cached("sns", scanSnsPacks, refresh));
+      case "/api/sns/board":
+        return sendJson(res, 200, await cached("board", snsBoard, refresh));
+      default:
+        return sendJson(res, 404, { error: "not found" });
+    }
+  } catch (err) {
+    console.error(`[admin] API error ${url.pathname}:`, err);
+    return sendJson(res, 500, { error: String(err?.message || err) });
+  }
+}
+
+function serveStatic(req, res, pathname) {
+  const rel = pathname === "/" ? "index.html" : pathname.slice(1);
+  const full = resolve(join(PUBLIC, rel));
+  if (full !== PUBLIC && !full.startsWith(PUBLIC + sep)) {
+    res.writeHead(403);
+    return res.end("403");
+  }
+  if (!existsSync(full) || !statSync(full).isFile()) {
+    res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+    return res.end("404 Not Found");
+  }
+  const mime = STATIC_MIME[extname(full).toLowerCase()] || "application/octet-stream";
+  res.writeHead(200, { "Content-Type": mime, "Cache-Control": "no-cache" });
+  createReadStream(full).pipe(res);
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${HOST}:${PORT}`);
+  if (req.method !== "GET") {
+    return sendJson(res, 405, { error: "read-only server (Phase 0-2)" });
+  }
+  if (serveMedia(req, res)) return;
+  if (url.pathname.startsWith("/api/")) return handleApi(req, res, url);
+  return serveStatic(req, res, url.pathname);
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`[admin] doboku-note 管理画面 → http://${HOST}:${PORT}`);
+  console.log(`[admin] ローカル専用（${HOST} バインド・デプロイなし）。Ctrl+C で終了`);
+});


### PR DESCRIPTION
## 概要

SNS 投稿・記事画像・note カバーの目視確認、投稿/予約実行、記事・note・マガジンの一覧管理、収益実績の可視化までを1画面で行う **ローカル専用** 管理画面を `tools/admin/` に新設。デプロイなし（運用コスト 0 円）・依存追加ゼロ（`node:http` のみ）。

```bash
npm run admin   # → http://127.0.0.1:3021
```

## 配置判断（なぜ tools/admin ローカルサーバーか）

- **投稿系はローカル実行必須**: Playwright ログインプロファイル（`.local/playwright-*-profile`）がこの PC にあるため。クラウドにデプロイしても投稿・書き込み不可で、認証・ホスティングコストだけ増える。
- 本体 Next.js は本番 `output: 'export'` のため `/admin` 同居は export ビルドと干渉 → 却下。apps/admin 別アプリは node_modules 数百MB 重複 → 却下。
- `tools/` は eslint(`src/`) / tsc(`**/*.ts` — tools に TS 0 件) / knip / next build のどのスコープにも入らず **CI 影響ゼロ**。

## タブ（Phase 0〜5）

| タブ | 内容 | データソース |
|---|---|---|
| OGP | 全 ogp.png（資格×分類フィルタ） | `.local/r2/posts/**/ogp.png` |
| 記事図版 | SVG / PNG・WebP クロップ（監査 severity バッジ） | `.local/r2/posts/**/img/*`, `svg-audit.json` |
| note画像 | カバー / 図版（試験×種別フィルタ） | `docs/note/**/img/{cover*,figure-*}.png` |
| SNSパック | IG パック・X ドラフトの画像目視 + posted バッジ | `docs/sns/instagram/**`, `docs/sns/x/draft/**` |
| SNS状態板 | IG 進捗・X 予約状況・直近スケジュール | `schedule.json`, posted.json, x status.json |
| 投稿/予約 | X 4ステップパイプライン・IG 予約投稿・note 公開（2段階UI + SSEログ） | 既存 CLI を child_process 実行（`lib/jobs.mjs`） |
| 記事/note/マガジン | サイト記事 / note 原稿 / マガジンの一覧・公開状態 | `doc-meta-index.json` / `docs/note/**/article*.md` / `note-magazines.ts`（`lib/content.mjs`） |
| 売上 | 月次売上推移（インライン SVG 棒グラフ）+ 商品別内訳・¥15k マイルストーン | `sales-log.json`（`lib/sales.mjs`） |

## 設計の要点

- **走査/集計は既存資産を再利用**（`ig-status.mjs` の export を import、ギャラリー/売上は既存スクリプトと同ロジック）。
- **/media/*** は3ルート限定 static serve（`path.resolve` 後 `startsWith` + MIME allowlist）。
- **投稿(P3)はガードを CLI 側に残す**: ホワイトリスト実行（`lib/jobs.mjs`）・引数厳格検証・`spawn(shell:false)`・`mode≠commit` は `--dry-run` 強制・本番は dry 成功+タイプ確認・同時1ジョブ・CSRF（Origin+`X-Admin`）。

## 検証（数値突合・実 HTTP）

- **件数一致**: OGP **1098** / note cover **642** / figure **128** / IG **453**（done **22**） / サイト記事 **1056** / マガジン **50**（公開45） / note原稿 **642** / 売上 **¥250,980・119件**（すべて既存スクリプトと一致）。
- **P3 セキュリティ**: CSRF 403 / 不明action 409 / traversal 拒否 / dry-run 強制 / 実 `x-schedule-guard` を SSE 完走(exit 0) / 単一ジョブロック 409。
- 全 JS `node --check` OK、API/静的配信 200。
- ⚠️ ライブのブラウザ描画/2段階クリックの screenshot 確認は worktree 制約（Chrome拡張未接続・preview は main tree 束縛）で未実施。P3 の安全の本丸はサーバ側（dry-run 強制・CLI 内ガード）、P4/P5 は読み取り専用でデータ層を突合済み。

## 変更ファイル
`tools/**` + `package.json`（admin script 1行）+ `.claude/launch.json`（preview 用）のみ。

> 注: 最終コミット（P4/P5）は pre-commit を `--no-verify`（ユーザー承認済み）。共有 node_modules から `@mdx-js/mdx@3.1.1` が欠落し `pre-commit-mdx.mjs` が import 時クラッシュするため（本 PR は MDX 0件で無関係）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)