### PR TITLE
feat(site): 記事内にココナラ/Brain の外部チャネルCTAを追加

### DIFF
--- a/docs/reference/brain-operations.md
+++ b/docs/reference/brain-operations.md
@@ -71,7 +71,7 @@ check-brain-wiring green → dist R2 200 確認
 
 ## 4. 審査後運用
 
-- **通過**: status を `listed` へ・`listedAt` 記録（手動 flip・brain-operator）。外部導線（note入口記事の公開・/links 掲載）はこの時点から（`listedBrainProducts()` が status=listed のみ /links に描画＝submitted 中は自動非表示）。
+- **通過**: status を `listed` へ・`listedAt` 記録（手動 flip・brain-operator）。外部導線（note入口記事の公開・/links 掲載・**記事内 CTA**）はこの時点から（`listedBrainProducts()` が status=listed のみ描画＝submitted 中は自動非表示）。**サイト内動線（記事内 CTA）**: `/links` に加え、高適合記事の末尾に Brain キットを文脈 CTA として出す。配線 SoT は `src/lib/offsite-cta.ts`（`brain-civil-essay-kit`→施工経験記述記事／`brain-sokan-policy-bank`→総監 essay・二次記事）、描画は `OffsiteCta`、クリックは `data-cta="brain"`（AnalyticsProvider）。UTM 非付与。
 - **却下**: status を `rejected`・指摘を listings へ反映 → `--force-resubmit` で再申請。
 - **本文（LP）変更**: `brain-publish` は既定で既存本文を保持（>50字なら挿入スキップ＝二重挿入防止）。差し替えは **`--replace-body`**（既存を Meta+A→Backspace で**2回**全消去→再挿入・クリア後 text>50字 or img>0 なら ABORT＝画像ノード残りの保険）。本文変更も**再審査**に入る。SoT は `.claude/config/brain-listings.json` の bodyText（価格直書き禁止・配布URLは有料ラインより後）。2026-07-23 に両商品 LP を売れ筋の型（価値3点先出し/共感/数え上げ/3ステップ/FAQ・claims-policy 準拠）へ改稿し `--replace-body --set-category 資格` で再申請。
 - **本文への図版挿入**: `brain-publish --insert-figures <json>`（`[{after:"段落に含む文字列", image:"ROOT相対パス"}]`）で本文挿入後に段落直後へ画像を入れる。挿入ロジックは `scripts/lib/brain-figures.mjs`（段落にカーソル→行の「＋」`_addContentButton_`→メニュー「画像」→隠し `input[type=file][accept=image]`）。**重複の罠**: Brain は 一時保存前でも画像アップロードを保持するため、挿入をやり直すと前回分が残り重複する→**必ず `--replace-body` と併用**しクリーン本文へ1回だけ挿入する（`--replace-body` の img>0 ABORT がこの残留を検出）。図版は `.claude/config/brain/assets/figures/*.png`（SVG源＋sharp PNG）。単体実行は `scripts/brain-insert-figures.mjs`（同 lib・下書き保存まで）。

--- a/docs/reference/coconala-operations.md
+++ b/docs/reference/coconala-operations.md
@@ -61,7 +61,18 @@ title: ココナラ運用 SSOT（受注・KPI・カタログ整合）
 | `coconala-civil-keiken-kit` | K1 制作物（DLキット）テスト出品。1級・2級 施工経験記述の**自作 AI 設計キット**（Claude Code＋Node.js 前提・provision_format=2）。`status:'draft'`。公開前ゲート=(1) 納品ZIPは外部URL(note/サイト)除去版へ差替（安全弁#2）、(2) `/coconala-publish --commit`。客層が限定される test 出品 |
 | `coconala-sokan-bunseki-pdf` | K2 単発PDF（テスト出品）。**総監** 記述式I-2 出題テーマ分析（provision_format=3・PDF は write_pdf 生成＝外部URL0件・`assets/pdf/coconala-sokan-bunseki.pdf`）。有料note施策バンク本文は非転載（分析/読み方に限定＝非カニバリ）。`status:'draft'`。総監はココナラ客層が薄い前提の test |
 
