### PR TITLE
feat(ci): オフライン PDCA surfacer を CI に載せ、発見可能性と SSOT 二重管理を解消

### DIFF
--- a/.claude/agents/gsc-browser-collector.md
+++ b/.claude/agents/gsc-browser-collector.md
@@ -72,6 +72,8 @@ GSC/GA4 の UI CSV を取得する既存スクリプトを実行し、生成物�
 - **GA4 管理画面の設定**（カスタムディメンション作成・データ保持の観測）: `scripts/ga4-admin-setup.mjs`
   （`npm run ga4-admin:check` / `:apply`）。収集ではなく**設定**の面なので本エージェントの守備範囲外。
 - SSOT 整合の判定: `npm run check-google-ui-ssot`（決定的スクリプト）。
+- **インデックス登録のリクエスト**: `scripts/gsc-request-indexing.mjs`（`npm run gsc-indexing:check` / `:request`）。
+  収集ではなく**介入**なので守備範囲外。外向き操作なので既定 dry-run・`--commit` gate で分離してある。
 
 ## 出力フォーマット（親へ返すテキスト）
 

--- a/.claude/knowledge/reference/gsc-management.md
+++ b/.claude/knowledge/reference/gsc-management.md
@@ -57,6 +57,21 @@ Google Search Console の継続管理（インデックス被覆・検索パフ�
 - **月次（ローカル・手動）**: `/google-search-growth` で理由別 UI CSV を取得 → 突合 → 修正計画 → 観測ログ追記。**放置防止**は `check-gsc-ui-due`（30日）を weekly-review が surface（DUE なら次セッションで実行）。`/gsc-review`（coverage 全体）の深掘り＝理由ごとの例 URL を足す層。
 - **週次**: `fetch-metrics.yml`（CI・金 JST 6:00）→ `/weekly-improve`（performance 側）
 
+> [!warning] 何が自動で回り、何が回らないか（2026-07-30 実査）
+> **自動（GitHub Actions cron・実績で確認）**: fetch-metrics（週次）/ psi-audit（日次）/
+> index-coverage（月次）/ link-audit / r2-audit / note-live-audit / uptime-ping。
+> **オフライン surfacer も CI 側で自動**（`weekly-review-guard.yml` が毎週月曜に実行）:
+> check-experiment-due / check-gsc-ui-due / check-google-ui-ssot / check-ga4-dimensions を
+> job summary へ出力し、check-internal-links-vs-gsc は hard fail させる。
+>
+> **自動で回っていないもの**:
+> 1. **`/weekly-review` のクラウドルーティンは停止している**。W29 までは Claude が生成していたが
+>    W30/W31 は手動、`weekly-review-guard` は 2026-07-20・07-27 と 2 週連続で赤。復旧は対話セッションで
+>    `/routines`（list-first）→ 無ければ `/schedule`。**重複作成事故を避けるため必ず list-first**。
+> 2. **Playwright 経路は原理的に CI 化不可**（Google ログインが必要）＝`search-growth:audit` /
+>    `ga4-admin:check` / `gsc-indexing:request` は月次の手動儀式。放置検知は上の surfacer が担う。
+> 3. **`/nsm-experiment measure` の実行も手動**。期限の surface は自動、判断と記録は人（セッション）。
+
 - **GA4 管理画面 設定（ローカル手動・随時＋90日で再観測）**: `npm run ga4-admin:check`（観測・dry-run）→ 不足があれば `npm run ga4-admin:apply`（`--commit`）。
   オフラインの `npm run check-ga4-dimensions` が desired state と最後の観測を突合し、blocking な未登録を FAIL にする。
 

--- a/.claude/knowledge/reference/gsc-management.md
+++ b/.claude/knowledge/reference/gsc-management.md
@@ -33,6 +33,9 @@ Google Search Console の継続管理（インデックス被覆・検索パフ�
 | `check-google-ui-ssot` | Script（ゲート） | 追跡 SSOT の整合（marker ↔ history ↔ urls の runId・スキーマ・truncated・**検査ゼロ**）。SSOT が空／直近実行が不完全なら exit 1 | `gsc-ui/ssot/**` → exit 0/1 |
 | `ga4-admin-setup` | Script（ローカル手動・Playwright） | GA4 管理画面の設定を desired state と突合し、**不足カスタムディメンションを作成**（既定 dry-run・`--commit` で実行）。データ保持は観測のみ | `config/ga4-admin-desired-state.json` → `metrics/ga4-admin/inventory-latest.json` |
 | `check-ga4-dimensions` | Script（ゲート・オフライン） | desired state と最後の実機観測を突合。blocking なカスタムディメンション（`event_label`/`cta_placement`）が未登録なら exit 1 | inventory-latest → exit 0/1 |
