### PR TITLE
feat(layout): 記事レイアウトの余白を締め TwoColumnShell に一元化

### DIFF
--- a/.claude/skills/dev/zenn-audit/SKILL.md
+++ b/.claude/skills/dev/zenn-audit/SKILL.md
@@ -142,19 +142,22 @@ for m in re.finditer(r'@media[^{]+\{(?:[^{}]|\{[^{}]*\})*\}', css):
 
 複数ファイルから値を抜き取る:
 
-1. **`src/app/docs/[...slug]/page.tsx`** を Read:
+1. **`src/components/layout/TwoColumnShell.tsx`**（2カラムレイアウト値の真実源）を Read:
    - `max-w-\[(\d+)px\]` → コンテナ max-width
-   - `w-\[(\d+)px\]` on `<aside>` → サイドバー幅
-   - `gap-(\d+)` または `gap-\[(\d+)px\]` → ギャップ
-   - `hidden (xl|lg|md|zenn-\w+):block` → サイドバー可視化境界
-   - `<article>` の `rounded-`, `shadow-`, `p-`, `py-`, `px-`, `max-*:*` → カードデザイン
+   - `<aside>` の幅ユーティリティ（現行 `w-72`=288px） → サイドバー幅
+   - `gap-(\d+)` または `gap-\[(\d+)px\]`（現行 `gap-10`=40px） → カラム間ギャップ
+   - `zenn-desktop:block` → サイドバー可視化境界（≥993px）
+
+2. **`src/app/docs/[...slug]/page.tsx`** を Read:
+   - `<article>` の `rounded-`, `shadow-`, `py-`, `px-`, `zenn-desktop:px-`, `max-zenn-*:*` → カードデザイン（現行 `px-10` / `zenn-desktop:px-11` / `max-zenn-sp:px-[var(--article-gutter-sp)]`）
    - `pb-(\d+)` on `flex-grow` → ページ下部余白
 
-2. **`tailwind.config.js`** を Read:
+3. **`tailwind.config.js`** を Read:
    - `extend.screens` → Zenn ブレイクポイント確認（`zenn-tiny` 401, `zenn-sp` 577, `zenn-tablet` 769, `zenn-desktop` 993）
 
-3. **`src/styles/globals.css`** を Read:
+4. **`src/styles/globals.css`** を Read:
    - `.prose-blog h1` → `max-width` 値
+   - `--article-gutter-sp` → モバイル記事カード横 gutter（現行 16px・details のフルブリード相殺と連動）
 
 ### Step 6: レイアウト差分を分類
 
@@ -231,7 +234,7 @@ for m in re.finditer(r'@media[^{]+\{(?:[^{}]|\{[^{}]*\})*\}', css):
 
 ### ✅ Matches
 - container max-width: 1200px
-- sidebar width: 300px
+- sidebar width: 288px (w-72)
 - sidebar visibility: ≥993px (zenn-desktop)
 - gap: 30px
 - card border-radius: 4px
@@ -239,8 +242,7 @@ for m in re.finditer(r'@media[^{]+\{(?:[^{}]|\{[^{}]*\})*\}', css):
 - card shadow: none
 - card padding: py-10 px-10 (40px)
 - mobile full-bleed at ≤576px (max-zenn-sp)
-- mobile card padding: 35px vertical / 20px horizontal
-- tiny padding: 14px at ≤400px (max-zenn-tiny)
+- mobile card padding: 35px vertical / 16px horizontal (--article-gutter-sp, ≤576px 統一)
 - container responsive padding: 14/20/25/40px at Zenn breakpoints
 - H1 max-width: 780px
 - page bottom padding: pb-16 (64px ≒ 4rem)

--- a/docs/design-system/design-system.md
+++ b/docs/design-system/design-system.md
@@ -134,7 +134,8 @@
 
 | コンポーネント | 役割 | 主な API |
 |---|---|---|
