### PR TITLE
feat(ui): カード角丸ゼロ化＋カテゴリページ白カード統一・人気記事サムネ縦リスト化

### DIFF
--- a/docs/design-system/design-system.md
+++ b/docs/design-system/design-system.md
@@ -86,14 +86,14 @@
 
 ### 2.4 カード・影・モーショントークン
 
-**2026-07 Soft Editorial 改訂**: 角丸を小→大で段階化し、影を 2 層ソフトシャドウ（slate 寒色 `rgb(15 23 42)`）へ。値のみ変更で `rounded-card-*`/`shadow-*` 経由の全カードが自動追従。
+**2026-07 改訂**: カードは直角（角丸ゼロ）。inline（バッジ・チップ・インラインコード）のみ `6px` を維持。影は 2 層ソフトシャドウ（slate 寒色 `rgb(15 23 42)`）。値のみ変更で `rounded-card-*`/`shadow-*` 経由の全カードが自動追従。
 
 | 変数 | 値 | 用途 |
 |---|---|---|
 | `--radius-card-inline` | `6px` | バッジ・チップ・インラインコード |
-| `--radius-card-content` | `10px` | 標準カード・表・details・pre・KaTeX display |
-| `--radius-card-section` | `14px` | SectionCard 等の大カード |
-| `--radius-card-hero` | `20px` | トップ hero |
+| `--radius-card-content` | `0` | 標準カード・表・details・pre・KaTeX display |
+| `--radius-card-section` | `0` | SectionCard 等の大カード |
+| `--radius-card-hero` | `0` | トップ hero |
 | `--shadow-card-content` | `0 1px 2px /.04, 0 2px 8px /.05` | カード影（2 層）。Tailwind `shadow-card-*` |
 | `--shadow-card-section` | `0 1px 3px /.04, 0 6px 20px /.06` | 大カード影 |
 | `--shadow-card-hover` | `0 2px 4px /.06, 0 12px 32px /.10` | hover lift |

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -123,10 +123,14 @@ export default async function CategoryPage({
             カテゴリ見出しは全幅ヒーロー帯を廃し、左カラム上部にコンパクト配置（2026-06-26）。
             これにより右サイドバー（転職枠）がファーストビューへ繰り上がる。 */}
         <div className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 flex gap-8 relative">
-          <main className="flex-1 min-w-0">
+          <main className="flex-1 min-w-0 pt-8 sm:pt-10 pb-10">
+            {/* 左メインカラム全体を 1 枚の白カードに統一（グレー地に白サーフェス・角丸ゼロの
+                エディトリアル面）。見出し・人気記事・各セクションを同一カード内に載せ、内側は
+                リスト/テーブル/フラットタイルで構成してカード内カードを避ける（2026-07 A-1）。 */}
+            <div className="card-surface-section px-5 sm:px-8 lg:px-10 pb-8 sm:pb-10">
             {/* カテゴリ見出し（縮小版・H1/パンくず/説明は SEO のため維持。CATEGORY チップは
                 パンくずと重複のため削除） */}
-            <div className="pt-8 sm:pt-10 pb-5 border-b border-[var(--rule-soft)]">
+            <div className="pt-6 sm:pt-8 pb-5 border-b border-[var(--rule-soft)]">
               <nav aria-label="breadcrumb" className="font-mono text-[11px] text-[var(--ink-muted)] uppercase tracking-widest mb-2 flex items-center gap-2">
                 <Link href="/" className="hover:text-[var(--accent)] transition-colors">Home</Link>
                 <span aria-hidden className="opacity-60">›</span>
@@ -140,7 +144,7 @@ export default async function CategoryPage({
                 <span>{docs.length.toLocaleString()} docs</span>
               </div>
             </div>
-            <div className="pt-8 sm:pt-10 pb-10 sm:pb-12 text-[17px] leading-[1.9]">
+            <div className="pt-8 text-[17px] leading-[1.9]">
           {/* よく読まれている記事 特集（GA4 上位 top3・グループ別セクションの上）。データ無しなら描画されない。 */}
           {popularDocs.length > 0 && (
             <div className="mb-16">
@@ -181,6 +185,7 @@ export default async function CategoryPage({
               ))}
             </div>
           )}
+            </div>
             </div>
 
             {/* note もくじ CTA（モバイル＜993px のみ）。PC は右サイドバーへ集約。 */}

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -140,9 +140,6 @@ export default async function CategoryPage({
                 {cat.label}
               </h1>
               <p className="text-[15px] leading-[1.8] text-[var(--ink-body)] max-w-[60ch]">{cat.subtitle}</p>
-              <div className="mt-3 flex gap-4 flex-wrap font-mono text-[11px] text-[var(--ink-muted)] tabular-nums">
-                <span>{docs.length.toLocaleString()} docs</span>
-              </div>
             </div>
             <div className="pt-8 text-[17px] leading-[1.9]">
           {/* よく読まれている記事 特集（GA4 上位 top3・グループ別セクションの上）。データ無しなら描画されない。 */}

--- a/src/components/category/CategorySections.tsx
+++ b/src/components/category/CategorySections.tsx
@@ -20,7 +20,7 @@ export function DocCard({ doc }: { doc: DocMeta }) {
       href={`/docs/${doc.slug}`}
       data-cta="nav"
       data-cta-label="category-card"
-      className="card-surface-content group relative flex flex-col overflow-hidden transition-[border-color,box-shadow] hover:border-[var(--accent)] hover:shadow-soft"
+      className="group relative flex flex-col overflow-hidden border border-[var(--rule-soft)] bg-[var(--paper)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--accent-fill)]"
     >
       {/* ブランド色の上端アクセント（mockup の category band を mono 化＝硬質エディトリアル維持）。
           ガイドカバー写真（guide-cover.ts）は dormant: メタガイドに literal 機械写真が不一致のため撤回（PR #276→revert）。 */}

--- a/src/components/category/CategorySections.tsx
+++ b/src/components/category/CategorySections.tsx
@@ -482,10 +482,7 @@ export function DocSection({ group, layout, secondaryDocs }: { group: DocGroup; 
   return (
     <section id={`sec-${group.key}`} className="scroll-mt-24">
       <div className="mb-6">
-        <div className="flex items-baseline justify-between gap-2 flex-wrap">
-          <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">{group.title}</h2>
-          <span className="font-mono text-[11px] text-[var(--ink-muted)]">{group.docs.length} docs</span>
-        </div>
+        <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">{group.title}</h2>
         <p className="text-[14px] text-[var(--ink-muted)] mt-1">{group.description}</p>
       </div>
       {layout === 'exam-table' ? (

--- a/src/components/category/CurriculumSections.tsx
+++ b/src/components/category/CurriculumSections.tsx
@@ -50,14 +50,16 @@ function CurriculumRow({ doc, marker }: { doc: DocMeta; marker: React.ReactNode 
         <span className="shrink-0 flex items-center justify-center min-w-6" aria-hidden>
           {marker}
         </span>
-        <span className="text-[15px] sm:text-base font-medium text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors">
-          {doc.shortTitle || doc.title}
-        </span>
-        {doc.subtitle && (
-          <span className="hidden sm:inline ml-auto max-w-[40%] truncate text-right text-[13px] text-[var(--ink-muted)]">
-            {doc.subtitle}
+        {/* タイトル下に subtitle を縦積み（旧: 右寄せ truncate はデスクトップで途切れ・
+            モバイル非表示だった）。全文・全デバイス表示で記事選択の手がかりを保つ（2026-07 C-2）。 */}
+        <span className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-[15px] sm:text-base font-medium text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors">
+            {doc.shortTitle || doc.title}
           </span>
-        )}
+          {doc.subtitle && (
+            <span className="text-[13px] text-[var(--ink-muted)]">{doc.subtitle}</span>
+          )}
+        </span>
       </Link>
     </li>
   );

--- a/src/components/category/CurriculumSections.tsx
+++ b/src/components/category/CurriculumSections.tsx
@@ -23,24 +23,19 @@ export function CurriculumSection({
   id,
   title,
   description,
-  count,
   children,
 }: {
   id: string;
   title: string;
   description?: string | undefined;
+  /** 呼び出し側の互換のため残置（表示はしない）。件数バッジは 2026-07 撤去。 */
   count?: number | undefined;
   children: React.ReactNode;
 }) {
   return (
     <section id={`sec-${id}`} className="scroll-mt-24">
       <div className="mb-6">
-        <div className="flex items-baseline justify-between gap-2 flex-wrap">
-          <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">{title}</h2>
-          {typeof count === 'number' && (
-            <span className="font-mono text-[11px] text-[var(--ink-muted)]">{count} docs</span>
-          )}
-        </div>
+        <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">{title}</h2>
         {description && <p className="text-[14px] text-[var(--ink-muted)] mt-1">{description}</p>}
       </div>
       {children}

--- a/src/components/category/PopularSections.tsx
+++ b/src/components/category/PopularSections.tsx
@@ -14,8 +14,8 @@ function windowLabel(): string | null {
   return `${fmt(popularWindow.start)}〜${fmt(popularWindow.end)}`;
 }
 
-/** 人気記事リストの1行（サムネ左＋タイトル/抜粋右のブログ型）。OGP を 1200:630 サムネにし、
- *  行の高さは line-clamp で揃える。ランクは左上バッジ。 */
+/** 人気記事リストの1行（サムネ左＋ランク番号＋タイトル/抜粋のブログ型）。OGP を 1200:630 サムネにし、
+ *  行の高さは line-clamp で揃える。ランクは OGP のタイトル焼込みと重ならないようタイトル側に置く。 */
 function PopularListRow({ item }: { item: PopularDoc }) {
   const { doc, rank } = item;
   const title = doc.shortTitle || doc.title;
@@ -24,7 +24,7 @@ function PopularListRow({ item }: { item: PopularDoc }) {
     <li className="border-b border-[var(--rule-soft)] last:border-b-0">
       <Link
         href={`/docs/${doc.slug}`}
-        className="group flex gap-4 py-4 first:pt-0"
+        className="group flex gap-3 sm:gap-4 py-4 first:pt-0"
       >
         <div className="relative aspect-[1200/630] w-[124px] sm:w-[168px] shrink-0 overflow-hidden border border-[var(--rule-soft)] bg-[var(--bg)]">
           <Image
@@ -37,17 +37,19 @@ function PopularListRow({ item }: { item: PopularDoc }) {
             sizes="(max-width: 640px) 124px, 168px"
             className="h-full w-full object-cover"
           />
-          <span className="absolute left-1.5 top-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-card-inline bg-[var(--accent)] px-1 font-mono text-[10px] font-bold tabular-nums text-white">
+        </div>
+        <div className="flex min-w-0 flex-1 gap-2.5">
+          <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-card-inline bg-[var(--accent-fill)] font-mono text-xs font-bold tabular-nums text-[var(--accent)]">
             {rank}
           </span>
-        </div>
-        <div className="flex min-w-0 flex-col gap-1 pt-0.5">
-          <h3 className="font-serif text-[15px] sm:text-lg font-bold leading-snug text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors line-clamp-2">
-            {title}
-          </h3>
-          {excerpt && (
-            <p className="text-[13px] sm:text-sm text-[var(--ink-muted)] line-clamp-2">{excerpt}</p>
-          )}
+          <div className="flex min-w-0 flex-col gap-1">
+            <h3 className="font-serif text-[15px] sm:text-lg font-bold leading-snug text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors line-clamp-2">
+              {title}
+            </h3>
+            {excerpt && (
+              <p className="text-[13px] sm:text-sm text-[var(--ink-muted)] line-clamp-2">{excerpt}</p>
+            )}
+          </div>
         </div>
       </Link>
     </li>

--- a/src/components/category/PopularSections.tsx
+++ b/src/components/category/PopularSections.tsx
@@ -24,7 +24,7 @@ function PopularListRow({ item }: { item: PopularDoc }) {
     <li className="border-b border-[var(--rule-soft)] last:border-b-0">
       <Link
         href={`/docs/${doc.slug}`}
-        className="group flex gap-3 sm:gap-4 py-4 first:pt-0"
+        className="group flex gap-3 sm:gap-4 py-4"
       >
         <div className="relative aspect-[1200/630] w-[124px] sm:w-[168px] shrink-0 overflow-hidden border border-[var(--rule-soft)] bg-[var(--bg)]">
           <Image

--- a/src/components/category/PopularSections.tsx
+++ b/src/components/category/PopularSections.tsx
@@ -63,16 +63,9 @@ function PopularListRow({ item }: { item: PopularDoc }) {
  */
 export function PopularShowcase({ items }: { items: PopularDoc[] }) {
   if (items.length === 0) return null;
-  const label = windowLabel();
   return (
     <section data-cta="nav" data-cta-label="popular-showcase">
-      <div className="mb-5">
-        <div className="flex items-baseline justify-between gap-2 flex-wrap">
-          <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">よく読まれている記事</h2>
-          {label && <span className="font-mono text-[11px] text-[var(--ink-muted)] tabular-nums">{label}</span>}
-        </div>
-        <p className="text-[14px] text-[var(--ink-muted)] mt-1">アクセスの多い記事から探す</p>
-      </div>
+      <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)] mb-5">よく読まれている記事</h2>
       <ol className="flex flex-col">
         {items.map((item) => (
           <PopularListRow key={item.doc.slug} item={item} />

--- a/src/components/category/PopularSections.tsx
+++ b/src/components/category/PopularSections.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { type PopularDoc, popularWindow } from '@/lib/popular';
+import { getOgpImageUrl } from '@/lib/r2-image-loader';
 
 /** 集計窓を「YYYY.MM.DD–MM.DD」で短く表示。窓不明なら null。 */
 function windowLabel(): string | null {
@@ -12,72 +14,68 @@ function windowLabel(): string | null {
   return `${fmt(popularWindow.start)}〜${fmt(popularWindow.end)}`;
 }
 
-function RankBadge({ rank }: { rank: number }) {
-  return (
-    <span className="inline-flex items-center gap-1 rounded-card-inline bg-[var(--accent-fill)] px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-widest text-[var(--accent)]">
-      人気 #{rank}
-    </span>
-  );
-}
-
-function ShowcaseCard({ item, lead = false }: { item: PopularDoc; lead?: boolean }) {
+/** 人気記事リストの1行（サムネ左＋タイトル/抜粋右のブログ型）。OGP を 1200:630 サムネにし、
+ *  行の高さは line-clamp で揃える。ランクは左上バッジ。 */
+function PopularListRow({ item }: { item: PopularDoc }) {
   const { doc, rank } = item;
   const title = doc.shortTitle || doc.title;
   const excerpt = doc.subtitle || doc.description;
   return (
-    <Link
-      href={`/docs/${doc.slug}`}
-      className="card-surface-content group relative flex flex-col overflow-hidden transition-[border-color,box-shadow] hover:border-[var(--accent)] hover:shadow-soft"
-    >
-      <span aria-hidden className="block h-[3px] w-full bg-[var(--accent)] opacity-70 transition-opacity group-hover:opacity-100" />
-      <div className="flex flex-1 flex-col gap-2 p-5">
-        <RankBadge rank={rank} />
-        <h3
-          className={`font-serif font-bold text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors leading-snug ${
-            lead ? 'text-xl sm:text-2xl line-clamp-3' : 'text-lg line-clamp-2'
-          }`}
-        >
-          {title}
-        </h3>
-        {excerpt && (
-          <p className={`text-sm text-[var(--ink-muted)] ${lead ? 'line-clamp-3' : 'line-clamp-2'}`}>{excerpt}</p>
-        )}
-        <div className="mt-auto pt-3 inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-[var(--ink-muted)] group-hover:text-[var(--accent)] transition-colors">
-          Read <span aria-hidden>→</span>
+    <li className="border-b border-[var(--rule-soft)] last:border-b-0">
+      <Link
+        href={`/docs/${doc.slug}`}
+        className="group flex gap-4 py-4 first:pt-0"
+      >
+        <div className="relative aspect-[1200/630] w-[124px] sm:w-[168px] shrink-0 overflow-hidden border border-[var(--rule-soft)] bg-[var(--bg)]">
+          <Image
+            src={getOgpImageUrl(doc.slug)}
+            alt=""
+            width={336}
+            height={176}
+            unoptimized
+            loading="lazy"
+            sizes="(max-width: 640px) 124px, 168px"
+            className="h-full w-full object-cover"
+          />
+          <span className="absolute left-1.5 top-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-card-inline bg-[var(--accent)] px-1 font-mono text-[10px] font-bold tabular-nums text-white">
+            {rank}
+          </span>
         </div>
-      </div>
-    </Link>
+        <div className="flex min-w-0 flex-col gap-1 pt-0.5">
+          <h3 className="font-serif text-[15px] sm:text-lg font-bold leading-snug text-[var(--ink)] group-hover:text-[var(--accent)] transition-colors line-clamp-2">
+            {title}
+          </h3>
+          {excerpt && (
+            <p className="text-[13px] sm:text-sm text-[var(--ink-muted)] line-clamp-2">{excerpt}</p>
+          )}
+        </div>
+      </Link>
+    </li>
   );
 }
 
 /**
  * カテゴリ hub 上部の「よく読まれている記事」特集。GA4 実アクセス上位（直近 28 日）を提示する。
- * 注目フラグでなく実シグナル駆動。OGP がタイトル焼込み済のため画像でなくランクバッジ＋タイポで構成。
- * items が空なら描画しない（graceful）。socialplus 参考の image-led showcase を資産現実に合わせた版。
+ * 注目フラグでなく実シグナル駆動。各記事の OGP（R2 配信・全 published で CI 実在保証）をサムネにした
+ * ブログ型の縦リストで、サイズを揃えて回遊させる。items が空なら描画しない（graceful）。
  */
 export function PopularShowcase({ items }: { items: PopularDoc[] }) {
-  const [lead, ...rest] = items;
-  if (!lead) return null;
+  if (items.length === 0) return null;
   const label = windowLabel();
   return (
     <section data-cta="nav" data-cta-label="popular-showcase">
-      <div className="mb-6">
+      <div className="mb-5">
         <div className="flex items-baseline justify-between gap-2 flex-wrap">
           <h2 className="font-serif text-[22px] sm:text-[26px] font-black text-[var(--ink)]">よく読まれている記事</h2>
           {label && <span className="font-mono text-[11px] text-[var(--ink-muted)] tabular-nums">{label}</span>}
         </div>
         <p className="text-[14px] text-[var(--ink-muted)] mt-1">アクセスの多い記事から探す</p>
       </div>
-      <div className="grid gap-4 md:grid-cols-3">
-        <div className="md:col-span-1 md:row-span-2">
-          <ShowcaseCard item={lead} lead />
-        </div>
-        {rest.map((item) => (
-          <div key={item.doc.slug} className="md:col-span-2">
-            <ShowcaseCard item={item} />
-          </div>
+      <ol className="flex flex-col">
+        {items.map((item) => (
+          <PopularListRow key={item.doc.slug} item={item} />
         ))}
-      </div>
+      </ol>
     </section>
   );
 }

--- a/src/config/category-curriculum.json
+++ b/src/config/category-curriculum.json
@@ -16,19 +16,11 @@
         "guide-last-minute-2026"
       ]
     },
-    "fields": {
-      "title": "分野別対策（土木一般）",
-      "description": "テキスト章の無い土木一般（土工・コンクリート・基礎工）の要点。他分野の要点は各テキスト章の入口に収録",
-      "blocks": [
-        {
-          "id": "doboku-ippan",
-          "label": "土木一般（土工・コンクリート・基礎工）",
-          "slugs": ["guide-earthwork-key-points", "guide-concrete-key-points", "guide-concrete-maintenance", "guide-foundation"]
-        }
-      ]
-    },
     "textbookChapters": [
+      { "volume": "土木一般・共通工学編", "label": "土工", "min": 1, "max": 49, "introGuides": ["guide-earthwork-key-points"] },
       { "volume": "土木一般・共通工学編", "label": "建設機械", "min": 100, "max": 149, "introGuides": ["guide-machinery"] },
+      { "volume": "土木一般・共通工学編", "label": "コンクリート工", "min": 50, "max": 79, "introGuides": ["guide-concrete-key-points", "guide-concrete-maintenance"] },
+      { "volume": "土木一般・共通工学編", "label": "基礎工", "min": 80, "max": 99, "introGuides": ["guide-foundation"] },
       { "volume": "土木一般・共通工学編", "label": "測量", "min": 150, "max": 169, "introGuides": ["guide-surveying"] },
       { "volume": "土木一般・共通工学編", "label": "解体工事", "min": 170, "max": 199, "introGuides": ["guide-demolition"] },
       { "volume": "施工管理・法規編", "label": "施工管理・施工計画", "min": 200, "max": 249, "introGuides": ["guide-construction-plan"] },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,12 +19,12 @@
 @layer base {
   /* Card design tokens — single source of truth */
   :root {
-    /* Card radius — Soft Editorial (2026-07). 小→大で段階化（旧: 一律 2px）。
+    /* Card radius — カードは直角（2026-07 角丸ゼロ化）。inline のみ 6px 維持。
        値のみ変更で rounded-card-* 経由の全カードが自動追従する。 */
     --radius-card-inline: 6px;   /* バッジ・チップ・インラインコード */
-    --radius-card-content: 10px; /* 標準カード・表・details・pre・KaTeX display */
-    --radius-card-section: 14px; /* SectionCard 等の大カード */
-    --radius-card-hero: 20px;    /* トップ hero */
+    --radius-card-content: 0;    /* 標準カード・表・details・pre・KaTeX display */
+    --radius-card-section: 0;    /* SectionCard 等の大カード */
+    --radius-card-hero: 0;       /* トップ hero */
 
     /* 影 — 2 層ソフトシャドウ（slate 寒色 rgb(15 23 42) で紙面に馴染ませる） */
     --shadow-card-content: 0 1px 2px rgb(15 23 42 / 0.04), 0 2px 8px rgb(15 23 42 / 0.05);


### PR DESCRIPTION
## 概要

サイトのカード UI を 2 点刷新。

### 1. 全カードの角丸ゼロ化
`--radius-card-content/section/hero` を `0` に統一（`inline`=6px のバッジ/チップは維持）。トークン値変更のみで `rounded-card-*` 経由の全カード（SectionCard/Callout/表/pre/KaTeX/hero 等 104 箇所）が一括で直角化。`design-system.md` §2.4 を同期。

### 2. カテゴリページ改修（`/category/[slug]` 全カテゴリ共通・モックで A-1×B-2 を選定）
- **A-1**: 左メインカラム全体を 1 枚の白カード（`card-surface-section`）に統一。グレー地に白サーフェスのブログ型レイアウト。
- **B-2**: 「よく読まれている記事」を OGP サムネイル付きの縦リストに刷新し、行サイズを均一化。旧 `ShowcaseCard` の非対称グリッドを撤去。
- 白カード内のカード内カードを避けるため `DocCard` を影なしフラットタイル化。

## 検証（dev :3020・ブラウザ実測）
- 角丸: カード要素 `border-radius: 0px`／inline バッジ 6px 維持／pill 9999px 維持
- A-1: メインカラム白カード（`rgb(255,255,255)`・角丸 0）
- B-2: 人気記事 3 行・行高 104〜105px で均一・全行 OGP サムネ（R2 `ogp.png` 1200×630 実ロード確認）
- DocCard: `box-shadow: none`・border 1px
- 他カテゴリ（pe-comprehensive）も正常・keyword-nav カード維持
- モバイル 375px: 横スクロールなし・サムネ 124px・行高均一
- `lint-ui.mjs --all`: 101 ファイル OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)