+| `check-internal-links-vs-gsc` | Script（ゲート・オフライン） | **公開ページ**が GSC の 404/リダイレクト URL を指していないか（SSOT と全 MDX/src を突合）。旧 URL 件数を能動的に減らせる唯一のレバー | `gsc-ui/ssot` + MDX → exit 0/1 |
+| `gsc-request-indexing` | Script（ローカル手動・Playwright） | 未登録 URL を URL 検査で診断し、**インデックス登録をリクエスト**（既定 dry-run・`--commit` gate・上限 10 件/回）。crawled-not-indexed への直接レバー | SSOT → `gsc-indexing/{requests-latest,history}.json` |
+| `check-experiment-due` | Script（surfacer） | 実験台帳の再計測/close 期限（サイクルの最後の輪）。weekly-review が列挙 | `experiments.json` → DUE 一覧 |
 | 機械履歴 | `index-coverage-history.json` | indexed_ratio の時系列 | CI が append |
 | 人間判断履歴 | 本 doc「観測・判断ログ」 | 何を打ち手にしたかの意思決定記録 | `/gsc-review` がユーザーと追記 |
 
@@ -103,6 +106,8 @@ URL Inspection の `coverage_state` と `page_fetch_state` から真因を切り
 | GA4 UI 取得マーカー（committed） | `.claude/state/metrics/ga4-ui/last-run.json`（任意チャネル・一次経路は Data API） |
 | GA4 管理画面 設定の期待値 | `.claude/config/ga4-admin-desired-state.json` |
 | GA4 管理画面 設定の観測（committed） | `.claude/state/metrics/ga4-admin/inventory-latest.json` ＋ `history.json` |
+| インデックス登録リクエストの記録（committed・**SSOT**） | `.claude/state/metrics/gsc-indexing/requests-latest.json` ＋ `history.json`（診断 state / reason / crawl・index 許可 / 送信結果）|
+| 実験台帳（committed） | `.claude/state/experiments.json`（`/nsm-experiment` が管理・`check-experiment-due` が期限判定）|
 | 検索流入 修正計画 | `.claude/state/improvements/search-growth-latest.md`（run JSON は gitignore） |
 
 ## 観測・判断ログ（append-only・人間の意思決定記録）

--- a/.claude/skills/management/google-search-growth/SKILL.md
+++ b/.claude/skills/management/google-search-growth/SKILL.md
@@ -82,6 +82,15 @@ GSC/GA4 を横断して「どの URL が・なぜ検索に効いていないか�
      out HTML/GSC page/GA4 page を突合 → URL 分類）
    - 生成: `.claude/state/improvements/search-growth-<run>.json` と `search-growth-latest.md`
 
+5.5 **介入候補の抽出（crawled-not-indexed）**
+   - `npm run gsc-indexing:check -- --from-ssot --category <cat> --group <group>` で診断（読み取りのみ）
+   - `crawl=true` / `index=true` なのに `not-indexed` なら技術的阻害ゼロ＝Google の選別。残るレバーは
+     インデックス登録リクエスト（`npm run gsc-indexing:request -- … --limit 10`・外向き操作なので gate 済み）
+   - **実行したら `/nsm-experiment start` で台帳に載せる**（baseline と next_check_date を入れる）。
+     載せないと再計測されず学びが残らない（`check-experiment-due` が期限を surface する）
+   - 期待値の出し方: 同 group の登録済みページの「1 本あたり表示」× 未登録本数。件数の多さで選ばない
+     （2026-07-30 実測では textbook 20 本＝期待 +264 が keyword 190 本＝+180 を上回った）
+
 6. **evaluate**（Evaluator を並列起動）
    - `seo-fix-planner`（URL 分類の意味補正・優先順位）
    - `gsc-index-auditor`（coverage ratio・原因バケット）

--- a/.claude/skills/management/nsm-experiment/SKILL.md
+++ b/.claude/skills/management/nsm-experiment/SKILL.md
@@ -29,6 +29,26 @@ Act        : close で learnings 記録 → roadmap にフィードバック
 
 詳細は `.claude/skills/management/nsm-experiment/references/definition.md` と `.claude/pdfs/guide.pdf`（Chapter 3）を参照。
 