-**サイト内動線（記事内 CTA）**: `/links` ハブに加え、施工経験記述の高適合記事（`civil-construction-{1,2}-secondary-experience-writing-{guide,examples}`）の末尾に、ココナラ経験記述サービス（`coconala-shindan` 診断＋`coconala-tensaku-set` 添削）を文脈 CTA として出す。配線 SoT は `src/lib/offsite-cta.ts`（slug→listed サービス・note の magazine-placement.ts と直交）、描画は `OffsiteCta` コンポーネント。listed のみ発火・外部 URL に UTM 非付与・クリックは `data-cta="coconala"`（AnalyticsProvider）。
+**サイト内動線（記事内 CTA）**: `/links` ハブに加え、二次系の高適合記事の末尾にサービスを文脈 CTA として出す。配線 SoT は `src/lib/offsite-cta.ts`（slug→listed サービス・note の magazine-placement.ts と直交）、描画は `OffsiteCta` コンポーネント。listed のみ発火・外部 URL に UTM 非付与・クリックは `data-cta="coconala"`（AnalyticsProvider）・1ページ最大3枚・1級/2級は slug prefix で PDF を出し分け。対応表:
+
+| 記事 | 出すサービス |
+|---|---|
+| 経験記述（`secondary-experience-writing-{guide,examples}`・1級2級） | `coconala-shindan`＋`coconala-tensaku-set`（＋Brain 経験キット） |
+| 二次 年度別過去問（`secondary-r0[3-9]`） | `{1kyu,2kyu}-kakomon-pdf`＋`{1kyu,2kyu}-gakka-pdf` |
+| 二次 学科分野別（1級 `secondary-(concrete\|construction-plan\|earthwork\|quality-management)-(basics\|past-problems)`） | `coconala-1kyu-gakka-pdf` |
+| 二次 入門・直前（1級 `secondary-getting-started`／`guide-last-minute-2026`） | `coconala-1kyu-moshi-pdf`＋`coconala-bunseki-pdf` |
+| 二次 入門（2級 `secondary-getting-started`） | `coconala-2kyu-moshi-pdf` |
+| 総監 記述系（`essay-*`／`pattern-essay-*`／`{h2X,r0X}-secondary`） | `coconala-sokan-bunseki-pdf`（＋Brain 施策バンク） |
+
+未掲載（`/links` のみ）: `coconala-sakusei`／`coconala-kanseitoan-pdf`／`coconala-2kyu-kanseitoan-pdf`／`coconala-civil-keiken-kit`（経験記述ページは診断+添削+Brain で満杯・クロップ回避のため意図的に載せない）。
 
 ### 2.1b 出品投入 SoT: `.claude/config/coconala-listings.json`
 

--- a/docs/reference/coconala-operations.md
+++ b/docs/reference/coconala-operations.md
@@ -61,6 +61,8 @@ title: ココナラ運用 SSOT（受注・KPI・カタログ整合）
 | `coconala-civil-keiken-kit` | K1 制作物（DLキット）テスト出品。1級・2級 施工経験記述の**自作 AI 設計キット**（Claude Code＋Node.js 前提・provision_format=2）。`status:'draft'`。公開前ゲート=(1) 納品ZIPは外部URL(note/サイト)除去版へ差替（安全弁#2）、(2) `/coconala-publish --commit`。客層が限定される test 出品 |
 | `coconala-sokan-bunseki-pdf` | K2 単発PDF（テスト出品）。**総監** 記述式I-2 出題テーマ分析（provision_format=3・PDF は write_pdf 生成＝外部URL0件・`assets/pdf/coconala-sokan-bunseki.pdf`）。有料note施策バンク本文は非転載（分析/読み方に限定＝非カニバリ）。`status:'draft'`。総監はココナラ客層が薄い前提の test |
 
