### PR TITLE
docs(seo): SEO品質ゲート handoff 最終化＋残タスクを backlog 起票

### DIFF
--- a/docs/handoffs/2026-07-13-seo-quality-gates.md
+++ b/docs/handoffs/2026-07-13-seo-quality-gates.md
@@ -104,17 +104,22 @@ UI 刷新・`scripts/quality-audit.mjs` 統合 CHECKS レジストリ・v2 監�
 
 ## 完了 / 保留事項
 
-- **push 済み**: `claude/doboku-note-seo-quality-bfi3x7`（origin）。**draft PR #390**（base: develop）作成済み。
+- **マージ済み**: **PR #390**（merge commit `2aa8ab23`・base: develop）。CI green（`quality:audit:ci`
+  → `build` → `check-seo-build:ci` 全通過）。
+  - マージ直前に develop 由来の既存 ratchet drift（BuildJob アフィリ3記事の rule 15-1 文末単調・
+    私の変更外）を解消して CI を green 化（`guide-buildjob-review` / `guide-career-consultation-before-quit`
+    / `guide-career-agent-comparison` の文末表現のみ調整・事実/数値/リンク不変）。
   - 注記: 環境の git relay（127.0.0.1:41729）は最初 413 で push 不能だったが、リモート branch を
     develop tip で先に作成し共通祖先を確定させることで最小パックの push が通った。
-- **deploy / robots.txt / Cloudflare 変更は未実施**（意図的・ユーザー承認事項）。
+- **deploy / robots.txt / Cloudflare 変更は未実施**（意図的・ユーザー承認事項）。canonical/OGP 修正の
+  本番反映は `develop→main` の deploy 後。サイト全ページ canonical 一斉更新＝再クロールが走るため、
+  **コアアップデート期を避け直後2週間は GSC 日次監視**（gsc-management.md 2026-07-10 の教訓）。
 - **build が再生成する index JSON はコミットしていない**（`doc-meta-index.json` 等の
   timestamp/git-date churn。CI が build 前に refresh-indexes で再生成）。
-- **orphan/unreachable の gate 昇格は保留**（現状 warn）。R8 essay-theme の導線設計が固まったら
-  gate 化を再検討。
+- **orphan/unreachable の gate 昇格は保留**（現状 warn）→ `docs/todo/backlog.md`「SEO 品質ゲート後続」へ起票。
 - **GSC page×query の実データ生成は CI 待ち**（ローカルは creds 無し・会社 PC プロキシ遮断＝
-  measurement-incidents.md）。次回 `fetch-metrics.yml`（週次金曜）で `gsc-page-query-*.json`
-  が初生成される。metrics-analyzer の Pattern 7/8 はそれ以降に有効。
+  measurement-incidents.md）→ 同 backlog へ起票。次回 `fetch-metrics.yml`（週次金曜）で
+  `gsc-page-query-*.json` が初生成され、metrics-analyzer の Pattern 7/8 はそれ以降に有効。
 - **Node バージョン差**: ローカル Node 22 では旧 `node --test tests/`（dir 引数）が回帰するため
   `tests/*.test.mjs` に変更済み。CI（Node 20）でも同一 glob で全テスト discovery される。
 

--- a/docs/todo/backlog.md
+++ b/docs/todo/backlog.md
@@ -194,6 +194,15 @@ on-page は全数検証済みで健全＝追加微修正はしない（真実源
 2. **8月に index 率再測定**: 7/1 の demote 回帰（81.6%→74.6%）が継続なら総監キーワード薄ページの統合を検討（[[no-new-keyword-pages]]＝新規でなく統合）
 3. 受験期の高インテント head クエリの GSC 監視・月次 `/gsc-review` 継続
 
+### SEO 品質ゲート後続（PR #390 マージ後の残タスク）
+タグ: [インフラ・計測]
+
+SEO 品質ゲート実装（PR #390・`docs/handoffs/2026-07-13-seo-quality-gates.md`）の後続。ゲート本体は develop 済み。残:
+1. **deploy 後の GSC 監視**: `develop→main` deploy で canonical/OGP 修正が本番反映＝サイト全ページ canonical 一斉更新の再クロールが走る。**コアアップデート期を避け、直後2週間は GSC 日次を監視**（gsc-management.md 2026-07-10 の教訓）。
+2. **GSC page×query 実データ確認**: 週次 `fetch-metrics.yml`（金）初回実行後、`gsc-page-query-*.json` を `metrics-analyzer` に渡し Pattern 7/8（cannibalization/content-decay）を初検証。メタ改善は少数 URL の 14〜28 日実験に限る。
+3. **orphan/unreachable 6本の gate 昇格**: `pe-comprehensive-management-r8-essay-theme-*` 6本は現状 warn（意図的未リンク）。導線設計を決めたら check-seo-build の gate へ昇格。
+4. **robots / OAI-SearchBot の ADR**（v2監査 §8.3）: ChatGPT Search 露出を取りに行くか。training bot は block 維持、search/user bot の許可可否を ADR で決定。robots.txt/Cloudflare はユーザー承認事項。
+
 ### 計測基盤 Tier 2/3 ＋ GA4 UI 設定
 タグ: [インフラ・計測]
 


### PR DESCRIPTION
PR #390（SEO 品質ゲート実装・merge `2aa8ab23`）の記録整備。コード変更なし・docs のみ。

## 変更
- **`docs/handoffs/2026-07-13-seo-quality-gates.md`**: PR #390 マージ済みへ最終化。ratchet drift 解消（BuildJob アフィリ3記事の文末単調・私の変更外を修正して CI green 化）・deploy 後の GSC 監視の注意（canonical 一斉更新の再クロール）を反映。
- **`docs/todo/backlog.md`**: 「SEO 品質ゲート後続」を新設起票。
  1. deploy 後の GSC 日次監視（コアアップデート期を避ける）
  2. GSC page×query 実データ確認（週次CI初回後・Pattern 7/8 有効化）
  3. orphan/unreachable 6本（R8 essay-theme）の gate 昇格
  4. robots / OAI-SearchBot の ADR（v2監査 §8.3・ユーザー承認事項）

CLAUDE.md の handoff ライフサイクル（残タスク→backlog へ抽出）に沿った記録作業。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVwdA4VS7AT5UdqwyQtd39)_