-| `PageShell`（`layout/PageShell.tsx`） | 全ページの chrome（Header/main/Footer）を 1 箇所に集約 | `variant`: `default`（素の main・ページ側が PageHeader+SectionBlock を構成）/ `content`（内側 content rail を持つ単カラム）/ `article`（2カラム記事・docs/category が内側で grid 構成）。`rail`: `780`(既定)/`820`/`860`。`beforeHeader` |
+| `PageShell`（`layout/PageShell.tsx`） | 全ページの chrome（Header/main/Footer）を 1 箇所に集約 | `variant`: `default`（素の main・ページ側が PageHeader+SectionBlock を構成）/ `content`（内側 content rail を持つ単カラム）/ `article`（2カラム記事・内側で `TwoColumnShell` を使う）。`rail`: `780`(既定)/`820`/`860`。`beforeHeader` |
+| `TwoColumnShell`（`layout/TwoColumnShell.tsx`） | **2カラム（本文＋右サイドバー）の単一定義**。docs 記事・category が共用（旧: 各ページが手書きコピペ）。外枠 `max-w-[1280px]`・カラム間 `gap-10`(40px)・サイドバー `w-72`(288px)・`zenn-desktop`(≥993px)でのみサイドバー表示——これらレイアウト値の**真実源はこのファイルのみ**（幅・gap・cap を変えるときはここだけ）。サイドバー中身は `aside` prop へ渡す（`<aside>` 要素・幅・表示制御はシェルが所有） | `gutter`: `flush-mobile`（docs・≤576px 外周0でカードフルブリード）/ `default`（category 等・`px-4 sm:px-6 lg:px-10`）。`mainClassName`(既定 `py-10`)。`aside` |
 | `PageHeader`（`layout/PageHeader.tsx`） | 下層ページの breadcrumb + eyebrow label + h1 + lead + meta + actions | `variant`: `band`(全幅帯)/`inline`(帯なし)。`titleSize`: `default`/`lg`。`width`: `wide`(既定)/`860`/`780`/`760` |
 | `SectionBlock`（`layout/SectionBlock.tsx`） | セクション間余白・band 背景を統一 | — |
 | `SectionCard`（`ui/SectionCard/`） | カード（radius/border/shadow を token に統一・カード内カード回避） | — |
@@ -156,11 +157,15 @@
 | 用途 | 基準 |
 |---|---|
 | Site shell（外枠） | `max-w-[1280px]` + `px-4 sm:px-6 lg:px-10` |
-| Article shell | `1280px` 寄せ（docs は 2 カラム） |
+| Article shell（2カラム） | `max-w-[1280px]` + カラム間 `gap-10`(40px)。真実源 = `TwoColumnShell` |
 | Content rail（読み幅） | `max-w-[780px]`〜`860px`（PageShell `rail`） |
-| Sidebar | `300px` |
+| Sidebar | `288px`（`w-72`・`TwoColumnShell` 所有・≥993px でのみ表示） |
+| 記事カード 横 padding | ≤576px `16px`（`--article-gutter-sp`）/ 577–992px `40px`（`px-10`）/ ≥993px `44px`（`zenn-desktop:px-11`） |
 
 単カラムページでも外枠は変えず、読み幅は内側 content rail で制御する。
+2カラム（docs/category）は必ず `TwoColumnShell` を使い、コンテナ・サイドバー幅・gap を手書きしない。
+モバイル（≤576px）は記事カードを外周0でフルブリードし、設問カード（`.prose-blog details`）は
+`--article-gutter-sp` を負マージンで相殺して真の全幅化＋内側同値 padding の単層にする（二重 padding 回避）。
 
 ### 3.3 Hero / PageHeader
 
@@ -199,7 +204,7 @@
 - **リンク**: `color: var(--accent)` + 半透明 accent アンダーライン（offset 4px、hover で濃く）。
 - **表**: soft border（`--rule-soft`）+ thead 背景 `--accent-fill` + th はモノスペース・大文字・11px・letter-spacing。`rounded-card-content`。最初列（ラベル列慣習）は `white-space: nowrap`。
 - **details / blockquote / code / pre**: editorial soft rule（`--rule-soft`）。インラインコードは `--accent-fill` 背景 + `--accent` 文字。
-- **モバイル（≤576px）**: 本文 16px、見出しは em 比例で縮小、table/blockquote/pre/details はフルブリード化（左右 margin 0）。
+- **モバイル（≤576px）**: 本文 16px、見出しは em 比例で縮小、table/blockquote/pre はフルブリード化（左右 margin 0）。details（設問カード）は `--article-gutter-sp` を負マージンで相殺して記事カード端まで真の全幅化＋内側同値 padding の単層構成（table 等の単純 margin 0 とは別メカニズム・詳細 → §3.2）。
 - **KaTeX**: 本文サイズに揃える（`.katex { font-size: inherit }`）。display 式は `--color-surface` 背景 + `overflow-x: auto`。長い式は横スクロール。
 
 ---

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import { buildPageMetadata } from '@/lib/metadata';
 import PageShell from '@/components/layout/PageShell';
