### PR TITLE
fix(ui): CardRail の常時表示スクロールバーを非表示化

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -263,9 +263,15 @@
     gap: 1rem;
     overflow-x: auto;
     scroll-snap-type: x mandatory;
-    padding-bottom: 0.75rem;
+    padding-bottom: 0.75rem; /* カード影のクリップ防止（overflow-y も auto 化するため） */
     -webkit-mask: linear-gradient(90deg, #000 calc(100% - 24px), transparent);
             mask: linear-gradient(90deg, #000 calc(100% - 24px), transparent);
+    /* スクロールバーは非表示（覗き＋右端フェード＋左右矢印が「先がある」の主シグナル。
+       常時表示の横バーは冗長・下部に無用な帯を生むため隠す。スクロール機能自体は維持）。 */
+    scrollbar-width: none; /* Firefox */
+  }
+  .card-rail::-webkit-scrollbar {
+    display: none; /* Chrome / Safari / Edge */
   }
   .card-rail > * {
     scroll-snap-align: start;


### PR DESCRIPTION
## 概要

カテゴリページのキャリア・転職カードレール（CardRail）下部に**常時表示のスクロールバー**が出ており、冗長だったため非表示化。

横スクロールレールは既に **次カードの覗き＋右端フェード＋左右矢印**（`.card-rail` の設計コメントで「覗き＋フェードが主シグナル」と明記）でスクロール可能性を十分示しており、常時表示の横バーは無用な帯を生んでいた。

## 変更（`src/styles/globals.css` `.card-rail`）
- `scrollbar-width: none`（Firefox）＋ `.card-rail::-webkit-scrollbar { display: none }`（Chrome/Safari/Edge）
- スクロール/スワイプ機能・矢印ナビ・scroll-snap は維持
- `padding-bottom: 0.75rem` はカード影のクリップ防止のため残す（overflow-y も auto 化するため）

## 検証（:3020）
| 項目 | desktop 1280 | mobile 375 |
|---|---|---|
| スクロールバー占有 | 0px（非表示）✓ | 0px ✓ |
| スクロール/スワイプ | 動作（0→304）✓ | 動作 ✓ |
| 矢印ナビ | 表示 ✓ | (非表示=仕様) |
| ページ横オーバーフロー | なし ✓ | なし ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)