### PR TITLE
feat(admin): 記事図版タブの needs トリアージ復旧（#408 マージ後の追補）

### DIFF
--- a/tools/admin-app/src/app/gallery/figures/page.tsx
+++ b/tools/admin-app/src/app/gallery/figures/page.tsx
@@ -1,30 +1,48 @@
 import Link from 'next/link';
 import Thumb from '@/components/Thumb';
 import { PageHead } from '@/components/ui';
-import { scanFigures } from '@/lib/gallery';
+import { scanFigures, figureProgress, FIGURE_NEEDS_ORDER, FIGURE_NEEDS_LABEL } from '@/lib/gallery';
 
 export const dynamic = 'force-dynamic';
+
+/** needs → バッジ色（緊急=bad / 要対応=warn / ok=good）。 */
+function needsClass(n: string | null): string {
+  if (!n || n === 'ok') return 'good';
+  if (n === 'recrop-urgent') return 'bad';
+  return 'warn';
+}
 
 export default async function FiguresGallery({
   searchParams,
 }: {
-  searchParams: Promise<{ cat?: string; kind?: string }>;
+  searchParams: Promise<{ cat?: string; kind?: string; needs?: string }>;
 }) {
   const sp = await searchParams;
   const { items } = scanFigures();
+  const prog = figureProgress(items);
 
   const cats = [...new Set(items.map((i) => i.category))].sort();
   const activeCat = cats.includes(sp.cat ?? '') ? sp.cat! : 'all';
   const activeKind = sp.kind === 'svg' || sp.kind === 'raster' ? sp.kind : 'all';
+  const activeNeeds = (FIGURE_NEEDS_ORDER as readonly string[]).includes(sp.needs ?? '')
+    ? sp.needs!
+    : 'all';
 
   const filtered = items.filter(
-    (i) => (activeCat === 'all' || i.category === activeCat) && (activeKind === 'all' || i.kind === activeKind),
+    (i) =>
+      (activeCat === 'all' || i.category === activeCat) &&
+      (activeKind === 'all' || i.kind === activeKind) &&
+      (activeNeeds === 'all' || i.needs === activeNeeds),
   );
 
-  const link = (cat: string, kind: string) => {
+  const link = (patch: Partial<{ cat: string; kind: string; needs: string }>) => {
+    const cat = patch.cat ?? activeCat;
+    const kind = patch.kind ?? activeKind;
+    const needs = patch.needs ?? activeNeeds;
     const q = new URLSearchParams();
     if (cat !== 'all') q.set('cat', cat);
     if (kind !== 'all') q.set('kind', kind);
+    if (needs !== 'all') q.set('needs', needs);
     const s = q.toString();
     return '/gallery/figures' + (s ? `?${s}` : '');
   };
@@ -36,19 +54,55 @@ export default async function FiguresGallery({
         sub={`${items.length} 枚 · .local/r2/posts/**/img/*（表示中 ${filtered.length}）`}
       />
 
+      {/* 図クロップ進捗（公開×掲載＝ライブで読者に見える図）*/}
+      <div className="card">
+        <h2>
+          進捗（公開×掲載のライブ図）
+          <span className="sub">figure-provenance.json · ok 以外＝要対応 · png/webp は basename 重複排除</span>
+        </h2>
+        <div className="filterbar" style={{ marginBottom: prog.breakdown.length ? 8 : 0 }}>
+          <span className="badge good">OK {prog.liveOk}</span>
+          <span className="badge bad">要対応 {prog.liveAction}</span>
+          <span className="badge neutral">{prog.pct}% 完了</span>
+        </div>
+        {prog.breakdown.length ? (
+          <p className="small muted" style={{ margin: 0 }}>
+            内訳: {prog.breakdown.map((b) => `${FIGURE_NEEDS_LABEL[b.needs]} ${b.count}`).join(' · ')}
+          </p>
+        ) : null}
+      </div>
+
+      {/* 対応（needs）フィルタ — /figure-recrop・figure-provenance.md が参照 */}
       <div className="filterbar">
-        <Link href={link('all', activeKind)} className={'chip' + (activeCat === 'all' ? ' active' : '')}>
+        <span className="muted small" style={{ alignSelf: 'center', marginRight: 4 }}>
+          対応:
+        </span>
+        <Link href={link({ needs: 'all' })} className={'chip' + (activeNeeds === 'all' ? ' active' : '')}>
+          全て
+        </Link>
+        {FIGURE_NEEDS_ORDER.filter((s) => prog.ndCount[s]).map((s) => (
+          <Link key={s} href={link({ needs: s })} className={'chip' + (activeNeeds === s ? ' active' : '')}>
+            {FIGURE_NEEDS_LABEL[s]} {prog.ndCount[s]}
+          </Link>
+        ))}
+      </div>
+
+      {/* 資格 */}
+      <div className="filterbar">
+        <Link href={link({ cat: 'all' })} className={'chip' + (activeCat === 'all' ? ' active' : '')}>
           全資格
         </Link>
         {cats.map((c) => (
-          <Link key={c} href={link(c, activeKind)} className={'chip' + (activeCat === c ? ' active' : '')}>
+          <Link key={c} href={link({ cat: c })} className={'chip' + (activeCat === c ? ' active' : '')}>
             {c}
           </Link>
         ))}
       </div>
+
+      {/* 種別 */}
       <div className="filterbar">
         {['all', 'svg', 'raster'].map((k) => (
-          <Link key={k} href={link(activeCat, k)} className={'chip' + (activeKind === k ? ' active' : '')}>
+          <Link key={k} href={link({ kind: k })} className={'chip' + (activeKind === k ? ' active' : '')}>
             {k === 'all' ? '全種別' : k === 'svg' ? 'SVG図版' : 'ラスタ図'}
           </Link>
         ))}
@@ -62,6 +116,17 @@ export default async function FiguresGallery({
             <Thumb key={i.rel} url={i.url} name={i.name}>
               <span className="badge neutral">{i.category}</span>
               <span className={'badge ' + (i.kind === 'svg' ? 'accent' : 'neutral')}>{i.kind}</span>
+              {i.needs ? (
+                <span
+                  className={'badge ' + needsClass(i.needs)}
+                  title={[i.needsReason, i.sourceDir ? `元: ${i.sourceDir}` : '']
+                    .filter(Boolean)
+                    .join(' / ')}
+                >
+                  {FIGURE_NEEDS_LABEL[i.needs] ?? i.needs}
+                </span>
+              ) : null}
+              {i.kind === 'raster' && !i.referenced ? <span className="badge warn">孤児</span> : null}
             </Thumb>
           ))}
         </div>

--- a/tools/admin-app/src/lib/gallery.ts
+++ b/tools/admin-app/src/lib/gallery.ts
@@ -88,18 +88,59 @@ export function scanOgp(): OgpResult {
 }
 
 // ─── 記事図版（svg / raster） ───────────────────────────
+// needs トリアージは figure-provenance.json（真実源: figure-sources.json 台帳 +
+// figure-text-audit.json 品質）が published/referenced/needs/source_dir を precompute 済み。
+// 旧 admin の MDX 再ジョインは不要で、baseRel（拡張子なし）で lookup するだけ。
+export const FIGURE_NEEDS_ORDER = [
+  'recrop-urgent',
+  'recrop',
+  'recrop-review',
+  'rescan',
+  'rescan-need-source',
+  'rescan-or-svg',
+  'ok',
+] as const;
+export const FIGURE_NEEDS_LABEL: Record<string, string> = {
+  'recrop-urgent': '要再クロップ(緊急)',
+  recrop: '再クロップ',
+  'recrop-review': '再クロップ?(要目視)',
+  rescan: '要再スキャン',
+  'rescan-need-source': '要再スキャン(元入手)',
+  'rescan-or-svg': '再スキャン/SVG',
+  ok: 'OK',
+};
+
 export interface FigureItem {
   rel: string;
   category: string;
   name: string;
   kind: 'svg' | 'raster';
   url: string;
+  needs: string | null;
+  needsReason: string | null;
+  sourceDir: string | null;
+  textStatus: string | null;
+  published: boolean;
+  referenced: boolean;
+}
+
+interface ProvEntry {
+  published?: boolean;
+  referenced?: boolean;
+  textStatus?: string;
+  source_dir?: string;
+  needs?: string;
+  manualReason?: string;
 }
 
 export function scanFigures(): { items: FigureItem[] } {
   return memo('figures', () => {
     const POSTS = repoPath('.local', 'r2', 'posts');
     if (!existsSync(POSTS)) return { items: [] };
+    const prov = readJson<{ figures?: Record<string, ProvEntry> }>(
+      repoPath('.claude', 'state', 'figure-provenance.json'),
+    );
+    const figures = prov?.figures ?? {};
     const rels = readdirSync(POSTS, { recursive: true, withFileTypes: false })
       .map((p) => toPosix(String(p)))
       .filter((p) => /\/img\/[^/]+\.(svg|png|webp|jpg)$/i.test(p));
@@ -109,11 +150,65 @@ export function scanFigures(): { items: FigureItem[] } {
         const category = dirname(rel).split('/')[0] ?? 'other';
         const name = rel.split('/').pop() ?? rel;
         const kind: 'svg' | 'raster' = /\.svg$/i.test(name) ? 'svg' : 'raster';
-        return { rel, category, name, kind, url: `/media/posts/${rel}` };
+        const baseRel = rel.replace(/\.(svg|png|webp|jpg|jpeg)$/i, '');
+        const fp = figures[baseRel];
+        return {
+          rel,
+          category,
+          name,
+          kind,
+          url: `/media/posts/${rel}`,
+          needs: fp?.needs ?? null,
+          needsReason: fp?.manualReason ?? null,
+          sourceDir: fp?.source_dir ?? null,
+          textStatus: fp?.textStatus ?? null,
+          published: fp?.published ?? false,
+          referenced: fp?.referenced ?? false,
+        };
       })
       .sort((a, b) => a.rel.localeCompare(b.rel));
     return { items };
   });
+}
+
+export interface FigureProgress {
+  liveOk: number;
+  liveAction: number;
+  liveTotal: number;
+  pct: number;
+  breakdown: { needs: string; count: number }[];
+  ndCount: Record<string, number>;
+}
+
+/**
+ * 図クロップ進捗（旧 admin gallery.js の fig-progress を移植）。
+ * 「公開×掲載」（ライブで読者に見える図）だけを分母に、ok 以外を要対応として集計。
+ * png/webp ペアは basename（拡張子除去）で重複排除する。ndCount は全ラスタの needs 別。
+ */
+export function figureProgress(items: FigureItem[]): FigureProgress {
+  const ndCount: Record<string, number> = {};
+  const liveND: Record<string, number> = {};
+  const seen = new Set<string>();
+  for (const i of items) {
+    if (i.kind !== 'raster' || !i.needs) continue;
+    ndCount[i.needs] = (ndCount[i.needs] ?? 0) + 1;
+    if (i.published && i.referenced) {
+      const k = i.rel.replace(/\.(png|webp|jpg|jpeg)$/i, '');
+      if (!seen.has(k)) {
+        seen.add(k);
+        liveND[i.needs] = (liveND[i.needs] ?? 0) + 1;
+      }
+    }
+  }
+  const liveTotal = FIGURE_NEEDS_ORDER.reduce((n, s) => n + (liveND[s] ?? 0), 0);
+  const liveOk = liveND.ok ?? 0;
+  const liveAction = liveTotal - liveOk;
+  const pct = liveTotal ? Math.round((liveOk / liveTotal) * 100) : 100;
+  const breakdown = FIGURE_NEEDS_ORDER.filter((s) => s !== 'ok' && liveND[s]).map((s) => ({
+    needs: s,
+    count: liveND[s]!,
+  }));
+  return { liveOk, liveAction, liveTotal, pct, breakdown, ndCount };
 }
 
 // ─── note 画像（cover / figure） ────────────────────────


### PR DESCRIPTION
PR #408（Next.js 管理画面 全移植・旧 admin 退役）マージ後のレビューで、退役が露出させた**機能パリティ欠落を1件**修復した追補 PR（1コミット `b18ed4bea`・#408 マージに間に合わず branch に残ったもの）。

## 内容
旧 zero-dep admin にあった記事図版の「対応(needs)」トリアージが Phase1+2 の gallery 移植で欠落。4 SSOT（`figure-recrop`/`quality-cycle` スキル・`figure-provenance.md`・`backlog.md`）が `npm run admin` → 記事図版タブ →「対応」フィルタ を参照するため復旧。

- `gallery.ts`: `scanFigures` を `figure-provenance.json`（published/referenced/needs/source_dir precompute 済みの真実源）で enrich。`figureProgress()` で「公開×掲載」ライブ図の OK/要対応を basename dedupe 集計。
- figures ページ: 進捗カード＋「対応」needs フィルタ（`?needs=`）＋needs バッジ＋source_dir ツールチップ＋孤児バッジ。

## 検証
`?needs=recrop` で 1335→29 絞込 / needs チップ counts（rescan16・ok962）/ source_dir ツールチップ / tsc 0 / 全 pre-commit gate ✓（lint-ui・doc-refs・doc-coupling）。

変更は `tools/admin-app/` 2ファイルのみ（他 PR と非競合）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)