+## GSC インデックス登録リクエストの実行と記録（2026-07-30 改訂）
+
+本スキルの Use-when に「GSC インデックスリクエスト」が入っているが、実行手段は長らく**手作業**で、
+記録も手書きの `.claude/state/metrics/notes/gsc-indexing-requests-YYYY-MM-DD.md` だった
+（`.claude/state/*.md` 新規作成禁止＝CLAUDE.md §8 に反する旧パターン）。現在は自動化してある:
+
+```bash
+npm run gsc-indexing:check -- --from-ssot --category civil-construction-1 --group textbook   # 診断のみ
+npm run gsc-indexing:request -- --from-ssot --category civil-construction-1 --group textbook --limit 10
+```
+
+- 対象は GSC UI SSOT（`crawledNotIndexed--allKnownPages.json`）から category / group で絞る。
+  published:false は自動的に除外。
+- **既定 dry-run**。送信は `--commit`（`:request`）のみ。1 回の送信上限は既定 10 件（日次クォータ配慮）。
+  上限やクォータで送れなかった分は `limit-reached` / `quota-exceeded` として記録され、次回に回る。
+- 送信後に受理文言を確認し、読めなければ `unconfirmed`＝成功にカウントしない。
+- **記録の SSOT は `.claude/state/metrics/gsc-indexing/{requests-latest,history}.json`**（追跡）。
+  手書きノートは作らない。`notes/gsc-indexing-requests-2026-04-15.md` は 2026-04 当時の履歴として残置。
+- pending 表示（上の resume 画面）は history.json の `limit-reached` / `quota-exceeded` から組む。
+
 ## サイクルが閉じたことを機械で保証する（2026-07-30 追加）
 
 propose→start→measure→close の**仕組み**は本スキルが持つが、「期限が来たのに measure されていない」を
@@ -107,7 +127,7 @@ abandoned  abandoned  running (re-measure)
      ・civil-construction-1-textbook-construction-mgmt-overview
      ・civil-construction-1-guide-earthwork-key-points
    理由: GSC 1 日クォータ上限到達