+import TwoColumnShell from '@/components/layout/TwoColumnShell';
 import { getAllCategories, getCategoryBySlug } from '@/lib/categories';
 import { getDocsMetaByCategory } from '@/lib/docs';
 import { groupDocs } from '@/lib/category-groups';
@@ -115,6 +116,20 @@ export default async function CategoryPage({
     </div>
   ));
 
+  // 右サイドバー（PC ≥993px・TwoColumnShell の aside prop へ渡す）。上から
+  // 転職アフィリ（SidebarAdBanner＝当ページ唯一のピクセル発火源・各プログラム 1 回ずつ）→
+  // 運営者プロフィール（E-E-A-T）→ note もくじ CTA（PC 唯一の note 面・utm -sb）→ 人気記事ランキング。
+  const categorySidebar = (
+    <div className="space-y-3">
+      {careerAds.map((ad, i) => (
+        <SidebarAdBanner key={ad.trackLabel + i} {...ad.creative} trackLabel={ad.trackLabel} />
+      ))}
+      <AuthorSidebarCard />
+      {hubCtaSidebar && <HubCtaBanner cta={hubCtaSidebar} />}
+      <PopularRanking items={popularDocs} />
+    </div>
+  );
+
   return (
     <PageShell variant="article">
         {/* カテゴリ本文 + 右サイドバー（PC ≥993px・常に 2 カラム）。サイドバーは上から
@@ -122,8 +137,7 @@ export default async function CategoryPage({
             人気記事 → note マガジン CTA を配置。note CTA はモバイルでは記事一覧の下に出す。
             カテゴリ見出しは全幅ヒーロー帯を廃し、左カラム上部にコンパクト配置（2026-06-26）。
             これにより右サイドバー（転職枠）がファーストビューへ繰り上がる。 */}
-        <div className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 flex gap-8 relative">
-          <main className="flex-1 min-w-0 pt-8 sm:pt-10 pb-10">
+        <TwoColumnShell gutter="default" mainClassName="pt-8 sm:pt-10 pb-10" aside={categorySidebar}>
             {/* 左メインカラム全体を 1 枚の白カードに統一（グレー地に白サーフェス・角丸ゼロの
                 エディトリアル面）。見出し・人気記事・各セクションを同一カード内に載せ、内側は
                 リスト/テーブル/フラットタイルで構成してカード内カードを避ける（2026-07 A-1）。 */}
@@ -191,31 +205,7 @@ export default async function CategoryPage({
                 <HubCtaBanner cta={hubCtaMobile} />
               </div>
             )}
-          </main>
-
-          <aside className="hidden zenn-desktop:block w-[300px] shrink-0 py-10 sm:py-12">
-              {/* 2026-06-27 sticky 解除: 読中に広告/著者/ランキングを追従させない */}
-              <div className="space-y-3">
-                {/* 転職アフィリ（PC 右サイドバー最上部）。当ページのピクセル発火源（各プログラム 1 回ずつ）。
-                    civil/建設部門は 建設JOBs＋ビルドジョブ の両方を縦積み（show-both）、総監は DX 単独。
-                    creative は resolveCategoryCareerAds が解決（建設JOBs ＋ resolveCareerSidebarAd の期間出し分け）。 */}
-                {careerAds.map((ad, i) => (
-                  <SidebarAdBanner
-                    key={ad.trackLabel + i}
-                    {...ad.creative}
-                    trackLabel={ad.trackLabel}
-                  />
-                ))}
-                {/* 運営者プロフィール（合格体験者＝発注者）。転職枠の直下に置き E-E-A-T を提示（2026-06-26）。 */}
-                <AuthorSidebarCard />
-                {/* note もくじ CTA（PC はこのサイドバーが唯一の note 面）。著者カード直下に繰り上げて視認性を
-                    確保（旧: 人気記事の下＝最下部で埋もれていた。本文 CTA 撤去に合わせ 2026-07-06 移動）。utm -sb。 */}
-                {hubCtaSidebar && <HubCtaBanner cta={hubCtaSidebar} />}
-                {/* 人気記事ランキング（GA4 上位 top5・直近 28 日）。データ無しなら描画されない。 */}
-                <PopularRanking items={popularDocs} />
-              </div>
-            </aside>
-        </div>
+        </TwoColumnShell>
     </PageShell>
   );
 }

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { getDoc, getAllDocSlugs, getDocsMetaByCategory, type DocMeta } from '@/lib/docs';
 import PageShell from '@/components/layout/PageShell';
