### PR TITLE
fix(ui): メイン本文と右サイドバーの上端を揃える（全ページ）

### DIFF
--- a/docs/design-system/design-system.md
+++ b/docs/design-system/design-system.md
@@ -183,6 +183,8 @@
 以下には**追加しない**: `/links`・`/search`・`/about`・`/privacy`・`/terms`・`/tools`。
 理由 — 検索=入力と結果比較に集中 / links=試験カードを全幅で大きく / about=本文そのもので右に逃さない。
 
+**上端揃え（docs/category 共通）**: メイン本文と右サイドバーの上端は揃える。縦位置は `TwoColumnShell` の `aside py-10` ＝ main の上 padding（≥993px で 40px）が唯一の供給源で、**サイドバー先頭要素・main 先頭要素に独自の `margin-top` を持たせない**（先頭が下がって上端がズレる。例: 旧 `SidebarAdBanner` の `mt-3` を撤去して是正）。
+
 **PC 右サイドバー（`/docs`）は 2 ブロック構成**（2026-07 改訂）:
 1. **通常フロー（追従させない）**: 転職アフィリ枠（最上部・唯一のピクセル源）→ note もくじタイル（`HubCtaBanner`・転職枠直下に 1 枚・utm `-docs-sb`。HUB 対応資格 & 非 career 記事のときのみ＝`resolveHubCta` が null で自動非表示）→ 運営者プロフィール。広告・著者は追従させない（「広告が追いかけてくる」体験を避ける）。
 2. **sticky クラスタ（列の最終要素・読中に追従）**: TOC / 設問ナビ → カテゴリナビ → ピラーナビ。`sticky top-6 max-h-[calc(100vh-3rem)] overflow-y-auto`。ナビゲーションだけ追従させ長記事でも導線を視界に残す。

--- a/src/components/layout/TwoColumnShell.tsx
+++ b/src/components/layout/TwoColumnShell.tsx
@@ -44,6 +44,9 @@ export default function TwoColumnShell({
 }: TwoColumnShellProps) {
   return (
     <div className={`max-w-[1280px] mx-auto ${GUTTERS[gutter]} flex gap-10 relative`}>
+      {/* 上端揃えの不変条件: aside の py-10 は main の上 padding（既定 mainClassName='py-10'、
+          category は 'pt-8 sm:pt-10'＝≥993px で 40px）と同値であること。ここが唯一の縦位置供給源。
+          main/aside の先頭要素に独自 margin-top を持たせない（先頭が下がって上端がズレる）。 */}
       <main className={`flex-1 min-w-0 ${mainClassName}`}>{children}</main>
       {aside && (
         <aside className="hidden zenn-desktop:block w-72 shrink-0 py-10">{aside}</aside>

--- a/src/components/ui/SidebarAdBanner/SidebarAdBanner.tsx
+++ b/src/components/ui/SidebarAdBanner/SidebarAdBanner.tsx
@@ -30,7 +30,9 @@ export default function SidebarAdBanner({
   trackLabel,
 }: SidebarAdBannerProps) {
   return (
-    <div className="not-prose mt-3">
+    // 縦スペーシングは親の責務（docs=div.mb-3 / category サイドバー=space-y-3 / category モバイル=my-10）。
+    // 自前の mt を持たせるとサイドバー先頭がメインカードより下がり上端がズレる（2026-07 上端揃え）。
+    <div className="not-prose">
       <div className="card-surface-content relative overflow-hidden p-2">
         <span
           className="absolute right-2 top-2 z-10 inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wider text-white"


### PR DESCRIPTION
## 概要

category / docs 記事で、メイン本文カードの上端と右サイドバー先頭（転職アフィリバナー）の上端がズレていた問題を解消。右サイドバーを持つ全ページ（docs・category）で上端を揃える。

## 原因（実測で確定・1280px）
| ページ | 修正前ズレ | 内訳 |
|---|---|---|
| category | 20px | ①aside `sm:py-12`(48) vs main `sm:pt-10`(40)=8px ＋ ②`SidebarAdBanner` の `mt-3`=12px |
| docs | 12px | ②のみ |

- ① は #402（TwoColumnShell・aside を `py-10` に統一）で解消済み。
- ② `SidebarAdBanner` 根 div の `mt-3` を撤去（縦スペーシングは親 `div.mb-3`/`space-y-3`/`my-10` が管理済みで余剰）。

## 変更
- `src/components/ui/SidebarAdBanner/SidebarAdBanner.tsx`: 根 `not-prose mt-3` → `not-prose`
- `src/components/layout/TwoColumnShell.tsx`: 上端揃えの不変条件コメント（aside py-10 == main 上 padding）
- `docs/design-system/design-system.md` §3.4: 「先頭要素に margin-top を持たせない・縦位置は TwoColumnShell が唯一の供給源」を追記

## 検証（:3020・1280px, getBoundingClientRect）— 全て **delta=0**
- `/category/civil-construction-1`・`/category/pe-comprehensive-management`（DX単独広告）
- `/docs/civil-construction-1-guide-strategy`（TOCあり）・`/docs/civil-construction-1-primary-r07-a`（設問ナビ）
- モバイル375: 本文バナー `my-10` が対称化（旧 上52/下40 → 上下40）・横スクロールなし
- type-check / eslint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)