-   参照: .claude/state/metrics/notes/gsc-indexing-requests-2026-04-15.md
+   参照: .claude/state/metrics/gsc-indexing/history.json（機械記録・SSOT）
 ```
 
 5. ユーザーに「どの action から進めるか」を問う。「EXP-001 を resume して」等の返答があれば `resume` サブモードへ遷移。

--- a/.claude/skills/management/weekly-review/SKILL.md
+++ b/.claude/skills/management/weekly-review/SKILL.md
@@ -551,4 +551,6 @@ B. 実験進捗レポート:
 - `scripts/x-queue-surfacer.mjs` — X 予約キューの未投入下書き surfacer（本スキル Agent I の中核。`npm run x-queue-surfacer`）
 - `.claude/skills/analytics/fetch-gsc-data/scripts/fetch-gsc-data.mjs` — GSC 個別取得（ページ別・フィルタ付き）
 - `.claude/scripts/fetch-ga4-data.mjs` — GA4 個別取得（ディメンション・メトリクス指定）
+- `scripts/check-experiment-due.mjs` — 実験の再計測/close 期限 surfacer（`npm run check-experiment-due`）
+- `scripts/check-internal-links-vs-gsc.mjs` — 公開ページ→404/リダイレクト URL の内部リンク検査（`npm run check-internal-links-vs-gsc`）
 - `.claude/skills/management/nsm-experiment/references/definition.md` — NSM 定義の真実源

--- a/.claude/state/experiments.json
+++ b/.claude/state/experiments.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-30T06:52:40.499Z",
+  "updated_at": "2026-07-30T07:07:35.582Z",
   "experiments": [
     {
       "id": "EXP-002",
@@ -817,6 +817,39 @@
           "date": "2026-07-30T06:52:40.499Z",
           "action": "started",
           "summary": "GSC UI 実測で対象 20 本を確定（技術的阻害ゼロ）。リクエストを 10 本ずつ 2 日に分けて送信。next_check 2026-08-27。"
+        },
+        {
+          "date": "2026-07-30T07:07:35.579Z",
+          "action": "intervened",
+          "summary": "20本中10本にインデックス登録リクエストを送信し全件 accepted を実機確認（run 2026-07-30T06-40-03Z）。残り10本は送信上限(--limit 10)で limit-reached＝翌日送信。"
+        }
+      ],
+      "interventions": [
+        {
+          "date": "2026-07-30T07:07:35.582Z",
+          "n": 1,
+          "change": "gsc-request-indexing --commit --limit 10 で 10 本のインデックス登録をリクエスト",
+          "accepted": [
+            "civil-construction-1-textbook-road-act",
+            "civil-construction-1-textbook-demolition",
+            "civil-construction-1-textbook-port-regulations",
+            "civil-construction-1-textbook-leveling",
+            "civil-construction-1-textbook-transport-machinery",
+            "civil-construction-1-textbook-explosives-act",
+            "civil-construction-1-textbook-tractor-bulldozer",
+            "civil-construction-1-textbook-loader",
+            "civil-construction-1-textbook-schedule-overview",
+            "civil-construction-1-textbook-labor-standards"
+          ],
+          "verified": "各 URL で受理文言を確認（accepted 10/10・unconfirmed 0）。記録: .claude/state/metrics/gsc-indexing/requests-latest.json",
+          "not_yet": "残り10本（shovel-excavator, work-scheduling, grader-compaction, river-act, distance-angle, building-standards, surveying-basics, schedule-charts, management-subplans, site-investigation）"
+        }
+      ],
+      "pending_user_actions": [
+        {
+          "action": "残り10本のインデックス登録リクエスト（翌日・日次クォータ回復後）",
+          "detail": "npm run gsc-indexing:request -- --from-ssot --category civil-construction-1 --group textbook --limit 10",
+          "reference": ".claude/state/metrics/gsc-indexing/history.json の limit-reached"
         }
       ]
     }

--- a/.claude/state/metrics/gsc-indexing/history.json
+++ b/.claude/state/metrics/gsc-indexing/history.json
@@ -1,0 +1,113 @@
+{
+  "schemaVersion": 1,
+  "runs": [
+    {
+      "runId": "2026-07-30T06-31-15Z",
+      "collectedAt": "2026-07-30T06:31:15.594Z",
+      "mode": "dry-run",
+      "status": "inspection-unreadable",
+      "filter": {
+        "category": "civil-construction-1",
+        "group": "textbook"
+      },
+      "inspected": 20,
+      "accepted": 0,
+      "alreadyIndexed": 0,
+      "unreadable": 20,
+      "slugs": [
+        "civil-construction-1-textbook-road-act",
+        "civil-construction-1-textbook-demolition",
+        "civil-construction-1-textbook-port-regulations",
+        "civil-construction-1-textbook-leveling",
+        "civil-construction-1-textbook-transport-machinery",
+        "civil-construction-1-textbook-explosives-act",
+        "civil-construction-1-textbook-tractor-bulldozer",
+        "civil-construction-1-textbook-loader",
+        "civil-construction-1-textbook-schedule-overview",
+        "civil-construction-1-textbook-labor-standards",
+        "civil-construction-1-textbook-shovel-excavator",
+        "civil-construction-1-textbook-work-scheduling",
+        "civil-construction-1-textbook-grader-compaction",
+        "civil-construction-1-textbook-river-act",
+        "civil-construction-1-textbook-distance-angle",
+        "civil-construction-1-textbook-building-standards",
+        "civil-construction-1-textbook-surveying-basics",
+        "civil-construction-1-textbook-schedule-charts",
+        "civil-construction-1-textbook-management-subplans",
+        "civil-construction-1-textbook-site-investigation"
+      ]
+    },
+    {
+      "runId": "2026-07-30T06-38-12Z",
+      "collectedAt": "2026-07-30T06:38:12.363Z",
+      "mode": "dry-run",
+      "status": "dry-ok",
+      "filter": {
+        "category": "civil-construction-1",
+        "group": "textbook"
+      },
+      "inspected": 20,
+      "accepted": 0,
+      "alreadyIndexed": 0,
+      "unreadable": 0,
+      "slugs": [
+        "civil-construction-1-textbook-road-act",
+        "civil-construction-1-textbook-demolition",
+        "civil-construction-1-textbook-port-regulations",
+        "civil-construction-1-textbook-leveling",
+        "civil-construction-1-textbook-transport-machinery",
+        "civil-construction-1-textbook-explosives-act",
+        "civil-construction-1-textbook-tractor-bulldozer",
+        "civil-construction-1-textbook-loader",
+        "civil-construction-1-textbook-schedule-overview",
+        "civil-construction-1-textbook-labor-standards",
+        "civil-construction-1-textbook-shovel-excavator",
+        "civil-construction-1-textbook-work-scheduling",
+        "civil-construction-1-textbook-grader-compaction",
+        "civil-construction-1-textbook-river-act",
+        "civil-construction-1-textbook-distance-angle",
+        "civil-construction-1-textbook-building-standards",
+        "civil-construction-1-textbook-surveying-basics",
+        "civil-construction-1-textbook-schedule-charts",
+        "civil-construction-1-textbook-management-subplans",
+        "civil-construction-1-textbook-site-investigation"
+      ]
+    },
+    {
+      "runId": "2026-07-30T06-40-03Z",
+      "collectedAt": "2026-07-30T06:40:03.109Z",
+      "mode": "commit",
+      "status": "ok",
+      "filter": {
+        "category": "civil-construction-1",
+        "group": "textbook"
+      },
+      "inspected": 20,
+      "accepted": 10,
+      "alreadyIndexed": 0,
+      "unreadable": 0,
+      "slugs": [
+        "civil-construction-1-textbook-road-act",
+        "civil-construction-1-textbook-demolition",
+        "civil-construction-1-textbook-port-regulations",
+        "civil-construction-1-textbook-leveling",
+        "civil-construction-1-textbook-transport-machinery",
+        "civil-construction-1-textbook-explosives-act",
+        "civil-construction-1-textbook-tractor-bulldozer",
+        "civil-construction-1-textbook-loader",
+        "civil-construction-1-textbook-schedule-overview",
+        "civil-construction-1-textbook-labor-standards",
+        "civil-construction-1-textbook-shovel-excavator",
+        "civil-construction-1-textbook-work-scheduling",
+        "civil-construction-1-textbook-grader-compaction",
+        "civil-construction-1-textbook-river-act",
+        "civil-construction-1-textbook-distance-angle",
+        "civil-construction-1-textbook-building-standards",
+        "civil-construction-1-textbook-surveying-basics",
+        "civil-construction-1-textbook-schedule-charts",
+        "civil-construction-1-textbook-management-subplans",
+        "civil-construction-1-textbook-site-investigation"
+      ]
+    }
+  ]
+}

--- a/.claude/state/metrics/gsc-indexing/requests-latest.json
+++ b/.claude/state/metrics/gsc-indexing/requests-latest.json
@@ -1,0 +1,363 @@
+{
+  "schemaVersion": 1,
+  "runId": "2026-07-30T06-40-03Z",
+  "collectedAt": "2026-07-30T06:40:03.109Z",
+  "property": "sc-domain:doboku-note.com",
+  "mode": "commit",
+  "scriptVersion": "8d28546b8",
+  "filter": {
+    "category": "civil-construction-1",
+    "group": "textbook"
+  },
+  "limit": 10,
+  "targetCount": 20,
+  "items": [
+    {
+      "slug": "civil-construction-1-textbook-road-act",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-road-act",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/07/18 17:54:45",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-demolition",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-demolition",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/07/16 10:08:37",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-port-regulations",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-port-regulations",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/06/12 10:07:07",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-leveling",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-leveling",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/06/07 14:07:02",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-transport-machinery",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-transport-machinery",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/06/02 18:15:25",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-explosives-act",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-explosives-act",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/06/01 2:20:30",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-tractor-bulldozer",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-tractor-bulldozer",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/05/29 21:12:04",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-loader",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-loader",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/05/19 0:09:00",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-schedule-overview",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-overview",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/28 8:47:06",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-labor-standards",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-labor-standards",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/28 3:16:07",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": true,
+        "status": "accepted"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-shovel-excavator",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-shovel-excavator",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/28 2:32:35",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-work-scheduling",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-work-scheduling",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/28 2:08:23",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-grader-compaction",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-grader-compaction",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/28 1:16:23",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-river-act",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-river-act",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/27 23:32:07",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-distance-angle",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-distance-angle",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/27 21:06:58",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-building-standards",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-building-standards",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/27 20:40:59",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-surveying-basics",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-surveying-basics",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/27 19:59:58",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-schedule-charts",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-schedule-charts",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/27 18:22:01",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-management-subplans",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-management-subplans",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/26 7:44:41",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    },
+    {
+      "slug": "civil-construction-1-textbook-site-investigation",
+      "url": "https://doboku-note.com/docs/civil-construction-1-textbook-site-investigation",
+      "inspected": {
+        "state": "not-indexed",
+        "reason": "クロール済み - インデックス未登録",
+        "lastCrawl": "2026/04/26 1:31:35",
+        "discoveredVia": "sitemap",
+        "crawlAllowed": true,
+        "indexingAllowed": true
+      },
+      "request": {
+        "requested": false,
+        "status": "limit-reached"
+      },
+      "reachedVerdict": true
+    }
+  ],
+  "status": "ok",
+  "summary": {
+    "inspected": 20,
+    "accepted": 10,
+    "alreadyIndexed": 0,
+    "unreadable": 0
+  }
+}

--- a/.github/workflows/weekly-review-guard.yml
+++ b/.github/workflows/weekly-review-guard.yml
@@ -1,4 +1,4 @@
-name: Guard weekly-review cycle
+name: Guard PDCA cycle (weekly-review + offline surfacers)
 
 # 週次レビュー（/weekly-review）を回すクラウドルーティン（正典 = doboku-note weekly PDCA）が
 # 停止・無効・cron ズレで発火しなくなっても、状態はクラウド側にしかなく repo からは見えない。
@@ -10,6 +10,11 @@ name: Guard weekly-review cycle
 #
 # 赤落ち時の対処: 対話セッション（デスクトップ/web アプリ）で /routines（list-first）→ 無ければ
 #   /schedule で再作成、cron ズレなら update。真実源: .claude/skills/management/routines/SKILL.md
+#
+# 2026-07-30: 本 workflow は「レビュー生成の欠落検知」だけでなく、**オフラインで判定できる
+# PDCA surfacer の実行キャリア**も兼ねる。理由: surfacer を weekly-review スキルの中だけに置くと
+# ルーティン停止時に一緒に沈黙する（W30/W31 は手動生成・本ガードは 07-20/07-27 と 2 週連続赤）。
+# creds も外部到達性も要らない判定は CI 側で必ず動かす（「計測は CI/CD 供給が正」と同じ思想）。
 
 on:
   schedule:
@@ -32,7 +37,43 @@ jobs:
         with:
           node-version: "22"
 
+      # ── PDCA サイクルの surfacer（オフライン・creds 不要・依存パッケージ不要）─────────
+      # 2026-07-30 追加。これらは weekly-review（クラウドルーティン）の中で列挙する設計だったが、
+      # そのルーティンが停止しても発火しなくなる（実際 W30/W31 は手動生成・本ガードは 2 週連続赤）。
+      # 判定に creds も外部到達性も要らないので **CI 側で必ず動かす**＝ルーティン生存に依存させない。
+      # surfacer は落とさず job summary に出す（DUE があるのは正常な状態でもありうる）。
+      - name: Surface cycle state (experiments / UI collection / GA4 settings)
+        continue-on-error: true
+        run: |
+          {
+            echo "## PDCA サイクルの状態（$(date -u +%Y-%m-%dT%H:%MZ)）"
+            echo
+            echo '### 実験の再計測期限（check-experiment-due）'
+            echo '```'
+            node scripts/check-experiment-due.mjs || true
+            echo '```'
+            echo '### GSC/GA4 UI 取得の期限と完全性（check-gsc-ui-due）'
+            echo '```'
+            node scripts/check-gsc-ui-due.mjs || true
+            echo '```'
+            echo '### UI CSV SSOT の整合（check-google-ui-ssot）'
+            echo '```'
+            node scripts/check-google-ui-ssot.mjs || true
+            echo '```'
+            echo '### GA4 管理画面 設定ドリフト（check-ga4-dimensions）'
+            echo '```'
+            node scripts/check-ga4-custom-dimensions.mjs || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # 決定的ゲート: 公開ページが GSC の 404/リダイレクト URL を指していたら赤。
+      # これは「0 件が正常」な検査なので surfacer と違い hard fail にする。
+      - name: Gate - internal links vs GSC 404/redirect
+        run: node scripts/check-internal-links-vs-gsc.mjs
+
       # 先週分の docs/reviews/weekly/YYYY-Www-review.md が無ければ exit 1（赤落ち）。
       # 依存パッケージ不要（fs のみ）なので npm ci はスキップ。
