### PR TITLE
feat(admin): 品質タブ — モバイル可読性ラチェットの違反ダッシュボード

### DIFF
--- a/.claude/state/quality/history.jsonl
+++ b/.claude/state/quality/history.jsonl
@@ -1,0 +1,1 @@
+{"date":"2026-07-07","files":602,"violations":4465,"totals":{"HIGH":26,"MEDIUM":3979,"LOW":460},"byExam":{"civil-construction-1":1268,"civil-construction-2":331,"concrete-chief-engineer":45,"pe-comprehensive-management":1500,"pe-construction":1001,"pe-construction-guide-required-essay":12,"pe-first-stage":308}}

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "check-content-quality": "node .claude/scripts/lint-mdx-mobile.mjs --all --baseline --report",
     "check-content-quality:ci": "node .claude/scripts/lint-mdx-mobile.mjs --all --baseline --report --ci",
     "update-content-quality-baseline": "node .claude/scripts/lint-mdx-mobile.mjs --all --update-baseline",
+    "quality-snapshot": "node scripts/quality-snapshot.mjs",
     "check-orphan-figures": "node scripts/check-orphan-figures.mjs",
     "check-ig-cover": "node scripts/check-ig-cover.mjs",
     "check-ig-cta": "node scripts/check-ig-cta.mjs",

