### PR TITLE
feat(coconala): 競合市場調査を 2層 SSOT 化（軽量サマリー + 生アーカイブ）

### DIFF
--- a/.claude/agents/coconala-operator.md
+++ b/.claude/agents/coconala-operator.md
@@ -29,6 +29,7 @@ model: sonnet
 | 何を見るか | ファイル |
 |---|---|
 | サービスの価格・状態・URL・受付枠 | `src/lib/coconala-services.ts`（カタログ SoT） |
+| 競合の市場実測（価格帯・上位競合） | `.claude/state/coconala/market-summary.json`（軽量 SSOT・まずこれ／深掘りは `market-research.json`） |
 | アカウント（sellerName / profileUrl） | `.claude/config/coconala-account.json` |
 | 受注実績 | `.claude/state/coconala/orders-log.json` |
 | KPI 週次 | `.claude/state/coconala/kpi-log.json` |

--- a/.claude/state/coconala/market-summary.json
+++ b/.claude/state/coconala/market-summary.json
@@ -1,0 +1,273 @@
+{
+  "version": 1,
+  "generatedAt": "2026-07-16T12:32:54.406Z",
+  "fetchedAt": "2026-07-16T08:26:23.967Z",
+  "source": ".claude/state/coconala/market-research.json",
+  "note": "エージェント参照用の派生 SSOT。生データは source を read。再生成: npm run coconala-research -- --summary-only",
+  "keywords": [
+    {
+      "keyword": "土木施工管理技士",
+      "totalHits": 289,
+      "collected": 289,
+      "priceYen": {
+        "min": 100,
+        "median": 3000,
+        "mean": 4678,
+        "max": 65000
+      },
+      "segments": {
+        "other": 89,
+        "daiko": 10,
+        "soudan": 108,
+        "tensaku": 73,
+        "shindan": 3,
+        "kyozai": 6
+      },
+      "topByReviews": [
+        {
+          "title": "R8 1級建築施工 第１次検定 模擬試験販売します",
+          "seller": "ひげごろー（ひげごろ〜）施工管理技士講師",
+          "priceYen": 18000,
+          "rating": 4.9,
+          "reviews": 1730,
+          "segment": "other",
+          "url": "https://coconala.com/services/3345040"
+        },
+        {
+          "title": "１級建築施工【第１次】模擬試験＋解説動画販売します",
+          "seller": "ひげごろー（ひげごろ〜）施工管理技士講師",
+          "priceYen": 45000,
+          "rating": 4.8,
+          "reviews": 189,
+          "segment": "other",
+          "url": "https://coconala.com/services/3728522"
+        },
+        {
+          "title": "2026年★二次検定の出題分析と重点項目を送ります",
+          "seller": "303geos",
+          "priceYen": 2500,
+          "rating": 4.6,
+          "reviews": 134,
+          "segment": "other",
+          "url": "https://coconala.com/services/801208"
+        },
+        {
+          "title": "新出題形式対応！土木の経験記述セットで添削します",
+          "seller": "ちゃんさと技師",
+          "priceYen": 24000,
+          "rating": 5,
+          "reviews": 133,
+          "segment": "tensaku",
+          "url": "https://coconala.com/services/2280554"
+        },
+        {
+          "title": "一級土木施工管理技士経験記述例作成します",
+          "seller": "梅村在虎 建設教育",
+          "priceYen": 12000,
+          "rating": 4.7,
+          "reviews": 129,
+          "segment": "daiko",
+          "url": "https://coconala.com/services/349503"
+        }
+      ]
+    },
+    {
+      "keyword": "技術士",
+      "totalHits": 126,
+      "collected": 126,
+      "priceYen": {
+        "min": 100,
+        "median": 3000,
+        "mean": 4018,
+        "max": 33000
+      },
+      "segments": {
+        "soudan": 23,
+        "tensaku": 53,
+        "kyozai": 20,
+        "other": 26,
+        "daiko": 3,
+        "shindan": 1
+      },
+      "topByReviews": [
+        {
+          "title": "技術士第二次試験の筆記試験論文添削します",
+          "seller": "YOSHI＠技術士",
+          "priceYen": 2000,
+          "rating": 5,
+          "reviews": 57,
+          "segment": "tensaku",
+          "url": "https://coconala.com/services/3519699"
+        },
+        {
+          "title": "技術士試験の論文添削、アドバイスします",
+          "seller": "ikikd",
+          "priceYen": 3000,
+          "rating": 5,
+          "reviews": 45,
+          "segment": "tensaku",
+          "url": "https://coconala.com/services/2693992"
+        },
+        {
+          "title": "技術士試験（機械部門）の答案論文、添削します",
+          "seller": "MASA＠技術経営コンサルタント",
+          "priceYen": 2000,
+          "rating": 5,
+          "reviews": 39,
+          "segment": "tensaku",
+          "url": "https://coconala.com/services/2937635"
+        },
+        {
+          "title": "技術士(機械部門)キーワード集を提供します",
+          "seller": "ufotofu",
+          "priceYen": 1000,
+          "rating": 4.8,
+          "reviews": 37,
+          "segment": "kyozai",
+          "url": "https://coconala.com/services/361550"
+        },
+        {
+          "title": "技術士二次試験の論文、勉強法などアドバイスします",
+          "seller": "赤星宏一",
+          "priceYen": 5500,
+          "rating": 4.8,
+          "reviews": 21,
+          "segment": "soudan",
+          "url": "https://coconala.com/services/824100"
+        }
+      ]
+    },
+    {
+      "keyword": "土木施工管理",
+      "totalHits": 198,
+      "collected": 198,
+      "priceYen": {
+        "min": 100,
+        "median": 4000,
+        "mean": 10830,
+        "max": 300000
+      },
+      "segments": {
+        "daiko": 45,
+        "tensaku": 51,
+        "shindan": 5,
+        "soudan": 39,
+        "other": 53,
+        "kyozai": 5
+      },
+      "topByReviews": [
+        {
+          "title": "新出題形式対応！土木施工の経験記述を添削します",
+          "seller": "ちゃんさと技師",
+          "priceYen": 12000,
+          "rating": 4.9,
+          "reviews": 297,
+          "segment": "tensaku",
+          "url": "https://coconala.com/services/1690708"
+        },
+        {
+          "title": "2026年★施工条件予想し経験記述の解答例送ります",
+          "seller": "303geos",
+          "priceYen": 3500,
+          "rating": 4.6,
+          "reviews": 179,
+          "segment": "other",
+          "url": "https://coconala.com/services/801186"
+        },
+        {
+          "title": "2026年★二次検定の出題分析と重点項目を送ります",
+          "seller": "303geos",
+          "priceYen": 2500,
+          "rating": 4.6,
+          "reviews": 134,
+          "segment": "other",
+          "url": "https://coconala.com/services/801208"
+        },
+        {
+          "title": "新出題形式対応！土木の経験記述セットで添削します",
+          "seller": "ちゃんさと技師",
+          "priceYen": 24000,
+          "rating": 5,
+          "reviews": 133,
+          "segment": "tensaku",
+          "url": "https://coconala.com/services/2280554"
+        },
+        {
+          "title": "新出題形式対応！経験記述セットで作成代行します",
+          "seller": "ちゃんさと技師",
+          "priceYen": 32000,
+          "rating": 5,
+          "reviews": 132,
+          "segment": "daiko",
+          "url": "https://coconala.com/services/2196022"
+        }
+      ]
+    },
+    {
+      "keyword": "経験記述",
+      "totalHits": 461,
+      "collected": 460,
+      "priceYen": {
+        "min": 100,
+        "median": 4000,
+        "mean": 9074,
+        "max": 400000
+      },
+      "segments": {
+        "daiko": 56,
+        "tensaku": 133,
+        "shindan": 10,
+        "soudan": 111,
+        "other": 139,
+        "kyozai": 11
+      },
+      "topByReviews": [
+        {
+          "title": "驚くほど見違える！公務員試験ES、小論文添削します",
+          "seller": "元国家公務員mihiro",
+          "priceYen": 6000,
+          "rating": 4.8,
+          "reviews": 726,
+          "segment": "tensaku",
+          "url": "https://coconala.com/services/340306"
+        },
+        {
+          "title": "恋人・片思いの本音本心/恋愛関係の結末を霊視します",
+          "seller": "appraiser 朱璃",
+          "priceYen": 5000,
+          "rating": 5,
+          "reviews": 451,
+          "segment": "other",
+          "url": "https://coconala.com/services/241622"
+        },
+        {
+          "title": "大学/就職/昇進　論文・レポート作成サポートします",
+          "seller": "Mamiya＆Kaneko",
+          "priceYen": 3500,
+          "rating": 4.8,
+          "reviews": 387,
+          "segment": "soudan",
+          "url": "https://coconala.com/services/1673850"
+        },
+        {
+          "title": "算命学相性占い鑑定・プレミアム版となります",
+          "seller": "算命学占い鑑定師 龍メイ",
+          "priceYen": 4000,
+          "rating": 4.9,
+          "reviews": 302,
+          "segment": "other",
+          "url": "https://coconala.com/services/500796"
+        },
+        {
+          "title": "新出題形式対応！土木施工の経験記述を添削します",
+          "seller": "ちゃんさと技師",
+          "priceYen": 12000,
+          "rating": 4.9,
+          "reviews": 297,
+          "segment": "tensaku",
+          "url": "https://coconala.com/services/1690708"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/reference/coconala-operations.md
+++ b/docs/reference/coconala-operations.md
@@ -65,9 +65,22 @@ title: ココナラ運用 SSOT（受注・KPI・カタログ整合）
 > **記録しないもの**: 購入者名・提出原稿・トークルーム本文（privacyNote）。事例化は匿名化して
 > `docs/note/1級・2級土木/メンバーシップ/添削事例アーカイブ/` へ（1対多の資産化）。
 
-### 2.3 市場調査: `.claude/state/coconala/market-research.json`
+### 2.3 市場調査: 2層（生データ + エージェント参照サマリー）
 
-競合の一次データ（`npm run coconala-research`＝`scripts/coconala-research.mjs`）。**公開・ログイン不要ページの read-only 調査**で、§4 の「ダッシュボードはスクレイプしない」とは**スコープが直交**する（あちらは自社 KPI＝ログイン必須・規約と bot 検知の懸念。こちらは公開検索ページを低頻度〔商品設計時＝数ヶ月に1度〕に読むだけ・書き込みは一切しない）。
+競合の一次データを **2層** で管理する。**エージェントは軽量サマリーを SSOT として read し、生データは深掘り時のみ read する**。
+
+| 層 | ファイル | 役割 | サイズ |
+|---|---|---|---|
+| **エージェント参照 SSOT** | `.claude/state/coconala/market-summary.json` | キーワード別の価格分位・セグメント内訳・レビュー数トップ5 に畳んだ派生物。**着手時はまずこれを read** | 約 8KB |
+| アーカイブ（生データ） | `.claude/state/coconala/market-research.json` | 全出品の実測明細。個別出品の説明文・オプションまで見たいときだけ read | 約 700KB |
+
+- **再取得（実測）**: `npm run coconala-research`（＝`scripts/coconala-research.mjs`・Playwright）。生データ更新後にサマリーも自動再生成。
+- **サマリーだけ再生成**: `npm run coconala-summary`（＝`--summary-only`・Playwright 不使用・生データから畳むだけ・秒で終わる）。
+- **公開・ログイン不要ページの read-only 調査**で、§4 の「ダッシュボードはスクレイプしない」とは**スコープが直交**する（あちらは自社 KPI＝ログイン必須・規約と bot 検知の懸念。こちらは公開検索ページを低頻度〔商品設計時＝数ヶ月に1度〕に読むだけ・書き込みは一切しない）。
+
+`market-summary.json` = `{ version, generatedAt, fetchedAt, source, note, keywords: [{ keyword, totalHits, collected, priceYen: {min,median,mean,max}, segments, topByReviews: [{title,seller,priceYen,rating,reviews,segment,url}] }] }`
+
+生データ `market-research.json` = `{ version, fetchedAt, method, note, queries: [{ keyword, resolvedUrl, pageType, totalHits, pagesScanned, services: [...] }] }`
 
 `{ version, fetchedAt, method, note, queries: [{ keyword, resolvedUrl, pageType, totalHits, pagesScanned, services: [...] }] }`
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "check-sales-mapping": "node scripts/check-sales-mapping.mjs",
     "check-coconala-wiring": "node scripts/check-coconala-wiring.mjs",
     "coconala-research": "node scripts/coconala-research.mjs",
+    "coconala-summary": "node scripts/coconala-research.mjs --summary-only",
     "check-doc-lifecycle": "node scripts/check-doc-lifecycle.mjs",
     "check-policy-anchors": "node scripts/check-policy-anchors.mjs",
     "check-links": "node .claude/skills/quality/check-mdx/scripts/rules/links/check-links.mjs",

--- a/scripts/coconala-research.mjs
+++ b/scripts/coconala-research.mjs
@@ -47,6 +47,7 @@ import { join } from 'node:path';
 const ROOT = process.cwd();
 const OUT_DIR = join(ROOT, '.claude/state/coconala');
 const OUT_PATH = join(OUT_DIR, 'market-research.json');
+const SUMMARY_PATH = join(OUT_DIR, 'market-summary.json');
 const PROFILE = join(ROOT, '.local/playwright-coconala-profile');
 const PROXY = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || '';
 
@@ -112,6 +113,60 @@ function classify(title, catch_ = '') {
 function save(result) {
   result.updatedAt = new Date().toISOString();
   writeFileSync(OUT_PATH, JSON.stringify(result, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * エージェント参照用の軽量サマリー SSOT を生データ（market-research.json）から導出する。
+ * 生 JSON は 700KB 超でエージェントがコンテキストに載せられないため、
+ * キーワード別の価格分位・セグメント内訳・レビュー数トップ5 だけに畳む（数KB）。
+ * 生データが唯一の入力＝派生物なので、いつでも --summary-only で再生成できる。
+ */
+function buildSummary(result) {
+  const num = (a) => a.filter((x) => typeof x === 'number' && x > 0).sort((p, q) => p - q);
+  const stat = (arr) =>
+    arr.length
+      ? {
+          min: arr[0],
+          median: arr[Math.floor(arr.length / 2)],
+          mean: Math.round(arr.reduce((s, x) => s + x, 0) / arr.length),
+          max: arr[arr.length - 1],
+        }
+      : null;
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    fetchedAt: result.fetchedAt,
+    source: '.claude/state/coconala/market-research.json',
+    note: 'エージェント参照用の派生 SSOT。生データは source を read。再生成: npm run coconala-research -- --summary-only',
+    keywords: (result.queries || []).map((q) => {
+      const s = q.services || [];
+      const segments = {};
+      for (const x of s) segments[x.segment] = (segments[x.segment] || 0) + 1;
+      return {
+        keyword: q.keyword,
+        totalHits: q.totalHits,
+        collected: s.length,
+        priceYen: stat(num(s.map((x) => x.priceYen))),
+        segments,
+        topByReviews: [...s]
+          .sort((a, b) => (b.reviews || 0) - (a.reviews || 0))
+          .slice(0, 5)
+          .map((x) => ({
+            title: x.title,
+            seller: x.seller,
+            priceYen: x.priceYen,
+            rating: x.rating,
+            reviews: x.reviews,
+            segment: x.segment,
+            url: x.url,
+          })),
+      };
+    }),
+  };
+}
+
+function writeSummary(result) {
+  writeFileSync(SUMMARY_PATH, JSON.stringify(buildSummary(result), null, 2) + '\n', 'utf-8');
 }
 
 function loadPrev() {
@@ -292,11 +347,28 @@ async function main() {
 
   await ctx.close();
   save(result);
+  writeSummary(result);
   const total = result.queries.reduce((n, q) => n + q.services.length, 0);
   console.log(`[coconala-research] ✓ ${result.queries.length} クエリ / ${total} サービスを ${OUT_PATH} に保存`);
+  console.log(`[coconala-research] ✓ エージェント参照サマリーを ${SUMMARY_PATH} に生成`);
 }
 
-main().catch((e) => {
-  console.error('[coconala-research] ✗', e?.message ?? e);
-  process.exit(1);
-});
+/** Playwright を起動せず、既存の生データからサマリー SSOT だけを再生成する */
+function summaryOnly() {
+  const prev = loadPrev();
+  if (!prev) {
+    console.error(`[coconala-research] ✗ ${OUT_PATH} が無い／壊れている。先に実測を回してください（--force なしで）`);
+    process.exit(1);
+  }
+  writeSummary(prev);
+  console.log(`[coconala-research] ✓ ${SUMMARY_PATH} を生データから再生成（Playwright 不使用）`);
+}
+
+if (argv.includes('--summary-only')) {
+  summaryOnly();
+} else {
+  main().catch((e) => {
+    console.error('[coconala-research] ✗', e?.message ?? e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## 背景

ココナラ競合の Playwright 実測データ `market-research.json` が **728KB** あり、`coconala-operator` エージェントが毎回コンテキストに載せられない（＝実質「いつでも利用できる SSOT」になっていない）。

## 変更

競合市場調査を **2層 SSOT** に再構成した。

| 層 | ファイル | 役割 | サイズ |
|---|---|---|---|
| エージェント参照 SSOT | `market-summary.json`（新設） | キーワード別 価格分位/セグメント内訳/レビュー数トップ5 に畳んだ派生物 | 約 8KB |
| アーカイブ（生データ） | `market-research.json` | 全出品明細。深掘り時のみ read | 約 700KB |

- `scripts/coconala-research.mjs`: `buildSummary`/`writeSummary` を追加。実測後にサマリーを自動再生成。`--summary-only` で **Playwright 不使用**の再生成（生データから畳むだけ）
- `npm run coconala-summary` を追加
- `coconala-operator` の SoT テーブルに `market-summary.json` を配線（着手時にまず read）
- `coconala-operations.md §2.3` を 2層モデル・スキーマ・両コマンドで更新

## 検証

- `npm run coconala-summary` → 8.4KB 生成・4キーワード（土木施工管理技士289 / 技術士126 / 土木施工管理198 / 経験記述460）
- pre-commit / pre-push の全ガード通過（check-coconala-wiring / check-doc-coupling 含む）
- サマリーは生データから決定的に再生成可能（派生物）

🤖 Generated with [Claude Code](https://claude.com/claude-code)