+      # surfacer より後に置く＝レビュー欠落で赤くても上のサマリは必ず残る。
       - name: Check last week's review exists
+        if: always()
         run: node scripts/check-weekly-review.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,9 @@ npm run check-gsc-ui-due       # GSC/GA4 UI 取得の月次期限＋前回の完
 npm run check-google-ui-ssot   # UI CSV 情報の追跡 SSOT の整合ゲート（marker↔history↔urls・検査ゼロを FAIL）
 npm run ga4-admin:check        # GA4 管理画面の設定を desired state と突合（dry-run／:apply で不足カスタムディメンションを作成）
 npm run check-ga4-dimensions   # GA4 カスタムディメンション（event_label/cta_placement）のドリフト検知（オフライン）
+npm run check-experiment-due   # 実験台帳の再計測/close 期限を surface（計測→記録→改善→再計測の最後の輪）
+npm run check-internal-links-vs-gsc # 公開ページが GSC 404/リダイレクト URL を指していないか（旧URL件数を減らす唯一のレバー）
+npm run gsc-indexing:check     # 未登録URLをGSC URL検査で診断（dry-run／:request で登録リクエスト・上限10件/回）
 ```
 
 ---

--- a/docs/project/04_運営/gsc-ga4-playwright-automation-spec.md
+++ b/docs/project/04_運営/gsc-ga4-playwright-automation-spec.md
@@ -356,7 +356,7 @@ allowed-tools: Read, Glob, Grep, Bash, Task
   "ga4-ui:fetch": "node scripts/fetch-ga4-ui-csv.mjs",
   "google-console:normalize": "node scripts/normalize-google-console-csv.mjs",
   "search-growth:report": "node scripts/report-search-growth.mjs",
-  "search-growth:audit": "npm run gsc-ui:fetch; npm run google-console:normalize && npm run search-growth:report && npm run check-google-ui-ssot",
+  "search-growth:audit": "node scripts/run-search-growth-audit.mjs",
   "check-gsc-ui-due": "node scripts/check-gsc-ui-due.mjs",
   "check-google-ui-ssot": "node scripts/check-google-ui-ssot.mjs",
   "ga4-admin:check": "node scripts/ga4-admin-setup.mjs",
@@ -365,13 +365,24 @@ allowed-tools: Read, Glob, Grep, Bash, Task
 }
 ```
 