+import TwoColumnShell from '@/components/layout/TwoColumnShell';
 import ArticleHeader from '@/components/ui/ArticleHeader/ArticleHeader';
 import { getAllComponents } from '@/lib/component-loader';
 import { getCategoryLabel } from '@/lib/categories';
@@ -398,13 +399,29 @@ export default async function DocPage({
       className="pb-16"
       beforeHeader={<StructuredData type="article" docMeta={doc.meta} />}
     >
-        {/* Editorial Container: max-width 1280px + responsive padding（モバイル ≤576px はカードフルブリードのため padding 0） */}
-        <div className="max-w-[1280px] mx-auto zenn-sp:px-[25px] zenn-tablet:px-10 flex gap-[32px] relative">
-
-          {/* Main Content Area */}
-          <main className="flex-1 min-w-0 py-10">
-            {/* Editorial article card: 12px radius, soft border + shadow。1280 化に伴い desktop は px-16 で本文行長を抑える */}
-            <article className="bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section shadow-soft py-12 px-12 zenn-desktop:px-16 overflow-hidden transition-colors duration-300 max-zenn-sp:rounded-none max-zenn-sp:border-x-0 max-zenn-sp:py-[35px] max-zenn-sp:px-5 max-zenn-tiny:px-[14px]">
+        {/* 2カラムシェル（max-w-1280 / gap-10 / サイドバー w-72 の真実源）。gutter=flush-mobile で
+            ≤576px は外周 0（記事カードをフルブリードさせる）。サイドバーは aside prop へ集約。 */}
+        <TwoColumnShell
+          gutter="flush-mobile"
+          aside={
+            <ArticleSidebar
+              careerSidebarAd={careerSidebarAd}
+              sidebarMokuji={sidebarMokuji}
+              headings={headings}
+              category={category}
+              docGroup={docGroup}
+              slugStr={slugStr}
+              sectionStr={sectionStr}
+              categoryArticles={categoryArticles}
+              hasCategoryNavCard={hasCategoryNavCard}
+              showPillarNav={showPillarNav}
+            />
+          }
+        >
+            {/* Editorial article card: 12px radius, soft border + shadow。
+                横 padding = タブレット40(px-10) / デスクトップ44(zenn-desktop:px-11)。
+                ≤576px は角丸・左右枠を外し px = var(--article-gutter-sp)（設問カード details のフルブリード相殺と連動） */}
+            <article className="bg-[var(--paper)] border border-[var(--rule-soft)] rounded-card-section shadow-soft py-12 px-10 zenn-desktop:px-11 overflow-hidden transition-colors duration-300 max-zenn-sp:rounded-none max-zenn-sp:border-x-0 max-zenn-sp:py-[35px] max-zenn-sp:px-[var(--article-gutter-sp)]">
               {/* 記事ヘッダー: breadcrumb + H1 + description リード + byline を集約 */}
               <ArticleHeader
                 title={doc.meta.title}
@@ -456,21 +473,7 @@ export default async function DocPage({
               hasCategoryNavCard={hasCategoryNavCard}
               authorDates={authorDates}
             />
-          </main>
-
-          <ArticleSidebar
-            careerSidebarAd={careerSidebarAd}
-            sidebarMokuji={sidebarMokuji}
-            headings={headings}
-            category={category}
-            docGroup={docGroup}
-            slugStr={slugStr}
-            sectionStr={sectionStr}
-            categoryArticles={categoryArticles}
-            hasCategoryNavCard={hasCategoryNavCard}
-            showPillarNav={showPillarNav}
-          />
-        </div>
+        </TwoColumnShell>
     </PageShell>
   );
 }

--- a/src/components/layout/PageShell.tsx
+++ b/src/components/layout/PageShell.tsx
@@ -9,7 +9,7 @@
  * variant:
  * - `default` : 素の <main className="flex-grow">。ページ側が PageHeader(band) + SectionBlock を内側で構成する。
  * - `content` : <main> 自体に内側 content rail（max-w + 左右/上下 padding）を持たせる単一カラム用。
- * - `article` : コンテナを一切持たない <div>。docs/category が内側で 2カラム grid と自前 <main> を維持する。
+ * - `article` : コンテナを一切持たない <div>。docs/category は内側で TwoColumnShell（2カラム本文＋右サイドバー）を使う。
  *
  * not-found は Header/Footer を持たない設計のため、本シェルは使わない（意図的な例外）。
  */

--- a/src/components/layout/TwoColumnShell.tsx
+++ b/src/components/layout/TwoColumnShell.tsx
@@ -1,0 +1,53 @@
+/**
+ * 2カラムレイアウト（本文 + 右サイドバー）の単一定義。
+ *
+ * docs 記事・category ページが個別に手書きしていた
+ *   <div className="max-w-[1280px] mx-auto ... flex gap-* relative"><main>…</main><aside>…</aside></div>
+ * を 1 箇所に集約する（2026-07 余白リデザインで新設）。
+ *
+ * レイアウト値の真実源はこのファイルのみ:
+ * - 外枠 cap: max-w-[1280px]
+ * - カラム間 gap: gap-10（40px）
+ * - サイドバー: w-72（288px）・zenn-desktop（≥993px）でのみ表示
+ * サイドバー幅・gap・外枠 cap を変えるときはここだけを変更する（各ページに複製しない）。
+ * ドキュメント: docs/design-system/design-system.md §3
+ *
+ * gutter（外周余白）は 2 系統:
+ * - 'flush-mobile' : docs 記事用。≤576px は外周 0（記事カードをフルブリードさせるため）
+ * - 'default'      : category 等。サイト共通の px-4 sm:px-6 lg:px-10
+ */
+
+import type { ReactNode } from 'react';
+
+type Gutter = 'flush-mobile' | 'default';
+
+const GUTTERS: Record<Gutter, string> = {
+  'flush-mobile': 'zenn-sp:px-[25px] zenn-tablet:px-10',
+  default: 'px-4 sm:px-6 lg:px-10',
+};
+
+interface TwoColumnShellProps {
+  /** 外周 gutter。既定 'default' */
+  gutter?: Gutter;
+  /** <main> への追加クラス（縦 padding の差分吸収用）。既定 'py-10' */
+  mainClassName?: string;
+  /** 右サイドバーの中身。<aside> 要素・幅（w-72）・表示制御（≥993px）はシェルが所有する */
+  aside?: ReactNode;
+  children: ReactNode;
+}
+
+export default function TwoColumnShell({
+  gutter = 'default',
+  mainClassName = 'py-10',
+  aside,
+  children,
+}: TwoColumnShellProps) {
+  return (
+    <div className={`max-w-[1280px] mx-auto ${GUTTERS[gutter]} flex gap-10 relative`}>
+      <main className={`flex-1 min-w-0 ${mainClassName}`}>{children}</main>
+      {aside && (
+        <aside className="hidden zenn-desktop:block w-72 shrink-0 py-10">{aside}</aside>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/ArticleSidebar/ArticleSidebar.tsx
+++ b/src/components/ui/ArticleSidebar/ArticleSidebar.tsx
@@ -56,7 +56,9 @@ export default function ArticleSidebar({
       ? docGroup === 'primary' || hasCategoryNavCard || showPillarNav
       : true;
   return (
-    <aside className="hidden zenn-desktop:block w-[300px] shrink-0 py-10">
+    // 根の <aside> 要素・幅（w-72）・表示制御（≥993px）・py-10 は TwoColumnShell が所有する。
+    // ここは中身のみを返す（aside 入れ子の意味論を回避）。
+    <>
       {/* ブロック1: 通常フロー（追従させない）——転職ピクセル・note・著者 */}
       {/* 転職アフィリを全 docs サイドバー最上部に常設（唯一のピクセル発火源・ファーストビュー）。 */}
       <div className="mb-3">
@@ -102,6 +104,6 @@ export default function ArticleSidebar({
           )}
         </div>
       )}
-    </aside>
+    </>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -87,6 +87,11 @@
     --rule: #23252b;
     --rule-soft: #e7e9ef;
 
+    /* レイアウト変数（light/dark 共通・theme 非依存）。
+       ≤576px の記事カード横 gutter。記事カードの max-zenn-sp:px と、設問カード .prose-blog details の
+       フルブリード相殺（margin -X ＋ 内側 padding X）が同じ値を参照し、モバイルの単層 gutter を一元管理する。 */
+    --article-gutter-sp: 16px;
+
     /* 写真上のHero専用トークン。背景画像差し替え時の調整点をここに限定する。 */
     --hero-ink: #0f172a;
     --hero-ink-soft: #334155;
@@ -665,9 +670,20 @@
       margin-left: 0;
       margin-right: 0;
     }
+    /* 設問カード（details）はモバイルで真のフルブリード化。記事カードの横 padding（--article-gutter-sp）
+       を負マージンで相殺してカード端いっぱいに広げ、内側 padding を同値の単層にする。
+       旧: カード 16px + details 内 20px の二重（設問本文が端から 36px）→ 単層 16px。 */
     .prose-blog details {
-      margin-left: 0;
-      margin-right: 0;
+      margin-left: calc(-1 * var(--article-gutter-sp));
+      margin-right: calc(-1 * var(--article-gutter-sp));
+      border-left: 0;
+      border-right: 0;
+      border-radius: 0;
+    }
+    .prose-blog details > summary,
+    .prose-blog details > :not(summary):not([data-callout]):not([data-spec-sheet-list]) {
+      padding-left: var(--article-gutter-sp);
+      padding-right: var(--article-gutter-sp);
     }
   }
 }


### PR DESCRIPTION
## 概要

`/docs/*` 記事・`/category/*` の左右余白が過大だった問題を、**案A（締める）**で解消。あわせて docs/category に重複していた2カラムレイアウトを共通コンポーネント **TwoColumnShell** に一元化し、今後の余白微修正を1箇所で行えるようにした。

モック提案: https://claude.ai/code/artifact/74a096f5-e5ae-4e54-acf0-1986dc55cf3f

## 変更

**保守性（一元化）**
- 新規 `TwoColumnShell.tsx` … 外枠 `max-w-[1280px]` / カラム間 `gap-10`(40px) / サイドバー `w-72`(288px) / `zenn-desktop`(≥993px)表示 を**レイアウト値の単一真実源**に。`gutter` prop で docs(`flush-mobile`・≤576px 外周0)と category(`default`)を切替。
- docs / category の手書き2カラムコンテナを撤去してシェルへ置換。`ArticleSidebar` 根を Fragment 化（`<aside>`・幅・表示制御をシェルへ移譲）。

**余白（案A）**
- 記事カード横 padding: ≥993px **64→44px**(`zenn-desktop:px-11`) / タブレット 40px(`px-10`) / ≤576px **16px 統一**（`--article-gutter-sp`・`max-zenn-tiny:px-[14px]` 撤去）。
- サイドバー 300→**288px**、gap 32→**40px**（docs/category 統一）。
- モバイル設問カード(`.prose-blog details`): `--article-gutter-sp` を負マージンで相殺し**真の全幅化＋内側16px単層**（旧: カード+details の二重padding 実質30px）。

**ドキュメント同期**
- `design-system.md` §3.1(TwoColumnShell 追加) / §3.2(Sidebar 288・記事カード padding スケール・gap40) / §4(モバイル details)。
- `PageShell.tsx` コメント、`zenn-audit` スキルの抽出手順・サンプル値を新 SSOT へ更新（doc-sync-auditor 監査済み）。

## 検証

| 画面 | 結果 |
|---|---|
| デスクトップ1280 | カードpad44・本文776px・gap40・サイドバー288・横スクロールなし |
| モバイル375 | フルブリード・設問本文/段落16px・横スクロールなし |
| category | 同一シェル(gap40/サイドバー288)・サイドバー中身描画 |
| ダークモード | paper=#1b1d21・サイドバー正常 |
| SSR / type-check / lint | `<main>`＋主要KW存在・クリーン |

※ ブラウザペインのスクショはページを問わず描画ハングするため getBoundingClientRect 計測で代替。

## スコープ外（別案）
- 外枠 cap 1280 拡大（案B）・サイドバー畳み込み（案C）。TwoColumnShell 化により案B移行は1ファイルで可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)