### PR TITLE
fix(funnel): audit-note-funnel の Windows パス区切りで 2級土木 override 不発（誤ドリフト）を修正

### DIFF
--- a/scripts/audit-note-funnel.mjs
+++ b/scripts/audit-note-funnel.mjs
@@ -111,7 +111,10 @@ for (const [key, ex] of Object.entries(CONFIG.exams)) {
     const raw = readFileSync(f, 'utf8');
     const url = fm(raw, 'noteUrl');
     if (!url || url === 'TBD') continue; // 未公開は対象外
-    const name = adir.slice(baseDir.length + 1) || adir;
+    // Windows のパス区切り(\)を / に正規化。config の topCtaOverrides.dirPrefix /
+    // topCtaExcludeDirs は前方スラッシュ前提のため、正規化しないと Windows で
+    // 2級土木/ override が不発→誤ドリフト（1級完全パックを期待）になる。
+    const name = (adir.slice(baseDir.length + 1) || adir).replaceAll('\\', '/');
     // ナビ/入口記事は冒頭パック CTA を意図的に付けない（topCtaExcludeDirs）
     const topExcluded = (ex.topCtaExcludeDirs || []).some(x => name === x || name.endsWith('/' + x));
     const miss = [];


### PR DESCRIPTION
## 背景

ピーク週の導線監視（W29）で `audit-note-funnel --live` が 2級土木2記事の「冒頭パック(コアパック) CTA がライブ未反映」を報告。調査の結果、**これは誤検知**で、根因は監査スクリプトの Windows パス区切りバグと判明。

## 根本原因

`scripts/audit-note-funnel.mjs:114` の `name`（記事の相対ディレクトリ名）が Windows では `readdirSync`/`join` によりバックスラッシュ区切り（`2級土木\...`）になる。一方 config `.claude/config/note-funnel.json` の `topCtaOverrides.dirPrefix`（`"2級土木/"`）と `topCtaExcludeDirs` は前方スラッシュ前提。

→ `name.startsWith("2級土木/")` が Windows で **false** → 2級土木の override が不発 → D5 の期待マガジンが 2級バンク（`m8554e87ca6ec`）でなく 1級完全パック（`m8290970a7f05`）にフォールバック → 2級記事の live には無い → **誤ドリフトを量産**。

- CI（`check-note-funnel`）は Linux 実行なので正常＝**この Windows PC のローカル監査のみが嘘をつく**
- 実害：存在しない「穴」を報告し、無駄な note 再push を誘発する

## 修正

`name` を `.replaceAll('\', '/')` で正規化（1行）。POSIX ではバックスラッシュが無く no-op＝クロスプラットフォーム安全。`topCtaOverrides` と `topCtaExcludeDirs` の両方の照合が Windows でも正しく効く。

## 検証

isolated worktree（監査に必要な scripts/・config・note-magazines.ts・docs/note 517記事を materialize）で `node scripts/audit-note-funnel.mjs --live` を実行:
- 修正前: 2級土木2記事に「冒頭パック(コアパック)」誤ドリフト
- 修正後: **その2件が解消**（記事名も `2級土木/...` と正規化表示）。override が 2級バンク `m8554e87ca6ec`（live に実在）を正しく期待するようになった

（注: 別途 article「一次択一-過去問PDF」の末尾もくじ D5 は本バグと無関係の有料記事 paywall 可視性の論点。本PRのスコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)