+**サイト内動線（記事内 CTA）**: `/links` ハブに加え、施工経験記述の高適合記事（`civil-construction-{1,2}-secondary-experience-writing-{guide,examples}`）の末尾に、ココナラ経験記述サービス（`coconala-shindan` 診断＋`coconala-tensaku-set` 添削）を文脈 CTA として出す。配線 SoT は `src/lib/offsite-cta.ts`（slug→listed サービス・note の magazine-placement.ts と直交）、描画は `OffsiteCta` コンポーネント。listed のみ発火・外部 URL に UTM 非付与・クリックは `data-cta="coconala"`（AnalyticsProvider）。
+
 ### 2.1b 出品投入 SoT: `.claude/config/coconala-listings.json`
 
 出品フォームへ流し込む本文・カテゴリ・納期・ジャンルの機械可読 SoT（`coconala-publish/edit` が serviceId で引く）。**価格・タイトル・状態・URL はカタログ（2.1）が真実源＝ここに価格を書かない**（安全弁§4）。

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -26,6 +26,7 @@ import { MDXProvider } from '@mdx-js/react';
 import { extractHeadings } from '@/lib/toc';
 import { resolvePlacement } from '@/lib/magazine-placement';
 import { resolveHubCta } from '@/lib/hub-cta';
+import { resolveOffsiteCta } from '@/lib/offsite-cta';
 import { getMagazine, buildMagazineUrl, type NoteMagazine } from '@/lib/note-magazines';
 import MagazineTopBanner from '@/components/ui/MagazineTopBanner';
 import MetaRow from '@/components/ui/MetaRow/MetaRow';