-> [!warning] `search-growth:audit` の連鎖（2026-07-30 修正）
-> 修正前は `gsc-ui:fetch && google-console:normalize && search-growth:report` で、**中間の normalize が
-> 引数なし**のため `resolveRunDir` が null → 「run ディレクトリが見つかりません」で毎回 exit 2 になり、
-> report まで一度も到達していなかった。現在は (1) normalize の既定を最新 run に変更、
-> (2) 取得が**部分成功**（exit 2）でも取れた分は正規化するため `;` で繋ぎ、
-> (3) 末尾に SSOT 整合ゲートを置いて「取得したつもり」で終われないようにしている。
-> normalize 自体は downloaded 0 件なら exit 1 で止まる（検査ゼロを PASS にしない）。
+> [!warning] `search-growth:audit` の連鎖は**シェルで書けない**（2026-07-30 実走で確定）
+> 当初は `gsc-ui:fetch && google-console:normalize && search-growth:report` だったが、中間の normalize が
+> **引数なし**で呼ばれ `resolveRunDir` が null → 毎回 exit 2 で report に到達していなかった。
+> `&&` を `;` に変えると今度は **cmd.exe が `;` を区切りとして扱わず** npm が `gsc-ui:fetch;` という
+> スクリプト名を探して即死する（Windows 実測）。「失敗を許容する連鎖」は POSIX と Windows の両方で
+> 動く形にシェルでは書けないため、連鎖の意味を `scripts/run-search-growth-audit.mjs` に移した。
+>
+> | 取得の exit code | 意味 | 連鎖の挙動 |
+> |--:|---|---|
+> | 0 | 完全 | 続行 |
+> | 2 | 不完全（部分成功・全ゼロ） | **続行**（取れた分を正規化して突合する） |
+> | 3 | 未ログイン | 中断（`npm run google-console:login`） |
+> | 5 | property 不一致 | 中断 |
+> | 6 | レポート到達不能 | 中断（UI 変更の疑い） |
+>
+> 各ステップは **node で実体スクリプトを直接 spawn** する（Node 20+ は `.cmd` を shell:false で
+> spawn できず EINVAL、shell:true はクォートが OS 依存になる）。normalize は downloaded 0 件なら
+> exit 1 で止まり、末尾の SSOT ゲートで「取得したつもり」で終われないようにしている。
 
 ## 10.1 完全性と SSOT（2026-07-30 追加）
 