--- a/scripts/quality-snapshot.mjs
+++ b/scripts/quality-snapshot.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * quality-snapshot.mjs — コンテンツ品質ラチェットの違反総数スナップショットを記録する。
+ *
+ * `.claude/state/quality/lint-baseline.json`（現時点の grandfather 済み違反）を読み、
+ * 資格別・重大度別の総数を1行の JSON として `.claude/state/quality/history.jsonl` に追記する。
+ * これを定期的に叩くと、リライトで違反が減っていく「バーンダウン」が admin 品質タブに出る。
+ *
+ * 使い方:
+ *   node scripts/quality-snapshot.mjs            # 今日の日付でスナップショット追記
+ *   node scripts/quality-snapshot.mjs 2026-07-01 # 日付を明示（種まき・補填用）
+ *
+ * 週次運用では baseline 更新（リライト後の刈り込み）の後にこれを叩くと履歴が育つ。
+ * 進捗は「自己申告」ではなく baseline の実データから導出する（陳腐化しない）。
+ */
+import { readFileSync, appendFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(join(dirname(fileURLToPath(import.meta.url)), ".."));
+const BASELINE = join(ROOT, ".claude", "state", "quality", "lint-baseline.json");
+const HISTORY = join(ROOT, ".claude", "state", "quality", "history.jsonl");
+const RULES = join(ROOT, ".claude", "config", "content-rules.json");
+
+function readJson(p, fallback) {
+  try { return JSON.parse(readFileSync(p, "utf8")); } catch { return fallback; }
+}
+
+function isoDate(arg) {
+  if (arg && /^\d{4}-\d{2}-\d{2}$/.test(arg)) return arg;
+  // Date は通常スクリプトでは利用可（Workflow 制約は本スクリプトに無関係）
+  return new Date().toISOString().slice(0, 10);
+}
+
+function main() {
+  const baseline = readJson(BASELINE, null);
+  if (!baseline || !baseline.counts) {
+    console.error("baseline が見つかりません。先に npm run update-content-quality-baseline を実行してください。");
+    process.exit(1);
+  }
+  const sev = (readJson(RULES, { defaults: {} }).defaults) || {};
+
+  const totals = { HIGH: 0, MEDIUM: 0, LOW: 0 };
+  const byExam = {};
+  let files = 0;
+  let violations = 0;
+
+  for (const [rp, ruleCounts] of Object.entries(baseline.counts)) {
+    files++;
+    const exam = rp.split(/[\\/]/)[3] || "other";
+    byExam[exam] ||= 0;
+    for (const [rule, n] of Object.entries(ruleCounts)) {
+      violations += n;
+      byExam[exam] += n;
+      const s = sev[rule] || "MEDIUM";
+      totals[s] = (totals[s] || 0) + n;
+    }
+  }
+
+  const record = { date: isoDate(process.argv[2]), files, violations, totals, byExam };
+
+  mkdirSync(dirname(HISTORY), { recursive: true });
+  // 同日の重複追記は許容（最新が優先されるよう UI 側で日付集約）。運用上は1日1回想定。
+  appendFileSync(HISTORY, JSON.stringify(record) + "\n");
+
+  const label = existsSync(HISTORY) ? "追記" : "作成";
+  console.log(`[quality-snapshot] ${label}: ${record.date}  違反 ${violations}（HIGH ${totals.HIGH} / MEDIUM ${totals.MEDIUM} / LOW ${totals.LOW}・${files} 記事）`);
+}
+
+main();

--- a/tools/admin/README.md
+++ b/tools/admin/README.md
@@ -11,7 +11,7 @@ npm run admin        # → http://127.0.0.1:3021
 
 `127.0.0.1` バインドのみ（LAN 非公開）。依存追加ゼロ（node:http のみ）。
 
-## タブ（Phase 0〜5 実装済み）
+## タブ（Phase 0〜6 実装済み）
 
 | タブ | 内容 | データソース |
 |---|---|---|
@@ -22,6 +22,7 @@ npm run admin        # → http://127.0.0.1:3021
 | SNS状態板 | IG 進捗サマリ・X 予約状況・直近スケジュール（読み取り専用） | `docs/sns/schedule.json`、posted.json、x status.json |
 | 投稿/予約 | X 4ステップパイプライン・IG 予約投稿・note 公開（2段階UI + SSEログ） | 既存 CLI を child_process 実行（`lib/jobs.mjs`） |
 | 記事/note/マガジン | サイト記事 / note 原稿 / マガジンの一覧・公開状態（読み取り専用） | `doc-meta-index.json`、`docs/note/**/article*.md`、`note-magazines.ts`（`lib/content.mjs`） |
+| 品質 | モバイル可読性ラチェットの違反を GA4 人気度順に一覧（資格×分類×ルールでフィルタ）・ルール別集計・違反バーンダウン（読み取り専用） | `lint-baseline.json` × `popular-pages.json` × `content-rules.json` × `doc-meta-index.json` × `history.jsonl`（`lib/quality.mjs`） |
 | 売上 | 月次売上推移（インライン SVG 棒グラフ）+ 商品別内訳・¥15k マイルストーン | `.claude/state/sales/sales-log.json`（`lib/sales.mjs`） |
 
 件数は既存スクリプト（`ogp-gallery` / `note-cover-gallery` / `svg-gallery` / `sales-summary`）と一致する。
@@ -53,8 +54,18 @@ tools/admin/
   lib/jobs.mjs       投稿アクションのホワイトリスト実行 + 引数検証 + SSE（P3）
   lib/content.mjs    記事/note/マガジン一覧（P4）
   lib/sales.mjs      売上集計（P5）
+  lib/quality.mjs    品質ラチェット集計（P6・読み取り専用）
   public/            Vanilla JS SPA（no-build）
 ```
 
-Phase 0〜5 実装済み。追加候補: 計測ダッシュボード統合（GA4/GSC weekly-metrics）、
-IG ライブ照合（`verify-ig-status`）の UI 化、note ライブ照合（`verify-note-magazines`）ボタン。
+Phase 0〜6 実装済み。
+
+**品質タブ（P6）の補足**: データは全て live 読み（UI に状態を持たない）。表示の鮮度は
+`npm run check-content-quality` →（リライト後は）`npm run update-content-quality-baseline`
+で `lint-baseline.json` を更新した時点。違反バーンダウンは `npm run quality-snapshot`
+（`.claude/state/quality/history.jsonl` に日次追記）を週次で回すと折れ線になる。真実源は
+`.claude/scripts/lint-mdx-mobile.mjs` / `.claude/config/content-rules.json`。
+
+追加候補: 品質タブに「再スキャンボタン」（`lib/jobs.mjs` の CSRF/SSE パターンで
+`check-content-quality` を実行）、`/quality-cycle` リライト起動、TODO（`docs/todo/*.md`）の
+read-only 統合ビュー、計測ダッシュボード統合（GA4/GSC weekly-metrics）。

--- a/tools/admin/lib/quality.mjs
+++ b/tools/admin/lib/quality.mjs
@@ -1,0 +1,122 @@
+/**
+ * quality.mjs — コンテンツ品質ダッシュボード（読み取り専用）。
+ * lint ラチェットの baseline × GA4 人気度 × ルール設定 を join し、
+ * 記事別 / ルール別 / 資格別の違反集計と、違反バーンダウン履歴を返す。
+ *
+ * データソース（すべて git 作業ツリー内・live 読み）:
+ *   .claude/state/quality/lint-baseline.json … file × ruleID × 件数（真実源）
+ *   .claude/state/quality/history.jsonl      … 違反総数のスナップショット（バーンダウン）
+ *   src/config/popular-pages.json            … slug → activeUsers（優先度）
+ *   .claude/config/content-rules.json        … ルールの重大度（defaults）・fullScan
+ *   src/config/doc-meta-index.json           … slug → category / group / title
+ *
+ * lint 実装・ルールの真実源は .claude/scripts/lint-mdx-mobile.mjs / content-rules.json。
+ * 本モジュールは表示用の集約のみで、状態は一切持たない（UI で SoT を二重化しない）。
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(join(dirname(fileURLToPath(import.meta.url)), "..", "..", ".."));
+const BASELINE = join(ROOT, ".claude", "state", "quality", "lint-baseline.json");
+const HISTORY = join(ROOT, ".claude", "state", "quality", "history.jsonl");
+const POPULAR = join(ROOT, "src", "config", "popular-pages.json");
+const RULES = join(ROOT, ".claude", "config", "content-rules.json");
+const DOCMETA = join(ROOT, "src", "config", "doc-meta-index.json");
+
+function readJson(p, fallback) {
+  try { return JSON.parse(readFileSync(p, "utf8")); } catch { return fallback; }
+}
+
+// relPath（例 .local/r2/posts/pe-construction/river-coast-exam-themes/article.mdx）
+// から /docs のフラット slug を推定。lint-mdx-mobile.mjs の deriveSlug と同一規約。
+function deriveSlug(rp) {
+  const parts = rp.split(/[\\/]/);
+  const i = parts.indexOf("posts");
+  const seg = i >= 0 ? parts.slice(i + 1) : parts;
+  const last = seg[seg.length - 1];
+  if (last === "article.mdx") seg.pop();
+  else seg[seg.length - 1] = last.replace(/\.mdx$/, "");
+  return seg.join("-");
+}
+
+export function qualitySummary() {
+  const baseline = readJson(BASELINE, { counts: {} });
+  const rules = readJson(RULES, { defaults: {}, fullScan: { rules: [] } });
+  const popular = readJson(POPULAR, { pages: [] });
+  const docmeta = readJson(DOCMETA, { docs: {} });
+
+  const sev = rules.defaults || {};
+  const fullScanRules = (rules.fullScan && rules.fullScan.rules) || null;
+  const docs = docmeta.docs || {};
+
+  const popMap = new Map();
+  (popular.pages || []).forEach((p, i) => popMap.set(p.slug, { users: p.activeUsers || 0, rank: i + 1 }));
+
+  const counts = baseline.counts || {};
+  const articles = [];
+  const byRuleAgg = {};
+  const byExamAgg = {};
+  const totals = { HIGH: 0, MEDIUM: 0, LOW: 0 };
+
+  for (const [rp, ruleCounts] of Object.entries(counts)) {
+    const slug = deriveSlug(rp);
+    const meta = docs[slug] || {};
+    const pop = popMap.get(slug) || { users: 0, rank: null };
+    const exam = meta.category || rp.split(/[\\/]/)[3] || "other";
+    const group = meta.group || "";
+
+    let total = 0;
+    for (const [rule, n] of Object.entries(ruleCounts)) {
+      total += n;
+      const s = sev[rule] || "MEDIUM";
+      totals[s] = (totals[s] || 0) + n;
+      const ra = (byRuleAgg[rule] ||= { rule, severity: s, total: 0, files: 0 });
+      ra.total += n;
+      ra.files += 1;
+    }
+
+    const ea = (byExamAgg[exam] ||= { exam, files: 0, total: 0 });
+    ea.files += 1;
+    ea.total += total;
+
+    articles.push({
+      rp,
+      slug,
+      exam,
+      group,
+      title: meta.shortTitle || meta.title || slug,
+      users: pop.users,
+      rank: pop.rank,
+      total,
+      counts: ruleCounts,
+      priority: total * (pop.users + 1),
+    });
+  }
+
+  articles.sort((a, b) => b.priority - a.priority || b.total - a.total);
+  const byRule = Object.values(byRuleAgg).sort((a, b) => b.total - a.total);
+  const byExam = Object.values(byExamAgg).sort((a, b) => b.total - a.total);
+
+  let history = [];
+  if (existsSync(HISTORY)) {
+    history = readFileSync(HISTORY, "utf8")
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .filter(Boolean);
+  }
+
+  return {
+    generatedFrom: popular.generatedFrom || null,
+    window: popular.window || null,
+    fullScanRules,
+    ruleSeverity: sev,
+    totals,
+    articleCount: articles.length,
+    articles,
+    byRule,
+    byExam,
+    history,
+  };
+}

--- a/tools/admin/public/index.html
+++ b/tools/admin/public/index.html
@@ -17,6 +17,7 @@
     <button class="tab" data-tab="board">SNS状態板</button>
     <button class="tab" data-tab="publish">投稿/予約</button>
     <button class="tab" data-tab="content">記事/note/マガジン</button>
+    <button class="tab" data-tab="quality">品質</button>
     <button class="tab" data-tab="sales">売上</button>
   </nav>
   <div class="filterbar" id="filterbar"></div>
@@ -29,6 +30,7 @@
 <script src="/tabs/sns.js"></script>
 <script src="/tabs/publish.js"></script>
 <script src="/tabs/content.js"></script>
+<script src="/tabs/quality.js"></script>
 <script src="/tabs/sales.js"></script>
 <script>App.init();</script>
 </body>

--- a/tools/admin/public/tabs/quality.js
+++ b/tools/admin/public/tabs/quality.js
@@ -1,0 +1,133 @@
+/* quality.js — コンテンツ品質ダッシュボード（読み取り専用）。
+ * lint ラチェットの baseline × GA4 人気度を join した /api/quality を表示する。
+ * 状態は持たず、常に live データを描画する（SoT は baseline.json / content-rules.json）。 */
+(function () {
+  const { esc, fetchJson } = App;
+
+  const GROUP_LABEL = {
+    guide: "ガイド", textbook: "テキスト", keyword: "キーワード", pillar: "まとめ",
+    primary: "過去問(一次)", secondary: "過去問(二次)", "past-exam": "過去問", other: "その他", "": "—",
+  };
+  const sevClass = (s) => (s === "HIGH" ? "high" : s === "LOW" ? "low" : "medium");
+
+  // 違反バーンダウン（履歴 >=2 で折れ線、1 点なら現況カード）。
+  function burndown(history) {
+    if (!history.length) return "";
+    // 同日重複は最後を採用
+    const byDate = {};
+    for (const h of history) byDate[h.date] = h;
+    const pts = Object.values(byDate).sort((a, b) => a.date.localeCompare(b.date));
+    if (pts.length < 2) {
+      const p = pts[0];
+      return `<div class="cinfo">履歴 1 点（${esc(p.date)}）。<b>週次で <code>npm run quality-snapshot</code></b> を回すと違反バーンダウンが出ます。<br>` +
+        `<small style="color:#888">現況: 違反 ${p.violations}（HIGH ${p.totals.HIGH} / MEDIUM ${p.totals.MEDIUM} / LOW ${p.totals.LOW}）</small></div>`;
+    }
+    const W = 720, H = 200, padL = 44, padB = 26, padT = 14;
+    const max = Math.max(...pts.map((p) => p.violations)) * 1.1 || 1;
+    const x = (i) => padL + (W - padL - 12) * (pts.length === 1 ? 0 : i / (pts.length - 1));
+    const y = (v) => padT + (H - padT - padB) * (1 - v / max);
+    const line = pts.map((p, i) => `${i ? "L" : "M"}${x(i).toFixed(1)},${y(p.violations).toFixed(1)}`).join(" ");
+    const area = `M${x(0).toFixed(1)},${(H - padB).toFixed(1)} ` +
+      pts.map((p, i) => `L${x(i).toFixed(1)},${y(p.violations).toFixed(1)}`).join(" ") +
+      ` L${x(pts.length - 1).toFixed(1)},${(H - padB).toFixed(1)} Z`;
+    const dots = pts.map((p, i) =>
+      `<circle cx="${x(i).toFixed(1)}" cy="${y(p.violations).toFixed(1)}" r="3" fill="#16365c"></circle>` +
+      `<text x="${x(i).toFixed(1)}" y="${(y(p.violations) - 7).toFixed(1)}" text-anchor="middle" font-size="10" fill="#555">${p.violations}</text>` +
+      `<text x="${x(i).toFixed(1)}" y="${(H - padB + 14).toFixed(1)}" text-anchor="middle" font-size="9" fill="#999">${esc(p.date.slice(5))}</text>`
+    ).join("");
+    return `<svg viewBox="0 0 ${W} ${H}" style="width:100%;max-width:${W}px;height:auto;background:#fff;border:1px solid #e5e5e5;border-radius:8px">` +
+      `<path d="${area}" fill="#16365c" opacity="0.08"></path>` +
+      `<path d="${line}" fill="none" stroke="#16365c" stroke-width="1.5"></path>${dots}</svg>`;
+  }
+
+  App.register("quality", {
+    async render(main, filterbar) {
+      filterbar.innerHTML = "";
+      const data = await fetchJson("/api/quality");
+      const { totals, articleCount, articles, byRule, byExam, history, window: win, generatedFrom } = data;
+
+      // サマリカード
+      const winStr = win ? `${win.start}〜${win.end}` : "";
+      const cinfo =
+        `<div class="cinfo">違反のある記事 <b>${articleCount}</b> 件　/　違反計 ` +
+        `<span class="badge high">HIGH ${totals.HIGH}</span> ` +
+        `<span class="badge medium">MEDIUM ${totals.MEDIUM}</span> ` +
+        `<span class="badge low">LOW ${totals.LOW}</span><br>` +
+        `<small style="color:#888">対象 = fullScan ルール（表/入れ子/段落/見出し/文体）の baseline。` +
+        `優先度 = 違反数 × GA4 activeUsers（${esc(winStr)}）。更新は <code>npm run check-content-quality</code> → <code>update-content-quality-baseline</code></small></div>`;
+
+      // ルール別集計
+      const ruleRows = byRule.map((r) =>
+        `<tr class="row"><td><span class="badge ${sevClass(r.severity)}">${esc(r.rule)}</span></td>` +
+        `<td>${esc(r.severity)}</td><td style="text-align:right">${r.files}</td><td style="text-align:right">${r.total}</td></tr>`
+      ).join("");
+      const ruleTable = `<div class="board-section"><h2>ルール別（違反の内訳）</h2>` +
+        `<table class="summary"><thead><tr><th>ルール</th><th>重大度</th><th style="text-align:right">記事数</th><th style="text-align:right">違反数</th></tr></thead>` +
+        `<tbody>${ruleRows}</tbody></table></div>`;
+
+      // フィルタ用の候補
+      const exams = [...new Set(articles.map((a) => a.exam))].sort();
+      const groups = [...new Set(articles.map((a) => a.group))].filter(Boolean).sort();
+      const topRules = byRule.slice(0, 12).map((r) => r.rule);
+
+      // 記事テーブル（優先度順）
+      const rows = articles.map((a, i) => {
+        const chips = Object.entries(a.counts).sort((x, y) => y[1] - x[1])
+          .map(([rule, n]) => `<span class="badge ${sevClass(data.ruleSeverity[rule] || "MEDIUM")}" style="margin:1px">${esc(rule)}:${n}</span>`).join(" ");
+        const pop = a.users ? `${a.users} / #${a.rank}` : "—";
+        return `<tr class="row" data-exam="${esc(a.exam)}" data-group="${esc(a.group)}" data-rules="${esc(Object.keys(a.counts).join(" "))}">` +
+          `<td style="text-align:right;color:#999">${i + 1}</td>` +
+          `<td>${esc(a.title)}<br><a class="mono" href="https://doboku-note.com/docs/${esc(a.slug)}" target="_blank" rel="noopener" style="font-size:11px">/docs/${esc(a.slug)}</a></td>` +
+          `<td><span class="badge gray">${esc(a.exam)}</span> ${esc(GROUP_LABEL[a.group] || a.group)}</td>` +
+          `<td style="text-align:right">${pop}</td>` +
+          `<td style="text-align:right"><b>${a.total}</b></td>` +
+          `<td>${chips}</td></tr>`;
+      }).join("");
+
+      const filterBar =
+        `<div class="cfilter"><b>資格</b>` +
+        exams.map((e) => `<button class="chip" data-key="exam" data-val="${esc(e)}">${esc(e)}</button>`).join("") +
+        `<span class="sep"></span><b>分類</b>` +
+        groups.map((g) => `<button class="chip" data-key="group" data-val="${esc(g)}">${esc(GROUP_LABEL[g] || g)}</button>`).join("") +
+        `<span class="sep"></span><b>ルール</b>` +
+        topRules.map((r) => `<button class="chip" data-key="rule" data-val="${esc(r)}">${esc(r)}</button>`).join("") +
+        `<span class="cfcount"></span></div>`;
+
+      const artTable =
+        `<div class="board-section"><h2>記事別（優先度＝違反数 × 人気）</h2>${filterBar}` +
+        `<table class="summary listing"><thead><tr><th>#</th><th>記事</th><th>資格・分類</th><th style="text-align:right">人気(users/順位)</th><th style="text-align:right">違反</th><th>内訳</th></tr></thead>` +
+        `<tbody>${rows}</tbody></table></div>`;
+
+      main.innerHTML =
+        `<div class="pub-wrap" style="max-width:900px">` +
+        cinfo +
+        `<div class="board-section"><h2>違反バーンダウン</h2>${burndown(history)}</div>` +
+        ruleTable +
+        artTable +
+        `</div>`;
+
+      // フィルタ配線（exam/group は完全一致、rule は data-rules に含むか）
+      const bar = main.querySelector(".cfilter");
+      const sel = {};
+      bar.addEventListener("click", (e) => {
+        const b = e.target.closest(".chip[data-key]");
+        if (!b) return;
+        const key = b.dataset.key;
+        sel[key] = sel[key] === b.dataset.val ? "" : b.dataset.val;
+        bar.querySelectorAll(`.chip[data-key="${key}"]`).forEach((x) =>
+          x.classList.toggle("active", x.dataset.val === sel[key] && sel[key] !== ""));
+        let shown = 0;
+        main.querySelectorAll("table.listing tr.row").forEach((tr) => {
+          const okExam = !sel.exam || tr.dataset.exam === sel.exam;
+          const okGroup = !sel.group || tr.dataset.group === sel.group;
+          const okRule = !sel.rule || (" " + tr.dataset.rules + " ").includes(" " + sel.rule + " ");
+          const ok = okExam && okGroup && okRule;
+          tr.style.display = ok ? "" : "none";
+          if (ok) shown++;
+        });
+        const c = main.querySelector(".cfcount");
+        if (c) c.textContent = `${shown} 件`;
+      });
+    },
+  });
+})();

--- a/tools/admin/server.mjs
+++ b/tools/admin/server.mjs
@@ -9,6 +9,7 @@
  *   /media/*      … .local/r2/posts | docs/sns | docs/note の画像/動画（lib/media.mjs）
  *   /api/gallery/{ogp|figures|note|sns} … ギャラリー走査 JSON（lib/scan.mjs）
  *   /api/sns/board                      … SNS 投稿状態板 JSON（lib/sot.mjs）
+ *   /api/quality                        … コンテンツ品質集計 JSON（lib/quality.mjs）
  *   /api/actions                        … 実行可能アクション一覧（GET）
  *   /api/job/run   (POST, SSE)          … アクション実行 + ログストリーム（lib/jobs.mjs）
  *   /api/job/status (GET)               … 実行中ジョブ状態
@@ -27,6 +28,7 @@ import { snsBoard } from "./lib/sot.mjs";
 import { ACTIONS, startJob, jobStatus } from "./lib/jobs.mjs";
 import { articlesIndex, magazines, noteArticles } from "./lib/content.mjs";
 import { salesSummary } from "./lib/sales.mjs";
+import { qualitySummary } from "./lib/quality.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PUBLIC = resolve(join(HERE, "public"));
@@ -80,6 +82,8 @@ async function handleApi(req, res, url) {
         return sendJson(res, 200, await cached("note-articles", noteArticles, refresh));
       case "/api/sales":
         return sendJson(res, 200, await cached("sales", salesSummary, refresh));
+      case "/api/quality":
+        return sendJson(res, 200, await cached("quality", qualitySummary, refresh));
       case "/api/actions":
         return sendJson(res, 200, {
           actions: Object.entries(ACTIONS).map(([id, a]) => ({


### PR DESCRIPTION
#384 マージ後に develop へ付け替えた再PR（旧 #385 は base ブランチ削除で自動クローズ）。内容は #385 と同一（品質タブ）。

`tools/admin` に「品質」タブを追加。`lint-baseline.json` × `popular-pages.json`（GA4）× `content-rules.json` × `doc-meta-index.json` を join し、記事別（優先度=違反数×人気）/ ルール別 / 資格別集計 + 違反バーンダウン（`quality-snapshot`）を読み取り専用で表示。

検証: `/api/quality` 200・sibling 無回帰・全 .mjs/.js の node --check・render() を実データ+DOM シムで headless 実行し10アサーション green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)