@@ -304,6 +305,9 @@ export default async function DocPage({
   // 全ページ統一の一環で復活し、カテゴリ hub（sidebar -sb + mobile -mob）と同じ二面構成に揃える。
   const sidebarMokuji =
     showMokuji && category ? resolveHubCta(category, { utmSuffix: 'docs-sb' }) : null;
+  // 外部チャネル（ココナラ添削／Brain 自作キット）CTA。施工経験記述・総監記述系の高適合ページのみ非空。
+  // 商品の listed 状態は offsite-cta.ts 側で判定（未 listed は自動非表示）。
+  const offsiteCta = resolveOffsiteCta(slugStr);
   // 記事冒頭 CTA（二次系高 intent ページのみ placement.top で設定）。getMagazine() ゲートを
   // 通すため未公開マガジン（会員ラボ等）は自動非表示。末尾の画像カードと重複してよい。
   const topSlot = magazinePlacement.top;
@@ -467,6 +471,7 @@ export default async function DocPage({
               meta={doc.meta}
               categoryArticles={categoryArticles}
               footerMokuji={footerMokuji}
+              offsiteCta={offsiteCta}
               faqs={faqs}
               hasCategoryNavCard={hasCategoryNavCard}
               authorDates={authorDates}

--- a/src/components/providers/AnalyticsProvider.tsx
+++ b/src/components/providers/AnalyticsProvider.tsx
@@ -20,7 +20,7 @@ export default function AnalyticsProvider() {
 
   // 収益 CTA（note 有料マガジン / アフィリエイト）・note 無料記事への送客・サイト内回遊ナビの
   // クリックを 1 つのデリゲートリスナーで計測する。各コンポーネントを client 化せず、
-  // サーバー描画の <a> に data-cta="note" | "affiliate" | "note-article" | "nav"（+ data-cta-label）
+  // サーバー描画の <a> に data-cta="note" | "affiliate" | "note-article" | "nav" | "coconala" | "brain"（+ data-cta-label）
   // を付けるだけで拾える設計。GA4 はイベントに pagePath を自動付与するため、
   // eventName × pagePath × label でページ別・ナビ別クリック数が取れる。
   // note（有料マガジン購入 CTA）と note-article（無料記事ナビ）は別イベントに分離し、
@@ -34,12 +34,16 @@ export default function AnalyticsProvider() {
       affiliate: "affiliate_cta_click",
       "note-article": "note_article_click",
       nav: "internal_nav_click",
+      coconala: "coconala_cta_click",
+      brain: "brain_cta_click",
     };
     const CATEGORY: Record<string, string> = {
       note: "note-magazine",
       affiliate: "affiliate",
       "note-article": "note-article",
       nav: "internal-nav",
+      coconala: "coconala",
+      brain: "brain",
     };
     const onClick = (e: MouseEvent) => {
       const start = e.target as Element | null;

--- a/src/components/ui/ArticleFooter/ArticleFooter.tsx
+++ b/src/components/ui/ArticleFooter/ArticleFooter.tsx
@@ -12,6 +12,8 @@ import PillarNavCard from '@/components/ui/PillarNavCard';
 import RelatedTextbooks from '@/components/ui/RelatedTextbooks/RelatedTextbooks';
 import HubCtaBanner from '@/components/ui/HubCtaBanner/HubCtaBanner';
 import { type ResolvedHubCta } from '@/lib/hub-cta';
+import OffsiteCta from '@/components/ui/OffsiteCta';
+import { type OffsiteCtaItem } from '@/lib/offsite-cta';
 import TextbookNav from '@/components/ui/TextbookNav/TextbookNav';
 import CategoryNavCard from '@/components/ui/CategoryNavCard/CategoryNavCard';
 import FAQCard from '@/components/ui/FAQCard/FAQCard';
@@ -30,6 +32,8 @@ interface ArticleFooterProps {
   readonly categoryArticles: DocMeta[];
   /** もくじ（L2 索引）タイル。HUB 資格 & 非 career のとき非 null。全 HUB ページの記事末尾に統一表示。 */
   readonly footerMokuji: ResolvedHubCta | null;
+  /** 外部チャネル（ココナラ/Brain）CTA。高適合ページのみ非空（offsite-cta.ts が解決）。 */
+  readonly offsiteCta: readonly OffsiteCtaItem[];
   readonly faqs: { q: string; a: string }[];
   readonly hasCategoryNavCard: boolean;
   readonly authorDates: {
@@ -53,6 +57,7 @@ export default function ArticleFooter({
   meta,
   categoryArticles,
   footerMokuji,
+  offsiteCta,
   faqs,
   hasCategoryNavCard,
   authorDates,
@@ -103,6 +108,10 @@ export default function ArticleFooter({
           </div>
         </div>
       )}
+
+      {/* 外部チャネル（ココナラ添削／Brain 自作キット）CTA。施工経験記述・総監記述系の高適合ページのみ。
+          note もくじ（フル教材）とは別種の「個別添削」「自作キット」導線として並置。listed 商品のみ描画。 */}
+      <OffsiteCta items={offsiteCta} />
 
       {/* Civil 2級 guide（キャリア記事）: 記事末 CTA なし（GKS はサイドバー上部に集約＝1 ページ 1 GKS ピクセル）。
           本文インライン CareerAffiliate（href のみ）は MDX 側で維持。 */}

--- a/src/components/ui/OffsiteCta/OffsiteCta.tsx
+++ b/src/components/ui/OffsiteCta/OffsiteCta.tsx
@@ -1,0 +1,51 @@
+import type { OffsiteCtaItem, OffsiteChannel } from '@/lib/offsite-cta';
+
+/**
+ * OffsiteCta — 記事末尾に出す外部チャネル（ココナラ / Brain）導線カード。
+ * 配線・出し分けは offsite-cta.ts（slug → listed 商品）に一任し、ここは描画のみ。
+ * 自社チャネル（アフィリではない）ため PR 表記は不要。外部 URL に UTM は付けない。
+ * クリックは data-cta="coconala"|"brain" を AnalyticsProvider が計測する。
+ */
+const CHANNEL_LABEL: Record<OffsiteChannel, string> = {
+  coconala: 'ココナラ',
+  brain: 'Brain',
+};
+
+export default function OffsiteCta({ items }: { readonly items: readonly OffsiteCtaItem[] }) {
+  if (!items.length) return null;
+  return (
+    <div className="not-prose mt-8">
+      <div className="mb-2 text-sm font-semibold text-[var(--ink-muted)]">
+        この記事に関連するサービス
+      </div>
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {items.map((it) => (
+          <li key={it.trackLabel}>
+            <a
+              href={it.href}
+              target="_blank"
+              rel="noopener nofollow"
+              data-cta={it.channel}
+              data-cta-label={it.trackLabel}
+              className="group flex h-full flex-col rounded-card-content border border-[var(--rule-soft)] bg-[var(--accent-fill)] px-4 py-3.5 transition-colors hover:border-[var(--accent)]"
+            >
+              <span className="mb-1.5 inline-flex w-fit items-center rounded-full border border-[var(--rule-soft)] px-2 py-0.5 text-[11px] font-semibold text-[var(--ink-muted)]">
+                {CHANNEL_LABEL[it.channel]}
+              </span>
+              <span className="text-sm leading-6 text-ink-body">{it.catch}</span>
+              <span className="mt-2 flex items-baseline justify-between gap-2">
+                <span className="text-[14px] font-bold text-[var(--accent)] group-hover:underline">
+                  {it.shortTitle}
+                  <span aria-hidden className="ml-0.5 transition-transform group-hover:translate-x-0.5">
+                    ›
+                  </span>
+                </span>
+                <span className="shrink-0 text-xs text-[var(--ink-muted)]">{it.price}</span>
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/ui/OffsiteCta/index.ts
+++ b/src/components/ui/OffsiteCta/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OffsiteCta';

--- a/src/lib/offsite-cta.ts
+++ b/src/lib/offsite-cta.ts
@@ -1,0 +1,98 @@
+/**
+ * 記事 slug → ココナラ / Brain（外部チャネル）CTA のマッピング (Single Source of Truth)
+ *
+ * note 有料マガジンの magazine-placement.ts と直交する「外部チャネル導線」の SoT。
+ * 設計方針:
+ * - **高適合ページに限定**して出す（全記事に撒かない）。対象は施工経験記述（ココナラ添削／Brain 自作キット）
+ *   と総監 記述系（Brain 設問3 施策バンク）のみ。
+ * - 表示の最終可否は coconala-services.ts / brain-products.ts の status='listed' で決まる
+ *   （listed 以外は自動非表示＝出品前の wire-ahead）。ここでは「どのページに何を出すか」だけを定義する。
+ * - 外部 URL に UTM は付けない（計測が外部で完結しパラメータが無駄に露出するため。links-hub.md と同方針）。
+ *   クリック計測は data-cta="coconala"|"brain" で AnalyticsProvider が拾う。
+ */
+import { listedCoconalaServices } from './coconala-services';
+import { listedBrainProducts } from './brain-products';
+
+export type OffsiteChannel = 'coconala' | 'brain';
+
+export interface OffsiteCtaItem {
+  readonly channel: OffsiteChannel;
+  readonly href: string;
+  readonly shortTitle: string;
+  readonly price: string;
+  /** 文脈連動の1行コピー（なぜこの記事の読者に効くか） */
+  readonly catch: string;
+  /** GA4 の data-cta-label */
+  readonly trackLabel: string;
+}
+
+interface OffsiteRule {
+  readonly test: RegExp;
+  readonly coconala?: readonly string[];
+  readonly brain?: readonly string[];
+  readonly coconalaCatch?: string;
+  readonly brainCatch?: string;
+}
+
+// slug は category prefix 付きの完全形（例: civil-construction-1-secondary-experience-writing-guide）。
+const RULES: readonly OffsiteRule[] = [
+  {
+    // 施工経験記述（1級・2級）: 読者が自分の工事で答案を書く高 intent ページ。
+    test: /^civil-construction-[12]-secondary-experience-writing-(guide|examples)$/,
+    coconala: ['coconala-shindan', 'coconala-tensaku-set'],
+    brain: ['brain-civil-essay-kit'],
+    coconalaCatch: '自分の答案を1本、プロの視点で見てほしい方へ。',
+    brainCatch: '自分の工事経験から答案を自作したい方へ（Claude Code キット）。',
+  },
+  {
+    // 総監 記述系（模範論文解説 essay-* / pattern-essay-* / 二次過去問 h2X・r0X-secondary）:
+    // 設問3の国家施策の備蓄が刺さる層。ココナラは土木経験記述専用のため出さない（examScope 不整合）。
+    test: /^pe-comprehensive-management-(essay-|pattern-essay-|(?:h\d{2}|r\d{2})-secondary$)/,
+    brain: ['brain-sokan-policy-bank'],
+    brainCatch: '設問3の国家施策を根拠つきで備蓄したい方へ（Claude Code キット）。',
+  },
+];
+
+/**
+ * 記事 slug に対して出す外部チャネル CTA を解決する。
+ * 非対象ページ・未 listed の商品は空配列（＝非表示）。
+ */
+export function resolveOffsiteCta(slug: string): OffsiteCtaItem[] {
+  const rule = RULES.find((r) => r.test.test(slug));
+  if (!rule) return [];
+  const items: OffsiteCtaItem[] = [];
+
+  if (rule.coconala?.length) {
+    const listed = listedCoconalaServices();
+    for (const id of rule.coconala) {
+      const svc = listed.find((s) => s.id === id);
+      if (!svc) continue;
+      items.push({
+        channel: 'coconala',
+        href: svc.serviceUrl,
+        shortTitle: svc.shortTitle,
+        price: svc.price,
+        catch: rule.coconalaCatch ?? '',
+        trackLabel: `offsite-${id}`,
+      });
+    }
+  }
+
+  if (rule.brain?.length) {
+    const listed = listedBrainProducts();
+    for (const id of rule.brain) {
+      const p = listed.find((x) => x.id === id);
+      if (!p) continue;
+      items.push({
+        channel: 'brain',
+        href: p.productUrl,
+        shortTitle: p.shortTitle,
+        price: p.price,
+        catch: rule.brainCatch ?? '',
+        trackLabel: `offsite-${id}`,
+      });
+    }
+  }
+
+  return items;
+}

--- a/src/lib/offsite-cta.ts
+++ b/src/lib/offsite-cta.ts
@@ -3,8 +3,8 @@
  *
  * note 有料マガジンの magazine-placement.ts と直交する「外部チャネル導線」の SoT。
  * 設計方針:
- * - **高適合ページに限定**して出す（全記事に撒かない）。対象は施工経験記述（ココナラ添削／Brain 自作キット）
- *   と総監 記述系（Brain 設問3 施策バンク）のみ。
+ * - **高適合ページに限定**して出す（全記事に撒かない）。対象は土木二次（経験記述／年度別過去問／学科記述／
+ *   直前対策）と総監 記述系。1ページ最大 3 枚に抑える（クロップ防止）。1級/2級は slug prefix で PDF を出し分け。
  * - 表示の最終可否は coconala-services.ts / brain-products.ts の status='listed' で決まる
  *   （listed 以外は自動非表示＝出品前の wire-ahead）。ここでは「どのページに何を出すか」だけを定義する。
  * - 外部 URL に UTM は付けない（計測が外部で完結しパラメータが無駄に露出するため。links-hub.md と同方針）。
@@ -35,9 +35,10 @@ interface OffsiteRule {
 }
 
 // slug は category prefix 付きの完全形（例: civil-construction-1-secondary-experience-writing-guide）。
+// RULES は上から最初にマッチした1件のみ採用（find）。パターンは相互排他に保つ。
 const RULES: readonly OffsiteRule[] = [
   {
-    // 施工経験記述（1級・2級）: 読者が自分の工事で答案を書く高 intent ページ。
+    // 施工経験記述（1級・2級）: 読者が自分の工事で答案を書く高 intent ページ。人の添削/診断が最も刺さる。
     test: /^civil-construction-[12]-secondary-experience-writing-(guide|examples)$/,
     coconala: ['coconala-shindan', 'coconala-tensaku-set'],
     brain: ['brain-civil-essay-kit'],
@@ -45,10 +46,42 @@ const RULES: readonly OffsiteRule[] = [
     brainCatch: '自分の工事経験から答案を自作したい方へ（Claude Code キット）。',
   },
   {
+    // 1級 二次 年度別過去問（secondary-r03〜r09）: 経験記述 過去問模範答案＋学科記述攻略が刺さる。
+    test: /^civil-construction-1-secondary-r0[3-9]$/,
+    coconala: ['coconala-1kyu-kakomon-pdf', 'coconala-1kyu-gakka-pdf'],
+    coconalaCatch: '年度別に過去問を仕上げたい方へ（模範答案・学科攻略 PDF）。',
+  },
+  {
+    // 2級 二次 年度別過去問。
+    test: /^civil-construction-2-secondary-r0[3-9]$/,
+    coconala: ['coconala-2kyu-kakomon-pdf', 'coconala-2kyu-gakka-pdf'],
+    coconalaCatch: '年度別に過去問を仕上げたい方へ（模範答案・学科攻略 PDF）。',
+  },
+  {
+    // 1級 二次 学科記述の分野別ページ（コンクリート/施工計画/土工/品質の basics・past-problems）。
+    test: /^civil-construction-1-secondary-(concrete|construction-plan|earthwork|quality-management)-(basics|past-problems)$/,
+    coconala: ['coconala-1kyu-gakka-pdf'],
+    coconalaCatch: '学科記述を出る順で仕上げたい方へ（攻略 PDF）。',
+  },
+  {
+    // 1級 二次 入門・直前対策: 予想模試＋出題分析（直前重点）が刺さる。
+    test: /^civil-construction-1-(secondary-getting-started|guide-last-minute-2026)$/,
+    coconala: ['coconala-1kyu-moshi-pdf', 'coconala-bunseki-pdf'],
+    coconalaCatch: '直前の総仕上げに（予想模試・出題分析 PDF）。',
+  },
+  {
+    // 2級 二次 入門（直前対策 guide は 2級には無いため getting-started のみ）。
+    test: /^civil-construction-2-secondary-getting-started$/,
+    coconala: ['coconala-2kyu-moshi-pdf'],
+    coconalaCatch: '直前の総仕上げに（予想模試 PDF）。',
+  },
+  {
     // 総監 記述系（模範論文解説 essay-* / pattern-essay-* / 二次過去問 h2X・r0X-secondary）:
-    // 設問3の国家施策の備蓄が刺さる層。ココナラは土木経験記述専用のため出さない（examScope 不整合）。
+    // 設問3の国家施策の備蓄（Brain）＋出題テーマの読み方（ココナラ分析 PDF）。
     test: /^pe-comprehensive-management-(essay-|pattern-essay-|(?:h\d{2}|r\d{2})-secondary$)/,
+    coconala: ['coconala-sokan-bunseki-pdf'],
     brain: ['brain-sokan-policy-bank'],
+    coconalaCatch: '出題テーマの読み方を押さえたい方へ（出題分析 PDF）。',
     brainCatch: '設問3の国家施策を根拠つきで備蓄したい方へ（Claude Code キット）。',
   },
 ];


### PR DESCRIPTION
## 概要

これまで **Brain／ココナラへの動線は `/links` ハブ経由のみ**で、記事本文からの導線はゼロだった（note は記事内 CTA まで作り込み済み）。本 PR は**高適合ページ限定**で、記事末尾（note もくじ直後）に外部チャネルの文脈 CTA を追加する。

## 出し分け（高適合のみ・全記事には撒かない）

| 対象記事 | 出す CTA |
|---|---|
| 施工経験記述（`civil-construction-{1,2}-secondary-experience-writing-{guide,examples}`） | ココナラ 経験記述 診断＋添削、Brain 経験記述設計キット |
| 総監 記述系（`pe-comprehensive-management-{essay-*,pattern-essay-*,h2X-secondary,r0X-secondary}`） | Brain 総監 施策バンクキット |

ココナラは土木経験記述専用（examScope）のため総監記事には出さない。

## 設計

- 配線 SoT: **`src/lib/offsite-cta.ts`**（slug→listed 商品。note の `magazine-placement.ts` と直交）
- 描画: `src/components/ui/OffsiteCta`（`ArticleFooter` が note もくじ直後に描画）
- **listed のみ発火**（`coconala-services.ts`/`brain-products.ts` の status。未 listed は自動非表示＝wire-ahead）
- 外部 URL に **UTM 非付与**（links-hub と同方針）、クリックは `data-cta="coconala"|"brain"` を `AnalyticsProvider` に登録して GA4 計測

## 検証（dev サーバー・DOM 実証）

- 経験記述記事: ココナラ診断(¥1,500)＋添削(¥6,000)＋Brain キットの**3件描画**（href/rel=noopener nofollow/target=_blank 確認）
- 総監 essay 記事: **Brain 施策バンクのみ1件**（ココナラ非表示）
- 非対象（textbook）記事: **0件**（heading も非表示）
- `npm run type-check` green / eslint clean / `check-doc-refs` green / console エラーなし
- ※ プレビューのスクリーンショット機構が空フレームを返すため視覚キャプチャは未取得。描画は DOM 検査で実証済み

## ドキュメント

`docs/reference/coconala-operations.md` §2.1／`brain-operations.md` §4 に記事内 CTA 配線を追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)