### PR DESCRIPTION
## 概要

PR #436 のマージ後に積んだ 2 コミット。**「自動的に回っているか」を実査したら、#436 で入れた surfacer の配線先が止まっていた**ので、そこを直したのが主眼です。

## 1. 発見: 配線先（クラウドルーティン）が停止していた

| 証拠 | 内容 |
|---|---|
| `weekly-review-guard` の実行履歴 | 2026-07-20・07-27 と **2 週連続 failure**（欠落を検知し続けていた） |
| 週次レビューの生成者 | W28/W29 = Claude（ルーティン）→ **W30/W31 = 手動** |
| RemoteTrigger list | cron を持つ定期ルーティンが **0 件**（全て send_later の単発 PR チェックイン） |

surfacer を weekly-review SKILL の中だけに置くと、ルーティンが止まったとき**一緒に沈黙する**構造でした。

## 2. 対策: creds 不要の判定は CI 側で必ず動かす

5 本すべて fs のみ・外部到達性なし・npm 依存なしで完結し、入力（`experiments.json` / `last-run.json` / `inventory-latest.json` / `ssot/`）も全て追跡済みなので `weekly-review-guard.yml`（毎週月曜 11:17 JST）に載せました。

| ステップ | 扱い | 理由 |
|---|---|---|
| check-experiment-due / check-gsc-ui-due / check-google-ui-ssot / check-ga4-dimensions | job summary | DUE は正常な状態でもありうる |
| **check-internal-links-vs-gsc** | **hard fail** | 「0 件が正常」な決定的検査 |

