### PR TITLE
polish(cta): note もくじタイルを白カード枠で囲み転職アフィリと意匠統一

### DIFF
--- a/src/components/ui/HubCtaBanner/HubCtaBanner.tsx
+++ b/src/components/ui/HubCtaBanner/HubCtaBanner.tsx
@@ -17,21 +17,24 @@ export default function HubCtaBanner({ cta }: { cta: ResolvedHubCta }) {
       rel="noopener noreferrer"
       data-cta="note"
       data-cta-label={cta.trackLabel}
-      className="group relative block aspect-[6/5] w-full max-w-[360px] overflow-hidden rounded-card-content border border-[var(--rule-soft)] shadow-card-content transition-shadow hover:shadow-card-hover"
+      className="group block w-full max-w-[360px] overflow-hidden rounded-card-content border border-[var(--rule-soft)] bg-[var(--paper)] p-2 shadow-card-content transition-shadow hover:shadow-card-hover"
     >
-      <Image src={cta.bg} alt="" fill sizes="360px" className="object-cover" />
-      <div className="absolute inset-y-0 left-0 flex w-[56%] flex-col items-start justify-center pl-5 pr-1 text-[var(--on-image-ink)]">
-        <span className="text-[12px] font-extrabold tracking-wide" style={{ color: `var(${cta.themeVar})`, ...HALO }}>
-          ＼ {cta.badge ?? 'note限定'} ／
-        </span>
-        <span className="text-[12px] font-extrabold text-[var(--on-image-ink-soft)]" style={HALO}>{cta.qual}</span>
-        <span className="text-[19px] font-black leading-tight" style={HALO}>{cta.title1}</span>
-        {cta.title2 && <span className="text-[21px] font-black leading-tight" style={HALO}>{cta.title2}</span>}
-        <span className="mt-0.5 text-[11px] font-bold text-[var(--on-image-ink-soft)]" style={HALO}>{cta.sub}</span>
-        <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-[var(--on-image-pill-bg)] px-3 py-1 text-[13px] font-black text-white shadow-card-content">
-          {cta.price ?? cta.cta}
-          <span aria-hidden>›</span>
-        </span>
+      {/* 白カード枠（bg-paper + p-2）で囲む＝転職アフィリ SidebarAdBanner とカード意匠を統一。画像は内側に inset。 */}
+      <div className="relative aspect-[6/5] w-full overflow-hidden rounded-[6px]">
+        <Image src={cta.bg} alt="" fill sizes="360px" className="object-cover" />
+        <div className="absolute inset-y-0 left-0 flex w-[56%] flex-col items-start justify-center pl-4 pr-1 text-[var(--on-image-ink)]">
+          <span className="text-[12px] font-extrabold tracking-wide" style={{ color: `var(${cta.themeVar})`, ...HALO }}>
+            ＼ {cta.badge ?? 'note限定'} ／
+          </span>
+          <span className="text-[12px] font-extrabold text-[var(--on-image-ink-soft)]" style={HALO}>{cta.qual}</span>
+          <span className="text-[19px] font-black leading-tight" style={HALO}>{cta.title1}</span>
+          {cta.title2 && <span className="text-[21px] font-black leading-tight" style={HALO}>{cta.title2}</span>}
+          <span className="mt-0.5 text-[11px] font-bold text-[var(--on-image-ink-soft)]" style={HALO}>{cta.sub}</span>
+          <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-[var(--on-image-pill-bg)] px-3 py-1 text-[13px] font-black text-white shadow-card-content">
+            {cta.price ?? cta.cta}
+            <span aria-hidden>›</span>
+          </span>
+        </div>
       </div>
     </a>
   );


### PR DESCRIPTION
docs サイドバー等で note もくじタイル（HubCtaBanner）がフルブリード画像で、転職アフィリ（白カード枠）と不揃いだった問題を解消。HubCtaBanner を白カード枠（bg-paper+p-2+border+shadow・画像 inset）に変更。note CTA の単一コンポーネントのため、サイドバー/記事末/カテゴリhub の全箇所に自動適用（もれなく）。type-check/lint-ui/eslint green・スクショ確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)