レビュー欠落チェックは `if: always()` で最後に置き、赤くてもサマリが残ります。

> **効力の条件**: scheduled workflow は main 版で走るため、**main へ昇格するまで週次スケジュールには効きません**（measurement-incidents.md「定期ジョブの実行ブランチ」）。

## 3. 発見可能性・SSOT の監査もれ

- **`gsc-request-indexing` がどのドキュメントにも載っていなかった**（存在を知る手段がゼロ）。`run-search-growth-audit` も package.json だけ
- weekly-review: 節には書いたのに末尾の「参照するスクリプト」一覧に入れ忘れ（片側だけ更新）
- gsc-management.md 分業表に新ゲート 3 行が欠落／データの所在に gsc-indexing と experiments.json が欠落
- gsc-browser-collector に「`gsc-request-indexing` は担当外（収集ではなく介入）」が未記載
- 実装指示書 §10 の audit 連鎖が旧記述（`;` 形）のまま → exit code 意味論の表に更新

**SSOT の二重管理を 1 件解消**: インデックス登録の記録が手書き `.claude/state/metrics/notes/gsc-indexing-requests-*.md`（CLAUDE.md §8 の `state/*.md` 新規作成禁止に反する旧パターン）と新 JSON で並立するところだった。`nsm-experiment` の参照を機械生成 JSON へ一本化し「手書きノートは作らない」と明記。2026-04 の既存ノートは履歴として残置。

## 4. EXP-006 の介入 1 を記録

civil-1 textbook の未登録 20 本に対し、**10 本のインデックス登録リクエストを送信して accepted 10/10 を実機確認**（unconfirmed 0）。残り 10 本は送信上限（`--limit 10`）で `limit-reached` ＝翌日送信を `pending_user_actions` に登録。`check-experiment-due` が EXP-005 とともに PENDING として surface することを確認済み。

## 5. 判断基準もカタログ化

`google-search-growth` SKILL に「5.5 介入候補の抽出」を追加。要点は**件数で選ばないこと**:

> 期待値 = 同 group の登録済みページの「1 本あたり表示」× 未登録本数
> 実測では textbook **20 本**（期待 +264）が keyword **190 本**（+180）を上回った

## 検証

- 5 本の surfacer/ゲートすべて CI 相当（依存なし）で exit 0 を確認
- 入力ファイル 5 件すべて tracked を確認（CI で読める）
- workflow YAML を parse して steps 構成を検証
- `check-doc-refs` 1,204 ファイル緑 / `check-doc-coupling` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)
